### PR TITLE
Fix logic upload coverage artifact in CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,14 +57,18 @@ jobs:
           python -m pytest tests/ --cov=src -v
 
       - name: Generate coverage reports
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+          (github.event_name == 'push' && github.ref_name == 'main')
         run: |
           cd packages/qdrant-loader-core
           coverage xml -o ../../coverage-core.xml
           coverage html -d ../../htmlcov-core
 
       - name: Upload core coverage artifact
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+          (github.event_name == 'push' && github.ref_name == 'main')
         uses: actions/upload-artifact@v4
         with:
           name: coverage-core-${{ github.run_id }}
@@ -245,14 +249,18 @@ jobs:
           python -m pytest tests/integration --cov=src --cov-append --cov-report= -v
 
       - name: Generate coverage reports
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+          (github.event_name == 'push' && github.ref_name == 'main')
         run: |
           cd packages/qdrant-loader
           coverage xml -o ../../coverage-loader.xml
           coverage html -d ../../htmlcov-loader
 
       - name: Upload loader coverage artifact
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+          (github.event_name == 'push' && github.ref_name == 'main')
         uses: actions/upload-artifact@v4
         with:
           name: coverage-loader-${{ github.run_id }}
@@ -348,14 +356,18 @@ jobs:
           python -m pytest tests/integration --cov=src --cov-append --cov-report= --cov-report=term-missing -v
 
       - name: Generate coverage reports
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+          (github.event_name == 'push' && github.ref_name == 'main')
         run: |
           cd packages/qdrant-loader-mcp-server
           coverage xml -o ../../coverage-mcp.xml
           coverage html -d ../../htmlcov-mcp
 
       - name: Upload MCP server coverage artifact
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: |
+          (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+          (github.event_name == 'push' && github.ref_name == 'main')
         uses: actions/upload-artifact@v4
         with:
           name: coverage-mcp-${{ github.run_id }}


### PR DESCRIPTION
# Pull Request

## Summary

Fix the logic for uploading coverage artifacts in the CI/CD pipeline: artifacts are not fully uploaded and are not correctly retrieved by the website build process, resulting in missing coverage reports on the Qdrant Loader website.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [x] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages: No change
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

- Triggered the CI/CD pipeline by pushing a commit to the main branch of fork repo.
- Verified that all coverage reports created successfully.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test coverage reporting to include pull requests targeting the main branch in addition to direct pushes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->