### PR TITLE
fix: resolve Confluence URL generation issues

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/connectors/confluence/connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/confluence/connector.py
@@ -1,7 +1,7 @@
 import asyncio
 import re
 from datetime import datetime
-from urllib.parse import urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -794,7 +794,7 @@ class ConfluenceConnector(BaseConnector):
 
             # Construct URL based on deployment type
             page_url = self._construct_page_url(
-                space or "", content_id or "", content.get("type", "page")
+                space or "", content_id or "", title or "", content.get("type", "page")
             )
 
             # Parse timestamps for Document constructor
@@ -829,30 +829,36 @@ class ConfluenceConnector(BaseConnector):
             raise
 
     def _construct_page_url(
-        self, space: str, content_id: str, content_type: str = "page"
+        self, space: str, content_id: str, title: str, content_type: str = "page"
     ) -> str:
         """Construct the appropriate URL for a Confluence page based on deployment type.
 
         Args:
             space: The space key
             content_id: The content ID
+            title: The page title (will be URL-encoded for Data Center URLs)
             content_type: The type of content (page, blogpost, etc.)
 
         Returns:
             The constructed URL
         """
         if self.config.deployment_type == ConfluenceDeploymentType.CLOUD:
-            # Cloud URLs use a different format
+            # Cloud URLs use ID-based format
             if content_type == "blogpost":
-                return f"{self.base_url}/spaces/{space}/blog/{content_id}"
+                path = f"spaces/{space}/blog/{content_id}"
             else:
-                return f"{self.base_url}/spaces/{space}/pages/{content_id}"
+                path = f"spaces/{space}/pages/{content_id}"
         else:
-            # Data Center/Server URLs
+            # Data Center/Server URLs - use title for better readability
+            # URL-encode the title, replacing spaces with + (Confluence format)
+            encoded_title = quote(title.replace(" ", "+"), safe="+")
             if content_type == "blogpost":
-                return f"{self.base_url}/display/{space}/{content_id}"
+                path = f"display/{space}/{encoded_title}"
             else:
-                return f"{self.base_url}/display/{space}/{content_id}"
+                path = f"display/{space}/{encoded_title}"
+
+        # Use urljoin to properly handle base URL concatenation and avoid double slashes
+        return urljoin(str(self.base_url), path)
 
     def _parse_timestamp(self, timestamp_str: str | None) -> "datetime | None":
         """Parse a timestamp string into a datetime object.


### PR DESCRIPTION
## Description
Fix Confluence URL generation bug that was creating invalid URLs with double slashes and incorrect format for Data Center deployments.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Problem Statement
The Confluence connector was generating invalid URLs in two ways:
1. **Double slash issue**: URLs like `https://confluence.example.com//display/SPACE/123` (double slash after hostname)
2. **Invalid Data Center URL format**: Using content ID instead of page title, resulting in URLs like `https://confluence.example.com/display/SPACE/4358546` instead of the correct `https://confluence.example.com/display/SPACE/Page+Title`

## Solution
- **Fixed URL construction**: Replaced manual string concatenation with `urljoin()` to properly handle base URL concatenation and avoid double slashes
- **Corrected Data Center URL format**: Changed from using content ID to using page title for Data Center URLs, with proper URL encoding
- **Maintained Cloud compatibility**: Cloud URLs continue to use ID-based format as expected
- **Added proper URL encoding**: Using `quote()` to encode page titles with spaces replaced by `+` (Confluence format)

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Changes Made
- Modified `_construct_page_url()` method to use `urljoin()` for proper URL construction
- Added `title` parameter to `_construct_page_url()` method signature
- Updated Data Center URL format to use page title instead of content ID
- Added proper URL encoding for page titles
- Updated method call in `_process_content()` to pass title parameter

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation made
- [x] Tests added that prove the fix is effective or feature works
- [x] New and existing unit tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized Confluence URL construction for consistency across Cloud and Data Center. Cloud remains ID-based; Data Center now uses readable, title-based paths.
- Bug Fixes
  - Correct encoding for spaces, special characters, and Unicode in Confluence URLs. Prevents double slashes and supports long titles.
- Tests
  - Added comprehensive unit tests covering Cloud/Data Center URLs, pages/blog posts, special/unicode characters, long titles, and trailing slash handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->