### PR TITLE
fix: update reason field in document analysis to use recommendation_reason

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/engine/intelligence.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/engine/intelligence.py
@@ -542,7 +542,7 @@ class IntelligenceOperations:
                             "relevance_score": rec.get(
                                 "complementary_score", rec.get("relevance_score", 0.0)
                             ),
-                            "reason": rec.get("explanation", rec.get("reason", "")),
+                            "reason": rec.get("recommendation_reason", rec.get("reason", "")),
                             "strategy": rec.get(
                                 "relationship_type", rec.get("strategy", "related")
                             ),


### PR DESCRIPTION
# Pull Request

## Summary

In the MCP server’s find_complementary_content tool, the fields complementary_reason and reasons[] are not populated, even when cross-topic relationships are successfully detected. The tool correctly returns complementary documents, but does not provide an explanation text describing why a document is related

## Type of change

- [ ] Feature
- [X] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [X] Tests pass (`pytest -v`)
- [X] Linting passes (make lint / make format)
- [X] Documentation updated (if applicable)
