### PR TITLE
fix: update prometheus-client dependency. Fix #60

### DIFF
--- a/packages/qdrant-loader/pyproject.toml
+++ b/packages/qdrant-loader/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "markitdown[all]>=0.1.3",
     "rich>=13.0.0",
     "packaging>=21.0",
+    "prometheus-client>=0.19.0,<1.0.0"
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
# Pull Request

## Summary

Fixed missing prometheus-client dependency by adding "prometheus-client>=0.19.0,<1.0.0" to the main dependencies section in pyproject.toml, as this is a runtime requirement, not a development-only dependency.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages: No docs updates needed - internal implementation fix
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

### Test steps:

1. Create a fresh virtual environment.
2. Install qdrant-loader:
pip install qdrant-loader
3. Run any command, for example:
qdrant-loader --help

### Test Results:
No ModuleNotFoundError: No module named 'prometheus_client' occurred.
## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)
