### PR TITLE
fix: update collection_name source in search_handler

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/config_reranking.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/config_reranking.py
@@ -3,12 +3,9 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt
 
 class MCPReranking(BaseModel):
 
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = Field(
-        default=True,
-        description="Enable or disable reranking"
-    )
+    enabled: bool = Field(default=True, description="Enable or disable reranking")
     model: str = Field(
         default="cross-encoder/ms-marco-MiniLM-L-12-v2",
         description="Reranking model to use",

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from qdrant_client import models
 
-from qdrant_loader_mcp_server.config import QdrantConfig
 from qdrant_loader_mcp_server.config_reranking import MCPReranking
 
 from ..search.engine import SearchEngine
@@ -43,7 +42,6 @@ class SearchHandler:
         self.query_processor = query_processor
         self.protocol = protocol
         self.formatters = MCPFormatters()
-        self.qdrant_config = QdrantConfig()
         self.reranker = None
 
         if reranking_config is None:
@@ -502,7 +500,7 @@ class SearchHandler:
             next_offset = None
             truncated = False
 
-            collection_name = self.qdrant_config.collection_name
+            collection_name = self.search_engine.config.collection_name
             MAX_CHUNKS = 500  # Reasonable upper bound
             # Scroll to retrieve all chunks
             while True:

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -53,11 +53,17 @@ class SearchHandler:
         if reranking_config.enabled:
             # If handler-level reranking is active, disable pipeline-level reranking
             # to avoid running the cross-encoder twice.
-            if hasattr(search_engine, "hybrid_pipeline") and search_engine.hybrid_pipeline is not None:
+            if (
+                hasattr(search_engine, "hybrid_pipeline")
+                and search_engine.hybrid_pipeline is not None
+            ):
                 if hasattr(search_engine.hybrid_pipeline, "reranker"):
                     search_engine.hybrid_pipeline.reranker = None
 
-            if hasattr(search_engine, "pipeline") and search_engine.pipeline is not None:
+            if (
+                hasattr(search_engine, "pipeline")
+                and search_engine.pipeline is not None
+            ):
                 if hasattr(search_engine.pipeline, "reranker"):
                     search_engine.pipeline.reranker = None
 
@@ -149,7 +155,6 @@ class SearchHandler:
             )
 
             # Apply reranking if enabled
-
 
             if self.reranker:
                 results = await asyncio.to_thread(
@@ -497,7 +502,7 @@ class SearchHandler:
             next_offset = None
             truncated = False
 
-            collection_name = self.query_processor.collection_name
+            collection_name = self.qdrant_config.collection_name
             MAX_CHUNKS = 500  # Reasonable upper bound
             # Scroll to retrieve all chunks
             while True:

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/keyword_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/keyword_search_service.py
@@ -39,6 +39,7 @@ class KeywordSearchService:
         self._stemmer = SnowballStemmer(language="english")
 
         from nltk.corpus import stopwords
+
         try:
             nltk.data.find("corpora/stopwords")
         except LookupError:

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/cross_encoder_reranker.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/cross_encoder_reranker.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from sentence_transformers import CrossEncoder
 
+
 class CrossEncoderReranker:
     """Re-rank search results using a cross-encoder model."""
 

--- a/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
+++ b/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
@@ -656,7 +656,16 @@ class TestCollectSourcesLoopEnvCollision:
 
         # Simulate: user picks confluence, enters "my-wiki" (rejected),
         # then "my-wiki-2" (accepted), then stops.
-        prompts = iter(["my-wiki", "my-wiki-2", "https://x.atlassian.net/wiki", "SP", "u@c.com", "tok"])
+        prompts = iter(
+            [
+                "my-wiki",
+                "my-wiki-2",
+                "https://x.atlassian.net/wiki",
+                "SP",
+                "u@c.com",
+                "tok",
+            ]
+        )
         confirms = iter([False])  # don't add another source
 
         with (


### PR DESCRIPTION
# Pull Request

## Summary

Refactor collection_name handling to be request-scoped instead of relying on shared state by using `self.qdrant_config.collection_name` instead of `self.query_processor.collection_name`

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

It does not have any changes.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Code formatting updates across multiple modules for improved consistency.

* **Chores**
  * Adjusted document expansion to source its collection configuration from the unified search configuration (ensuring consistent collection selection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->