### PR TITLE
fix: remove project filtering for target document. Fixes #94

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/engine/core.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/engine/core.py
@@ -488,14 +488,19 @@ class SearchEngine:
         if not self._search_ops:
             raise RuntimeError("Search engine not initialized")
 
+        # Search strategy:
+        # 1. Target document: Search across ALL projects to find best match for target_query,
+        # not limited by project_ids filter
+        # 2. Comparison documents: Apply project_ids filter to limit comparison scope
+        
         # First, search for target documents
         target_documents = await self._search_ops.search(
-            target_query, source_types, 1, project_ids
+            target_query, source_types, 1, None
         )
         if not target_documents:
             return {}
 
-        # Then search for comparison documents
+        # Apply project_ids filter for comparison pool
         comparison_documents = await self._search_ops.search(
             comparison_query or target_query, source_types, limit, project_ids
         )


### PR DESCRIPTION
# Pull Request

## Summary

Removes project_ids filtering for target document search in `find_similar_documents` to enable cross-project similarity finding. Target documents are now searched across ALL projects while comparison documents respect the project_ids filter.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages: No - inline code documentation added
- [x] Have you updated or added pages under `docs/`? N/A - added inline comments only
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`) N/A
- [x] Did you avoid banned placeholders? (no "TBD/coming soon") Yes

## Changes Made

### Core Logic (`core.py`)

- Modified `find_similar_documents` to search target document across ALL projects (passing `None` for project_ids)
- Comparison documents still respect project_ids filter for scoped results
- Added comprehensive inline documentation explaining the cross-project filtering strategy

**Rationale:** This enables use cases like "Find documents in mobile-app project similar to the API Rate Limiting guide from backend-docs project"

### Test Coverage (`test_search_engine_advanced.py`)

Added 3 new test cases with detailed documentation:

1. `test_find_similar_documents_cross_project_filtering` - Verifies cross-project behavior
2. `test_find_similar_documents_same_project_behavior` - Tests same-project edge case
3. `test_find_similar_documents_no_project_filter` - Tests no filter scenario

## Testing

```bash
# Run all find_similar tests
python -m pytest packages/qdrant-loader-mcp-server/tests/unit/search/test_search_engine_advanced.py -k "find_similar" -v
# Result: 5/5 tests PASSED

# Run full test suite
pytest .\packages\qdrant-loader-mcp-server\ -v
# Result: All tests PASSED

# Linting
ruff check .\packages\
# Result: No issues found
```

## Business Logic Verification

**Before (Bug):** Target search incorrectly applied project_ids filter, causing:

- Empty results when target doesn't exist in filtered projects
- Unable to find similar documents across project boundaries

**After (Fixed):**

- Target: Searches ALL projects to find best match
- Comparison: Applies project_ids filter to limit comparison scope
- Enables cross-project similarity analysis

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (ruff check)
- [x] Documentation updated (inline comments added)
- [x] Test coverage comprehensive (3 new test cases)
- [x] No breaking changes to API

## Fixes

Fixes #94
