### PR TITLE
fix: prevent double reranking

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/handler.py
@@ -31,6 +31,8 @@ class MCPHandler:
         self.query_processor = query_processor
 
         # Initialize specialized handlers
+        # SearchHandler enforces reranking exclusivity: if an MCP-level reranker is enabled,
+        # it disables pipeline-level reranking to avoid double reranking of results.
         self.search_handler = SearchHandler(
             search_engine,
             query_processor,

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -49,6 +49,18 @@ class SearchHandler:
         if reranking_config is None:
             reranking_config = MCPReranking()
 
+        # always check after config is finalized
+        if reranking_config.enabled:
+            # If handler-level reranking is active, disable pipeline-level reranking
+            # to avoid running the cross-encoder twice.
+            if hasattr(search_engine, "hybrid_pipeline") and search_engine.hybrid_pipeline is not None:
+                if hasattr(search_engine.hybrid_pipeline, "reranker"):
+                    search_engine.hybrid_pipeline.reranker = None
+
+            if hasattr(search_engine, "pipeline") and search_engine.pipeline is not None:
+                if hasattr(search_engine.pipeline, "reranker"):
+                    search_engine.pipeline.reranker = None
+
         if reranking_config.enabled:
             try:
                 self.reranker = HybridReranker(
@@ -137,6 +149,8 @@ class SearchHandler:
             )
 
             # Apply reranking if enabled
+
+
             if self.reranker:
                 results = await asyncio.to_thread(
                     self.reranker.rerank,

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
@@ -182,6 +182,30 @@ class TestSearchHandlerInit:
         assert handler.protocol == mock_protocol
         assert handler.formatters is not None
 
+    def test_init_disables_hybrid_pipeline_reranker_when_handler_reranking_enabled(
+        self, mock_query_processor, mock_protocol
+    ):
+        from qdrant_loader_mcp_server.config_reranking import MCPReranking
+
+        search_engine = Mock()
+        pipeline_mock = Mock()
+        pipeline_mock.reranker = Mock()
+        search_engine.hybrid_pipeline = pipeline_mock
+
+        handler = SearchHandler(
+            search_engine,
+            mock_query_processor,
+            mock_protocol,
+            reranking_config=MCPReranking(enabled=True),
+        )
+
+        assert search_engine.hybrid_pipeline.reranker is None
+
+        assert handler.search_engine == search_engine
+        assert handler.query_processor == mock_query_processor
+        assert handler.protocol == mock_protocol
+        assert handler.formatters is not None
+
 
 class TestHandleSearch:
     """Test the main search functionality."""


### PR DESCRIPTION
# Pull Request

## Summary

Prevent double-reranking by ensuring only the handler's reranker executes on search results

## Type of change

- [ ] Feature
- [X] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where search results were processed through multiple reranking stages. Reranking now occurs only once in the search pipeline, ensuring accurate and consistent result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->