### PR TITLE
fix: Replace NestedCondition with dot notation for project_ids filter

### DIFF
--- a/packages/qdrant-loader-mcp-server/tests/unit/search/test_field_query_parser.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/search/test_field_query_parser.py
@@ -1,0 +1,239 @@
+"""Tests for FieldQueryParser component."""
+
+import pytest
+from qdrant_client.http import models
+from qdrant_loader_mcp_server.search.components import (
+    FieldQuery,
+    FieldQueryParser,
+)
+
+
+class TestFieldQueryParser:
+    """Test suite for FieldQueryParser."""
+
+    @pytest.fixture
+    def parser(self):
+        """Create a FieldQueryParser instance."""
+        return FieldQueryParser()
+
+    def test_parse_simple_field_query(self, parser):
+        """Test parsing a simple field query."""
+        query = "source_type:confluence"
+        parsed = parser.parse_query(query)
+
+        assert len(parsed.field_queries) == 1
+        assert parsed.field_queries[0].field_name == "source_type"
+        assert parsed.field_queries[0].field_value == "confluence"
+        assert parsed.text_query == ""
+
+    def test_parse_multiple_field_queries(self, parser):
+        """Test parsing multiple field queries."""
+        query = "source_type:confluence project_id:my-project"
+        parsed = parser.parse_query(query)
+
+        assert len(parsed.field_queries) == 2
+        assert parsed.field_queries[0].field_name == "source_type"
+        assert parsed.field_queries[0].field_value == "confluence"
+        assert parsed.field_queries[1].field_name == "project_id"
+        assert parsed.field_queries[1].field_value == "my-project"
+        assert parsed.text_query == ""
+
+    def test_parse_field_query_with_text(self, parser):
+        """Test parsing field query with remaining text search."""
+        query = "source_type:confluence API documentation"
+        parsed = parser.parse_query(query)
+
+        assert len(parsed.field_queries) == 1
+        assert parsed.field_queries[0].field_name == "source_type"
+        assert parsed.text_query == "API documentation"
+
+    def test_parse_quoted_field_value(self, parser):
+        """Test parsing field query with quoted value."""
+        query = 'title:"API Documentation"'
+        parsed = parser.parse_query(query)
+
+        assert len(parsed.field_queries) == 1
+        assert parsed.field_queries[0].field_name == "title"
+        assert parsed.field_queries[0].field_value == "API Documentation"
+
+    def test_parse_nested_metadata_field(self, parser):
+        """Test parsing nested metadata field queries."""
+        query = "chunk_index:0 total_chunks:5"
+        parsed = parser.parse_query(query)
+
+        assert len(parsed.field_queries) == 2
+        assert parsed.field_queries[0].field_name == "chunk_index"
+        assert parsed.field_queries[0].field_value == "0"
+        assert parsed.field_queries[1].field_name == "total_chunks"
+        assert parsed.field_queries[1].field_value == "5"
+
+    def test_create_filter_from_field_queries(self, parser):
+        """Test creating Qdrant filter from field queries."""
+        field_queries = [
+            FieldQuery(
+                field_name="source_type",
+                field_value="confluence",
+                original_query="source_type:confluence",
+            ),
+            FieldQuery(
+                field_name="title", field_value="API", original_query="title:API"
+            ),
+        ]
+
+        filter_obj = parser.create_qdrant_filter(field_queries)
+
+        assert filter_obj is not None
+        assert len(filter_obj.must) == 2
+        assert filter_obj.must[0].key == "source_type"
+        assert filter_obj.must[0].match.value == "confluence"
+        assert filter_obj.must[1].key == "title"
+        assert filter_obj.must[1].match.value == "API"
+
+    def test_create_filter_with_nested_fields(self, parser):
+        """Test creating Qdrant filter with nested metadata fields using dot notation."""
+        field_queries = [
+            FieldQuery(
+                field_name="chunk_index",
+                field_value="0",
+                original_query="chunk_index:0",
+            )
+        ]
+
+        filter_obj = parser.create_qdrant_filter(field_queries)
+
+        assert filter_obj is not None
+        assert len(filter_obj.must) == 1
+        # Verify dot notation is used for nested fields
+        assert filter_obj.must[0].key == "metadata.chunk_index"
+        assert filter_obj.must[0].match.value == 0  # Should be converted to int
+
+    def test_create_filter_with_project_ids(self, parser):
+        """Test creating filter with project_ids in 3 locations."""
+        project_ids = ["project-1", "project-2"]
+
+        filter_obj = parser.create_qdrant_filter(
+            field_queries=None, project_ids=project_ids
+        )
+
+        assert filter_obj is not None
+        assert len(filter_obj.must) == 1
+        # Should be a nested Filter with should clause
+        nested_filter = filter_obj.must[0]
+        assert isinstance(nested_filter, models.Filter)
+        assert len(nested_filter.should) == 3
+        # Check all 3 locations
+        assert nested_filter.should[0].key == "project_id"
+        assert nested_filter.should[1].key == "source"
+        assert nested_filter.should[2].key == "metadata.project_id"
+
+    def test_create_filter_field_queries_and_project_ids(self, parser):
+        """Test creating filter with both field queries and project_ids."""
+        field_queries = [
+            FieldQuery(
+                field_name="source_type",
+                field_value="confluence",
+                original_query="source_type:confluence",
+            )
+        ]
+        project_ids = ["my-project"]
+
+        filter_obj = parser.create_qdrant_filter(field_queries, project_ids)
+
+        assert filter_obj is not None
+        assert len(filter_obj.must) == 2
+        # First condition: field query
+        assert filter_obj.must[0].key == "source_type"
+        # Second condition: project filter (nested Filter with should)
+        assert isinstance(filter_obj.must[1], models.Filter)
+        assert len(filter_obj.must[1].should) == 3
+
+    def test_skip_project_filter_when_field_query_has_project_id(self, parser):
+        """Test that project filter is skipped when field query contains project_id."""
+        field_queries = [
+            FieldQuery(
+                field_name="project_id",
+                field_value="specific-project",
+                original_query="project_id:specific-project",
+            )
+        ]
+        project_ids = ["my-project"]
+
+        filter_obj = parser.create_qdrant_filter(field_queries, project_ids)
+
+        assert filter_obj is not None
+        # Should only have the field query, not the project filter
+        assert len(filter_obj.must) == 1
+        assert filter_obj.must[0].key == "project_id"
+        assert filter_obj.must[0].match.value == "specific-project"
+
+    def test_numeric_field_conversion(self, parser):
+        """Test that numeric fields are converted to int."""
+        field_queries = [
+            FieldQuery(
+                field_name="chunk_index",
+                field_value="42",
+                original_query="chunk_index:42",
+            ),
+            FieldQuery(
+                field_name="total_chunks",
+                field_value="100",
+                original_query="total_chunks:100",
+            ),
+        ]
+
+        filter_obj = parser.create_qdrant_filter(field_queries)
+
+        assert filter_obj is not None
+        assert filter_obj.must[0].match.value == 42  # int, not string
+        assert filter_obj.must[1].match.value == 100  # int, not string
+
+    def test_should_use_filter_only_with_document_id(self, parser):
+        """Test filter-only mode for document_id queries."""
+        parsed = parser.parse_query("document_id:abc123 some text")
+
+        # Even with text, document_id queries should be filter-only
+        assert parser.should_use_filter_only(parsed) is True
+
+    def test_should_use_filter_only_without_text(self, parser):
+        """Test filter-only mode when no text search."""
+        parsed = parser.parse_query("source_type:confluence")
+
+        assert parser.should_use_filter_only(parsed) is True
+
+    def test_should_not_use_filter_only_with_text(self, parser):
+        """Test that filter-only is False when text search is present."""
+        parsed = parser.parse_query("source_type:confluence API documentation")
+
+        # Should use both filter and text search
+        assert parser.should_use_filter_only(parsed) is False
+
+    def test_empty_query(self, parser):
+        """Test handling empty query."""
+        parsed = parser.parse_query("")
+
+        assert len(parsed.field_queries) == 0
+        assert parsed.text_query == ""
+        assert parser.create_qdrant_filter(parsed.field_queries) is None
+
+    def test_unsupported_field(self, parser):
+        """Test handling unsupported field."""
+        query = "invalid_field:value regular text"
+        parsed = parser.parse_query(query)
+
+        # Unsupported field should be treated as regular text
+        assert len(parsed.field_queries) == 0
+        # The entire query becomes text search since field is unsupported
+        assert "invalid_field:value" in parsed.text_query
+        assert "regular text" in parsed.text_query
+
+    def test_get_supported_fields(self, parser):
+        """Test getting list of supported fields."""
+        fields = parser.get_supported_fields()
+
+        assert "document_id" in fields
+        assert "source_type" in fields
+        assert "project_id" in fields
+        assert "chunk_index" in fields
+        assert (
+            "metadata.chunk_index" not in fields
+        )  # Should be chunk_index, not the payload key


### PR DESCRIPTION
# Pull Request

## Summary

Replace `NestedCondition` with simpler dot notation for nested field filtering in Qdrant queries. This fixes the project_ids filter issue where nested metadata fields were not being queried correctly.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Changes Made

### Main Changes

- **Replaced `NestedCondition` with dot notation**: Qdrant natively supports dot notation (e.g., `metadata.chunk_index`) which is simpler and more reliable than `NestedCondition`
- **Fixed project_ids filter logic**: Changed from using top-level `should` to nested `Filter(should=[...])` within `must` to ensure proper OR semantics
- **Removed dead code**: Eliminated unused `should_conditions` variable throughout the codebase
- **Added comprehensive test coverage**: Created 17 unit tests covering all field query parser functionality

### Technical Details

**Before:**

```python
# Used complex NestedCondition
nested_meta = models.NestedCondition(
    nested=models.Nested(
        key="metadata",
        filter=models.Filter(
            must=[
                models.FieldCondition(
                    key="project_id",
                    match=models.MatchAny(any=project_ids),
                )
            ]
        ),
    )
)
```

**After:**

```python
# Simple dot notation
metadata_field = models.FieldCondition(
    key="metadata.project_id",
    match=models.MatchAny(any=project_ids)
)
```

### Project Filter Logic

Now correctly implements: "At least ONE of three locations must match"

```python
Filter(
  must=[
    field_condition_1,        # AND
    field_condition_2,        # AND
    Filter(should=[           # AND (at least one must match)
      project_id,             # OR
      source,                 # OR
      metadata.project_id     # OR
    ])
  ]
)
```

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? **No** - Internal implementation change, API unchanged
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [x] Did you avoid banned placeholders? N/A

## Testing

### Unit Tests

```bash
cd packages/qdrant-loader-mcp-server
pytest tests/unit/search/test_field_query_parser.py -v
```

**Results:** ✅ All 17 tests pass

- ✅ Nested field filtering with dot notation works correctly
- ✅ Project filter with 3 locations (project_id, source, metadata.project_id) works correctly
- ✅ Numeric field conversion (chunk_index, total_chunks) works correctly
- ✅ Field query + project_ids combination works correctly
- ✅ Filter-only mode detection works correctly

### Test Coverage

- `test_create_filter_with_nested_fields` - Verifies dot notation for `metadata.chunk_index`
- `test_create_filter_with_project_ids` - Verifies 3-location project filter
- `test_create_filter_field_queries_and_project_ids` - Verifies combined filtering
- `test_numeric_field_conversion` - Verifies int conversion for numeric fields
- Plus 13 additional tests covering edge cases

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (black formatting applied)
- [x] Documentation updated (N/A - internal implementation)
- [x] All 17 unit tests passing
- [x] No breaking changes to public API

## Related Issues

Fixes #85

## Migration Notes

No migration needed - this is an internal implementation change with no API changes. Existing queries will continue to work as before, but with improved reliability for nested field filtering.
