### PR TITLE
Fix missing spacy in mcp-server dependencies

### DIFF
--- a/packages/qdrant-loader-mcp-server/pyproject.toml
+++ b/packages/qdrant-loader-mcp-server/pyproject.toml
@@ -41,9 +41,9 @@ dependencies = [
     "click>=8.0.0",
     "tomli>=2.0.0",
     "networkx>=3.0.0",
+    "spacy>=3.7.0",
     "qdrant-loader-core==0.7.3",
 ]
-
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/packages/qdrant-loader-mcp-server/tests/unit/search/test_vector_search_cache.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/search/test_vector_search_cache.py
@@ -1,7 +1,7 @@
 """Unit tests for vector search caching functionality."""
 
 import time
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from qdrant_loader_mcp_server.search.components.vector_search_service import (


### PR DESCRIPTION
# Pull Request

## Summary

Fix missing spacy in mcp-server dependencies causing ModuleNotFoundError by adding "spacy>=3.7.0" into dependencies section in pyproject.toml

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages: No docs updates needed - internal implementation fix
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)
