### PR TITLE
fix: enforce valid global reranking configuration and raise error on invalid type

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/config_loader.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/config_loader.py
@@ -140,11 +140,10 @@ def build_config_from_dict(config_data: dict[str, Any]) -> Config:
 
     # Build reranking config from global section if present
     reranking_cfg = None
-    if isinstance(global_data.get("reranking"), dict):
-        try:
-            reranking_cfg = MCPReranking(**global_data.get("reranking") or {})
-        except Exception:
-            logger.warning("Invalid reranking config in file; using defaults")
+    if "reranking" in global_data:
+        if not isinstance(global_data["reranking"], dict):
+            raise ValueError("global.reranking must be a mapping")
+        reranking_cfg = MCPReranking(**global_data["reranking"])
 
     cfg = Config(
         qdrant=QdrantConfig(**qdrant) if qdrant else QdrantConfig(),


### PR DESCRIPTION
# Pull Request

## Summary

Don't silently replace an invalid global.reranking block with defaults. This path warns and then falls back to MCPReranking(), so a malformed reranking section looks accepted while changing runtime behavior back to the default config

## Type of change

- [ ] Feature
- [X] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration validation for reranking functionality has been strengthened. The system now enforces stricter validation rules and provides explicit, detailed error messages when invalid configurations are detected. This replaces the previous silent processing behavior with clear and actionable feedback, enabling faster identification and resolution of configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->