### PR TITLE
Azure OpenAI support + Ollama endpoint autodetect and batch embeddings

### DIFF
--- a/packages/qdrant-loader-core/pyproject.toml
+++ b/packages/qdrant-loader-core/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 openai = [
-  "openai>=1.0.0",
+  "openai>=1.3.0",
   "tiktoken>=0.5.0",
 ]
 ollama = [


### PR DESCRIPTION
Summary
- Add Azure OpenAI support in core with api_version + provider_options (azure_endpoint)
- Route Azure in provider factory; validate base_url (no /openai/deployments) and require api_version
- Reuse OpenAI adapters with provider_label=azure_openai for accurate logs
- Enhance Ollama embeddings:
  - Auto-detect /v1 vs native
  - Prefer native POST /api/embed for batch inputs; fallback to /api/embeddings (per-item)
  - Normalize response variants (embedding, data.embedding, embeddings[][])
  - Respect request.timeout_s
- Logging: add latency_ms where applicable; correct provider labels
- Docs: config template + configuration reference updated (Azure and Ollama usage + troubleshooting)
- Release notes updated
- Tests: Azure provider init/validation; Ollama endpoints + fallbacks + error cases

Configuration
- global.llm supports:
  - api_version (required for azure_openai)
  - provider_options.azure_endpoint
  - provider_options.native_endpoint = auto|embed|embeddings (Ollama)
- Legacy mapping: if global.embedding.endpoint matches Azure hosts, provider=azure_openai inferred (with deprecation warning)

Acceptance
- Core tests: pass
- MCP server tests: pass
- CLI package tests: many pre-existing failures, unrelated to this change set

Notes
- openai optional dependency bumped to >=1.3.0 in core to ensure AzureOpenAI availability.

Please review. After merge, we can address remaining CLI tests separately.