### PR TITLE
fix: prevent silent env-variable overwrite across projects in setup wizard

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
@@ -594,7 +594,9 @@ def _collect_sources_loop(
             f"\n[bold cyan]Configure {SOURCE_TYPES[source_type]}[/bold cyan]"
         )
         existing_names = all_sources.get(source_type, {})
-        existing_suffixes = {_source_name_to_env_suffix(n) for n in existing_names}
+        # Collect suffixes from ALL already-registered env vars (across all
+        # source types and projects) to prevent silent overwrites.
+        existing_env_keys = set(all_extra_env.keys())
         while True:
             source_name = click.prompt(
                 "Source name (identifier)", default=f"my-{source_type}"
@@ -606,10 +608,12 @@ def _collect_sources_loop(
                     f"Pick a different name.[/red]"
                 )
                 continue
-            if suffix in existing_suffixes:
+            # Check if any env key with this suffix already exists
+            if any(k.endswith(f"_{suffix}") for k in existing_env_keys):
                 _get_console().print(
                     f"[red]'{source_name}' collides with an existing "
-                    f"env var suffix. Pick a different name.[/red]"
+                    f"env var suffix across projects. "
+                    f"Pick a different name.[/red]"
                 )
                 continue
             break

--- a/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
+++ b/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
@@ -9,6 +9,7 @@ import yaml
 from qdrant_loader.cli.commands.setup_cmd import (
     _collect_git_config,
     _collect_localfile_config,
+    _collect_sources_loop,
     _escape_env_value,
     _source_name_to_env_suffix,
     _write_config_file_multi,
@@ -635,6 +636,39 @@ class TestRunSetupAdvanced:
 
         config = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         assert config["global"]["reranking"]["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# _collect_sources_loop – cross-project env-var collision detection
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSourcesLoopEnvCollision:
+    """Verify that _collect_sources_loop rejects source names whose env-var
+    suffix collides with keys already present in all_extra_env (from a
+    previous project)."""
+
+    def test_rejects_duplicate_suffix_across_projects(self, tmp_path: Path) -> None:
+        """When project-1 already registered CONFLUENCE_TOKEN_MY_WIKI,
+        project-2 should not be allowed to reuse the name 'my-wiki'."""
+        all_sources: dict = {}
+        all_extra_env: dict = {"CONFLUENCE_TOKEN_MY_WIKI": "secret-1"}
+
+        # Simulate: user picks confluence, enters "my-wiki" (rejected),
+        # then "my-wiki-2" (accepted), then stops.
+        prompts = iter(["my-wiki", "my-wiki-2", "https://x.atlassian.net/wiki", "SP", "u@c.com", "tok"])
+        confirms = iter([False])  # don't add another source
+
+        with (
+            patch(_SST, side_effect=["confluence", None]),
+            patch("click.prompt", side_effect=lambda *a, **kw: next(prompts)),
+            patch("click.confirm", side_effect=lambda *a, **kw: next(confirms)),
+        ):
+            _collect_sources_loop(all_sources, all_extra_env, workspace_dir=tmp_path)
+
+        # "my-wiki" must have been rejected; "my-wiki-2" accepted
+        assert "my-wiki-2" in all_sources.get("confluence", {})
+        assert "CONFLUENCE_TOKEN_MY_WIKI_2" in all_extra_env
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix silent credential overwrite when two projects use the same source name in advanced setup wizard
- Env-var suffix collision detection now checks against all registered env keys across all projects and source types, not just the current source type

## Root Cause
`_collect_sources_loop` checked `existing_suffixes` only from `all_sources.get(source_type, {})` (current source type). The shared `all_extra_env` dict was updated via `.update()`, silently overwriting credentials from a previous project when both used the same source name.

## Changes
- `setup_cmd.py`: Replace source-type-scoped suffix check with global `all_extra_env` key check
- `test_setup_cmd.py`: Add `TestCollectSourcesLoopEnvCollision` test class

## Test plan
- [x] New unit test verifies rejection of duplicate suffix across projects
- [x] All 52 existing tests pass

Resolves: AIKH-1402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation during setup to more comprehensively detect naming conflicts across all projects, preventing potential issues with duplicate source names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->