### PR TITLE
fix(core): lazy load openai SDK to reduce CLI startup time

### DIFF
--- a/packages/qdrant-loader-core/src/qdrant_loader_core/llm/factory.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/llm/factory.py
@@ -2,13 +2,6 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
-from .providers.ollama import OllamaProvider
-from .providers.openai import OpenAIProvider
-
-try:
-    from .providers.azure_openai import AzureOpenAIProvider  # type: ignore
-except Exception:  # pragma: no cover - optional dependency surface
-    AzureOpenAIProvider = None  # type: ignore
 from .settings import LLMSettings
 from .types import ChatClient, EmbeddingsClient, LLMProvider, TokenCounter
 
@@ -37,6 +30,23 @@ class _NoopProvider(LLMProvider):
 
     def tokenizer(self) -> TokenCounter:
         return _NoopTokenizer()
+
+
+_SENTINEL = object()
+_azure_provider_class: type | None | object = _SENTINEL
+
+
+def _get_azure_provider_class():  # type: ignore[return]
+    """Lazily resolve the optional AzureOpenAIProvider (cached after first call)."""
+    global _azure_provider_class
+    if _azure_provider_class is _SENTINEL:
+        try:
+            from .providers.azure_openai import AzureOpenAIProvider  # type: ignore
+
+            _azure_provider_class = AzureOpenAIProvider
+        except Exception:  # pragma: no cover - optional dependency surface
+            _azure_provider_class = None
+    return _azure_provider_class
 
 
 def _safe_hostname(url: str | None) -> str | None:
@@ -69,19 +79,25 @@ def create_provider(settings: LLMSettings) -> LLMProvider:
             or base_host.endswith(".cognitiveservices.azure.com")
         )
     )
-    if is_azure and AzureOpenAIProvider is not None:  # type: ignore[truthy-bool]
-        try:
-            return AzureOpenAIProvider(settings)  # type: ignore[misc]
-        except Exception:
-            return _NoopProvider()
+    if is_azure:
+        azure_cls = _get_azure_provider_class()
+        if azure_cls is not None:
+            try:
+                return azure_cls(settings)  # type: ignore[misc]
+            except Exception:
+                return _NoopProvider()
 
     if "openai" in provider_name or "openai" in base_url.lower():
+        from .providers.openai import OpenAIProvider
+
         try:
             return OpenAIProvider(settings)
         except Exception:
             return _NoopProvider()
 
     if provider_name == "ollama" or (base_host in ("localhost", "127.0.0.1")):
+        from .providers.ollama import OllamaProvider
+
         return OllamaProvider(settings)
 
     return _NoopProvider()

--- a/packages/qdrant-loader-core/tests/test_factory_additional.py
+++ b/packages/qdrant-loader-core/tests/test_factory_additional.py
@@ -26,7 +26,7 @@ def test_factory_routes_to_noop_on_openai_init_failure(monkeypatch):
         def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
             raise RuntimeError("boom")
 
-    monkeypatch.setattr(factory, "OpenAIProvider", _BadProvider)
+    monkeypatch.setattr(openai_mod, "OpenAIProvider", _BadProvider)
 
     provider = factory.create_provider(
         _settings("openai", base_url="https://api.openai.com/v1")
@@ -58,8 +58,10 @@ def test_factory_azure_error_returns_noop(monkeypatch):
             raise RuntimeError("boom")
 
     # If Azure provider is importable, force failure path
-    if getattr(factory, "AzureOpenAIProvider", None) is not None:
-        monkeypatch.setattr(factory, "AzureOpenAIProvider", _BadAzure)
+    if azure_mod.AzureOpenAIProvider is not None:
+        monkeypatch.setattr(azure_mod, "AzureOpenAIProvider", _BadAzure)
+        # Reset the lazy cache so _get_azure_provider_class() re-imports the patched class
+        monkeypatch.setattr(factory, "_azure_provider_class", factory._SENTINEL)
         provider = factory.create_provider(
             _settings("azure_openai", base_url="https://x.openai.azure.com")
         )


### PR DESCRIPTION
# Pull Request

## Summary

Move OpenAI, Ollama, and Azure OpenAI provider imports from module-level to inside `create_provider()` function, so the openai SDK (~48% of startup time) is only loaded when actually needed.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? No
- [x] Have you updated or added pages under `docs/`? N/A
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [x] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

- Existing unit tests updated to match lazy import pattern
- `pytest packages/qdrant-loader-core/tests/test_factory_additional.py -v` — 3/3 passed

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [x] Documentation updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized LLM provider initialization with lazy loading and enhanced error handling for improved application performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->