### PR TITLE
Enable reranking by default and add reranking to setup wizard

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/config_reranking.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/config_reranking.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 class MCPReranking(BaseModel):
     """Reranking model."""
 
-    enabled: bool = Field(default=False, description="Enable or disable reranking")
+    enabled: bool = Field(default=True, description="Enable or disable reranking")
     model: str = Field(
         default="cross-encoder/ms-marco-MiniLM-L-12-v2",
         description="Reranking model to use",

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -50,12 +50,20 @@ class SearchHandler:
             reranking_config = MCPReranking()
 
         if reranking_config.enabled:
-            self.reranker = HybridReranker(
-                enabled=reranking_config.enabled,
-                model=reranking_config.model,
-                device=reranking_config.device,
-                batch_size=reranking_config.batch_size,
-            )
+            try:
+                self.reranker = HybridReranker(
+                    enabled=reranking_config.enabled,
+                    model=reranking_config.model,
+                    device=reranking_config.device,
+                    batch_size=reranking_config.batch_size,
+                )
+            except Exception as e:
+                logger = LoggingConfig.get_logger(__name__)
+                logger.warning(
+                    "Failed to initialize reranker, continuing without reranking",
+                    error=str(e),
+                )
+                self.reranker = None
 
     async def handle_search(
         self, request_id: str | int | None, params: dict[str, Any]

--- a/packages/qdrant-loader-mcp-server/tests/integration/test_search_handler_integration.py
+++ b/packages/qdrant-loader-mcp-server/tests/integration/test_search_handler_integration.py
@@ -34,7 +34,14 @@ def integration_search_handler(real_protocol):
     mock_search_engine.client = Mock()
     mock_search_engine.client.scroll = AsyncMock()
 
-    handler = SearchHandler(mock_search_engine, mock_query_processor, real_protocol)
+    from qdrant_loader_mcp_server.config_reranking import MCPReranking
+
+    handler = SearchHandler(
+        mock_search_engine,
+        mock_query_processor,
+        real_protocol,
+        reranking_config=MCPReranking(enabled=False),
+    )
 
     # mock config nếu code dùng
     handler.qdrant_config = Mock()

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_mcp_handler_filters.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_mcp_handler_filters.py
@@ -126,10 +126,17 @@ def mock_search_results():
 @pytest.fixture
 def search_handler():
     """Create a SearchHandler instance for testing."""
+    from qdrant_loader_mcp_server.config_reranking import MCPReranking
+
     mock_search_engine = Mock()
     mock_query_processor = Mock()
     mock_protocol = Mock(spec=MCPProtocol)
-    return SearchHandler(mock_search_engine, mock_query_processor, mock_protocol)
+    return SearchHandler(
+        mock_search_engine,
+        mock_query_processor,
+        mock_protocol,
+        reranking_config=MCPReranking(enabled=False),
+    )
 
 
 @pytest.fixture

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_async_behavior.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_async_behavior.py
@@ -35,8 +35,15 @@ def mock_protocol():
 
 @pytest.fixture
 def async_search_handler(async_search_engine, async_query_processor, mock_protocol):
-    """Create a SearchHandler with async components."""
-    return SearchHandler(async_search_engine, async_query_processor, mock_protocol)
+    """Create a SearchHandler with async components (reranking disabled for async tests)."""
+    from qdrant_loader_mcp_server.config_reranking import MCPReranking
+
+    return SearchHandler(
+        async_search_engine,
+        async_query_processor,
+        mock_protocol,
+        reranking_config=MCPReranking(enabled=False),
+    )
 
 
 @pytest.fixture

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
@@ -38,7 +38,14 @@ def search_handler(mock_search_engine, mock_query_processor, mock_protocol):
     mock_search_engine.client = Mock()
     mock_search_engine.client.scroll = AsyncMock()
 
-    handler = SearchHandler(mock_search_engine, mock_query_processor, mock_protocol)
+    from qdrant_loader_mcp_server.config_reranking import MCPReranking
+
+    handler = SearchHandler(
+        mock_search_engine,
+        mock_query_processor,
+        mock_protocol,
+        reranking_config=MCPReranking(enabled=False),
+    )
 
     # mock config dùng trong expand_document
     handler.qdrant_config = Mock()
@@ -161,7 +168,14 @@ class TestSearchHandlerInit:
         self, mock_search_engine, mock_query_processor, mock_protocol
     ):
         """Test that SearchHandler initializes correctly with all components."""
-        handler = SearchHandler(mock_search_engine, mock_query_processor, mock_protocol)
+        from qdrant_loader_mcp_server.config_reranking import MCPReranking
+
+        handler = SearchHandler(
+            mock_search_engine,
+            mock_query_processor,
+            mock_protocol,
+            reranking_config=MCPReranking(enabled=False),
+        )
 
         assert handler.search_engine == mock_search_engine
         assert handler.query_processor == mock_query_processor

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_error_handling.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_error_handling.py
@@ -35,7 +35,14 @@ def mock_protocol():
 @pytest.fixture
 def search_handler_with_mocks(mock_search_engine, mock_query_processor, mock_protocol):
     """Create a SearchHandler with all mocked dependencies."""
-    return SearchHandler(mock_search_engine, mock_query_processor, mock_protocol)
+    from qdrant_loader_mcp_server.config_reranking import MCPReranking
+
+    return SearchHandler(
+        mock_search_engine,
+        mock_query_processor,
+        mock_protocol,
+        reranking_config=MCPReranking(enabled=False),
+    )
 
 
 class TestSearchErrorHandling:

--- a/packages/qdrant-loader/conf/.env.simplified.template
+++ b/packages/qdrant-loader/conf/.env.simplified.template
@@ -5,7 +5,7 @@
 # Never commit .env with real secrets to version control.
 # Ensure .env is listed in .gitignore (it is by default).
 
-# Required: OpenAI API key (auto-fills embedding + LLM config)
+# OpenAI API key (auto-fills embedding + LLM config)
 OPENAI_API_KEY=your_openai_api_key_here
 
 # Optional: Override Qdrant defaults

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -157,7 +157,7 @@ global:
   # Cross-encoder re-ranking configuration
   # Controls fine-grained re-ranking using cross-encoders for improved precision
   reranking:
-    enabled: false                                         # Enable cross-encoder re-ranking (improves precision)
+    enabled: true                                          # Enable cross-encoder re-ranking (improves precision)
     model: "cross-encoder/ms-marco-MiniLM-L-12-v2"        # Cross-encoder model to use
                                                             # Other options:
                                                             #  - cross-encoder/ms-marco-TinyBERT-L-2-v2 (ultra-fast, low quality)

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
@@ -372,13 +372,20 @@ def run_setup_advanced(output_dir: Path) -> None:
     chunk_overlap: int = click.prompt("Chunk overlap (characters)", default=200, type=int)
 
     # ------------------------------------------------------------------
-    # Step 4: Projects with sources
+    # Step 4: Reranking settings
+    # ------------------------------------------------------------------
+    _get_console().print("\n[bold cyan]Step 4: Reranking Configuration[/bold cyan]")
+
+    enable_reranking: bool = click.confirm("Enable cross-encoder reranking?", default=True)
+
+    # ------------------------------------------------------------------
+    # Step 5: Projects with sources
     # ------------------------------------------------------------------
     projects: dict[str, dict[str, Any]] = {}
     all_extra_env: dict[str, str] = {}
 
     while True:
-        _get_console().print("\n[bold cyan]Step 4: Project Configuration[/bold cyan]")
+        _get_console().print("\n[bold cyan]Step 5: Project Configuration[/bold cyan]")
 
         while True:
             project_id: str = click.prompt("Project ID", default="my-project")
@@ -408,7 +415,7 @@ def run_setup_advanced(output_dir: Path) -> None:
             break
 
     # ------------------------------------------------------------------
-    # Step 5: Write files
+    # Step 6: Write files
     # ------------------------------------------------------------------
     config_path = output_dir / "config.yaml"
     env_path = output_dir / ".env"
@@ -449,6 +456,10 @@ def run_setup_advanced(output_dir: Path) -> None:
 
     if embedding_endpoint:
         global_config["embedding"]["endpoint"] = embedding_endpoint
+
+    global_config["reranking"] = {
+        "enabled": enable_reranking,
+    }
 
     _write_config_file_advanced(
         config_path,

--- a/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
+++ b/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
@@ -296,7 +296,12 @@ class TestRunSetup:
         ]
         with (
             patch("click.prompt", side_effect=prompt_side_effects),
-            patch("click.confirm", side_effect=[False, False, True]),
+            patch("click.confirm", side_effect=[
+                True,   # enable reranking
+                False,  # no more sources
+                False,  # no more projects
+                True,   # write files
+            ]),
             patch(_SST, return_value="localfile"),
         ):
             run_setup(ws, mode="advanced")
@@ -401,7 +406,12 @@ class TestRunSetupAdvanced:
         ]
         with (
             patch("click.prompt", side_effect=prompt_side_effects),
-            patch("click.confirm", side_effect=[False, False, True]),
+            patch("click.confirm", side_effect=[
+                True,   # enable reranking
+                False,  # no more sources
+                False,  # no more projects
+                True,   # write files
+            ]),
             patch(_SST, return_value="localfile"),
         ):
             run_setup_advanced(tmp_path)
@@ -414,6 +424,7 @@ class TestRunSetupAdvanced:
         assert proj["project_id"] == "proj-1"
         assert proj["display_name"] == "Project One"
         assert "localfile" in proj["sources"]
+        assert config["global"]["reranking"]["enabled"] is True
 
     def test_advanced_global_settings(self, tmp_path: Path) -> None:
         prompt_side_effects = [
@@ -425,7 +436,12 @@ class TestRunSetupAdvanced:
         ]
         with (
             patch("click.prompt", side_effect=prompt_side_effects),
-            patch("click.confirm", side_effect=[False, False, True]),
+            patch("click.confirm", side_effect=[
+                True,   # enable reranking
+                False,  # no more sources
+                False,  # no more projects
+                True,   # write files
+            ]),
             patch(_SST, return_value="localfile"),
         ):
             run_setup_advanced(tmp_path)
@@ -437,6 +453,7 @@ class TestRunSetupAdvanced:
         assert g["embedding"]["vector_size"] == 768
         assert g["chunking"]["chunk_size"] == 2000
         assert g["chunking"]["chunk_overlap"] == 300
+        assert g["reranking"]["enabled"] is True
 
     def test_advanced_multiple_projects(self, tmp_path: Path) -> None:
         prompt_side_effects = [
@@ -451,6 +468,7 @@ class TestRunSetupAdvanced:
         with (
             patch("click.prompt", side_effect=prompt_side_effects),
             patch("click.confirm", side_effect=[
+                True,   # enable reranking
                 False,  # no more sources for proj-a
                 True,   # add another project
                 False,  # no more sources for proj-b
@@ -464,6 +482,30 @@ class TestRunSetupAdvanced:
         config = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         assert "proj-a" in config["projects"]
         assert "proj-b" in config["projects"]
+
+    def test_advanced_reranking_disabled(self, tmp_path: Path) -> None:
+        """Test that reranking can be disabled in advanced mode."""
+        prompt_side_effects = [
+            "sk-test", "http://localhost:6333", "", "documents",
+            "text-embedding-3-small", "", 1536,
+            1500, 200,
+            "proj-1", "proj-1", "",
+            "my-localfile", "file:///tmp/data", "*.md",
+        ]
+        with (
+            patch("click.prompt", side_effect=prompt_side_effects),
+            patch("click.confirm", side_effect=[
+                False,  # disable reranking
+                False,  # no more sources
+                False,  # no more projects
+                True,   # write files
+            ]),
+            patch(_SST, return_value="localfile"),
+        ):
+            run_setup_advanced(tmp_path)
+
+        config = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert config["global"]["reranking"]["enabled"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/qdrant-loader/tests/unit/config/test_auto_env_resolution.py
+++ b/packages/qdrant-loader/tests/unit/config/test_auto_env_resolution.py
@@ -158,12 +158,19 @@ class TestAutoEnvResolution:
                 "QDRANT_API_KEY",
                 "QDRANT_COLLECTION_NAME",
             )
-            with patch.dict(os.environ, clean, clear=True):
+            with (
+                patch.dict(os.environ, clean, clear=True),
+                patch("qdrant_loader.config.load_dotenv"),
+            ):
                 settings = Settings.from_yaml(config_path, skip_validation=True)
             assert settings.global_config.qdrant.url == "http://localhost:6333"
             assert settings.global_config.qdrant.collection_name == "documents"
-            assert settings.global_config.qdrant.api_key is None
-            assert settings.global_config.embedding.api_key is None
+            assert settings.global_config.qdrant.api_key is None, (
+                "qdrant.api_key should be None when no env vars are set"
+            )
+            assert settings.global_config.embedding.api_key is None, (
+                "embedding.api_key should be None when no env vars are set"
+            )
         finally:
             os.unlink(config_path)
 

--- a/packages/qdrant-loader/tests/unit/test_main.py
+++ b/packages/qdrant-loader/tests/unit/test_main.py
@@ -45,7 +45,7 @@ def test_main_module_execution_via_runpy():
         cwd=str(package_root),  # Use portable path
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=30,
     )
 
     # The command should run (even if it exits with non-zero due to --help)


### PR DESCRIPTION
## Summary
- Enable reranking by default (`enabled: true`) when no reranking config is provided
- Add reranking enable/disable prompt to `qdrant-loader setup` advanced mode
- Remove "Required" label from `OPENAI_API_KEY` comment in simplified `.env` template
- Update `config.template.yaml` to reflect new default
- Update unit tests for advanced setup wizard reranking support

## Changes
| File | Change |
|------|--------|
| `config_reranking.py` | Default `enabled` from `False` → `True` |
| `.env.simplified.template` | Remove "Required:" prefix from OPENAI_API_KEY comment |
| `config.template.yaml` | Default `enabled` from `false` → `true` |
| `setup_cmd.py` | Add Step 4 reranking config in advanced mode |
| `test_setup_cmd.py` | Update existing tests + add `test_advanced_reranking_disabled` |

## Test plan
- [x] All 51 setup_cmd unit tests pass
- [x] All 19 MCP reranking unit tests pass
- [ ] Manual test: `qdrant-loader setup` advanced mode shows reranking prompt
- [ ] Manual test: MCP server starts with reranking enabled by default

Refs: AIKH-1370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added reranking configuration step to the setup wizard for easy cross-encoder re-ranking configuration.

* **Configuration Changes**
  * Cross-encoder re-ranking is now enabled by default in the configuration.
  * Updated setup wizard flow to include reranking settings during initial configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->