### PR TITLE
feat: filter out garbage data when nlp for metadata. Resolves #177

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -5,6 +5,7 @@ import inspect
 from typing import Any
 
 from qdrant_client import models
+
 from qdrant_loader_mcp_server.config_reranking import MCPReranking
 
 from ..search.engine import SearchEngine

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -14,6 +14,44 @@ from spacy.tokens import Doc
 logger = logging.getLogger(__name__)
 
 
+def is_meaningful_text(text: str) -> bool:
+    """Check if text contains meaningful content (letters or digits).
+
+    Returns False for text that only contains:
+    - Punctuation marks: ., #, @, |, -, _, etc.
+    - Whitespace characters
+    - Special symbols without semantic meaning (---, ..., |||, etc.)
+
+    This is used to filter both entities and tokens in NLP processing,
+    especially important for Excel/table processing where markdown tables
+    generate excessive pipe characters, commas, and spaces.
+
+    Args:
+        text: Text string to check
+
+    Returns:
+        True if text contains at least one letter or digit, False otherwise
+
+    Example:
+        >>> is_meaningful_text("Apple")
+        True
+        >>> is_meaningful_text("#")
+        False
+        >>> is_meaningful_text("|")
+        False
+        >>> is_meaningful_text("...")
+        False
+        >>> is_meaningful_text("---")
+        False
+        >>> is_meaningful_text("Apple123")
+        True
+        >>> is_meaningful_text("COVID-19")  # Has alphanumeric
+        True
+    """
+    # Check if text contains at least one alphanumeric character
+    return any(c.isalnum() for c in text)
+
+
 @dataclass
 class SemanticAnalysisResult:
     """Container for semantic analysis results."""
@@ -120,7 +158,12 @@ class SemanticAnalyzer:
         return result
 
     def _extract_entities(self, doc: Doc) -> list[dict[str, Any]]:
-        """Extract named entities with linking.
+        """Extract named entities with linking, filtering garbage entities.
+
+        Filters out entities that:
+        - Only contain punctuation/symbols (., #, |, etc.)
+        - Don't have any alphanumeric characters
+        - Are just whitespace
 
         Args:
             doc: spaCy document
@@ -130,6 +173,10 @@ class SemanticAnalyzer:
         """
         entities = []
         for ent in doc.ents:
+            # Filter entities that only contain punctuation/symbols
+            if not is_meaningful_text(ent.text):
+                continue
+
             # Get entity context
             start_sent = ent.sent.start
             end_sent = ent.sent.end
@@ -138,17 +185,19 @@ class SemanticAnalyzer:
             # Get entity description
             description = self.nlp.vocab.strings[ent.label_]
 
-            # Get related entities
+            # Get related entities (also filter meaningless ones)
             related = []
             for token in ent.sent:
                 if token.ent_type_ and token.text != ent.text:
-                    related.append(
-                        {
-                            "text": token.text,
-                            "type": token.ent_type_,
-                            "relation": token.dep_,
-                        }
-                    )
+                    # Only add related entities with meaningful text
+                    if is_meaningful_text(token.text):
+                        related.append(
+                            {
+                                "text": token.text,
+                                "type": token.ent_type_,
+                                "relation": token.dep_,
+                            }
+                        )
 
             entities.append(
                 {
@@ -165,16 +214,32 @@ class SemanticAnalyzer:
         return entities
 
     def _get_pos_tags(self, doc: Doc) -> list[dict[str, Any]]:
-        """Get part-of-speech tags with detailed information.
+        """Get part-of-speech tags with detailed information, filtering noise tokens.
+
+        Filters out multiple types of noise:
+        - Whitespace tokens (is_space=True)
+        - Punctuation tokens (is_punct=True)
+        - Symbol-only tokens without alphanumeric content (e.g., ---, ..., |||)
+
+        This is especially important for Excel tables and structured data.
 
         Args:
             doc: spaCy document
 
         Returns:
-            List of POS tag dictionaries
+            List of POS tag dictionaries (excluding spaces, punctuation, and symbols)
         """
         pos_tags = []
         for token in doc:
+            # Skip whitespace and punctuation - they pollute metadata
+            if token.is_space or token.is_punct:
+                continue
+
+            # Also skip tokens with no meaningful content (e.g., ---, ...)
+            # This catches edge cases where spaCy doesn't mark as punct
+            if not is_meaningful_text(token.text):
+                continue
+
             pos_tags.append(
                 {
                     "text": token.text,
@@ -182,8 +247,6 @@ class SemanticAnalyzer:
                     "tag": token.tag_,
                     "lemma": token.lemma_,
                     "is_stop": token.is_stop,
-                    "is_punct": token.is_punct,
-                    "is_space": token.is_space,
                 }
             )
         return pos_tags

--- a/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
+++ b/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 from qdrant_loader.cli.commands.setup_cmd import (
     _collect_git_config,
@@ -953,6 +955,10 @@ class TestDuplicateSourceNameRejection:
 class TestEnvFilePermissions:
     """Tests for .env file permission hardening."""
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Unix-style permissions not supported on Windows",
+    )
     def test_env_file_permissions_restricted(self, tmp_path: Path) -> None:
         import os
         import stat

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -1,12 +1,13 @@
 """Tests for SemanticAnalyzer."""
 
 import logging
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from qdrant_loader.core.text_processing.semantic_analyzer import (
     SemanticAnalysisResult,
     SemanticAnalyzer,
+    is_meaningful_text,
 )
 
 
@@ -37,6 +38,71 @@ class TestSemanticAnalysisResult:
         assert result.topics == topics
         assert result.key_phrases == key_phrases
         assert result.document_similarity == doc_similarity
+
+
+class TestIsMeaningfulText:
+    """Test cases for is_meaningful_text function."""
+
+    def test_text_with_letters_is_meaningful(self):
+        """Test that text with letters is considered meaningful."""
+        assert is_meaningful_text("Apple") is True
+        assert is_meaningful_text("hello") is True
+        assert is_meaningful_text("USA") is True
+
+    def test_text_with_digits_is_meaningful(self):
+        """Test that text with digits is considered meaningful."""
+        assert is_meaningful_text("123") is True
+        assert is_meaningful_text("2024") is True
+
+    def test_text_with_alphanumeric_is_meaningful(self):
+        """Test that text with letters and numbers is meaningful."""
+        assert is_meaningful_text("Apple123") is True
+        assert is_meaningful_text("COVID-19") is True
+        assert is_meaningful_text("Section1.2") is True
+
+    def test_punctuation_only_not_meaningful(self):
+        """Test that punctuation-only text is not meaningful."""
+        assert is_meaningful_text(".") is False
+        assert is_meaningful_text("#") is False
+        assert is_meaningful_text("|") is False
+        assert is_meaningful_text(",") is False
+        assert is_meaningful_text("...") is False
+        assert is_meaningful_text("---") is False
+        assert is_meaningful_text("!!!") is False
+
+    def test_special_symbols_not_meaningful(self):
+        """Test that special symbols without content are not meaningful."""
+        assert is_meaningful_text("@") is False
+        assert is_meaningful_text("$") is False
+        assert is_meaningful_text("%") is False
+        assert is_meaningful_text("&") is False
+        assert is_meaningful_text("*") is False
+        assert is_meaningful_text("~") is False
+
+    def test_whitespace_not_meaningful(self):
+        """Test that whitespace-only text is not meaningful."""
+        assert is_meaningful_text(" ") is False
+        assert is_meaningful_text("  ") is False
+        assert is_meaningful_text("\t") is False
+        assert is_meaningful_text("\n") is False
+
+    def test_mixed_with_punctuation_is_meaningful(self):
+        """Test that text with meaningful content and punctuation is still meaningful."""
+        assert is_meaningful_text("Apple.") is True
+        assert is_meaningful_text("#hashtag") is True
+        assert is_meaningful_text("@username") is True
+        assert is_meaningful_text("(test)") is True
+
+    def test_empty_string_not_meaningful(self):
+        """Test that empty string is not meaningful."""
+        assert is_meaningful_text("") is False
+
+    def test_table_separators_not_meaningful(self):
+        """Test that table separators (common in Excel/markdown) are not meaningful."""
+        assert is_meaningful_text("|") is False
+        assert is_meaningful_text("|-") is False
+        assert is_meaningful_text("|--") is False
+        assert is_meaningful_text("||") is False
 
 
 class TestSemanticAnalyzer:
@@ -236,6 +302,166 @@ class TestSemanticAnalyzer:
             assert "context" in entity
             assert "related_entities" in entity
 
+    def test_extract_entities_filters_punctuation_only(self):
+        """Test that entity extraction filters out punctuation-only entities."""
+        # Create custom mock_nlp with MISC label support
+        mock_nlp = Mock()
+
+        # Mock vocab.strings to support subscripting like a dict
+        vocab_strings_dict = {
+            "ORG": "Organization",
+            "PERSON": "Person",
+            "MISC": "Miscellaneous",
+        }
+        mock_vocab_strings = MagicMock()
+        mock_vocab_strings.__getitem__.side_effect = lambda key: vocab_strings_dict.get(
+            key, "Unknown"
+        )
+        mock_nlp.vocab.strings = mock_vocab_strings
+        mock_nlp.vocab.vectors_length = 0
+
+        with patch("spacy.load", return_value=mock_nlp):
+            # Create mock document with both meaningful and punctuation-only entities
+            mock_doc = MagicMock()
+
+            # Mock doc slicing for context extraction
+            mock_context = Mock()
+            mock_context.text = "Apple is a company"
+            mock_doc.__getitem__.return_value = mock_context
+
+            # Mock entity 1: meaningful (Apple)
+            entity1 = Mock()
+            entity1.text = "Apple"
+            entity1.label_ = "ORG"
+            entity1.start_char = 0
+            entity1.end_char = 5
+            entity1.sent = Mock()
+            entity1.sent.start = 0
+            entity1.sent.end = 10
+            sent_token1 = Mock()
+            sent_token1.text = "Apple"
+            sent_token1.ent_type_ = "ORG"
+            sent_token1.dep_ = "nsubj"
+            entity1.sent.__iter__ = Mock(return_value=iter([sent_token1]))
+
+            # Mock entity 2: punctuation only (should be filtered)
+            entity2 = Mock()
+            entity2.text = "#"
+            entity2.label_ = "MISC"
+            entity2.start_char = 6
+            entity2.end_char = 7
+            entity2.sent = Mock()
+            entity2.sent.start = 0
+            entity2.sent.end = 10
+            entity2.sent.__iter__ = Mock(return_value=iter([]))
+
+            # Mock entity 3: pipe character (should be filtered)
+            entity3 = Mock()
+            entity3.text = "|"
+            entity3.label_ = "MISC"
+            entity3.start_char = 8
+            entity3.end_char = 9
+            entity3.sent = Mock()
+            entity3.sent.start = 0
+            entity3.sent.end = 10
+            entity3.sent.__iter__ = Mock(return_value=iter([]))
+
+            # Mock entity 4: dots only (should be filtered)
+            entity4 = Mock()
+            entity4.text = "..."
+            entity4.label_ = "MISC"
+            entity4.start_char = 10
+            entity4.end_char = 13
+            entity4.sent = Mock()
+            entity4.sent.start = 0
+            entity4.sent.end = 13
+            entity4.sent.__iter__ = Mock(return_value=iter([]))
+
+            mock_doc.ents = [entity1, entity2, entity3, entity4]
+
+            analyzer = SemanticAnalyzer()
+            entities = analyzer._extract_entities(mock_doc)
+
+            # Should only return Apple, filter out #, |, ...
+            assert len(entities) == 1
+            assert entities[0]["text"] == "Apple"
+
+            # Verify no punctuation-only entities
+            entity_texts = [e["text"] for e in entities]
+            assert "#" not in entity_texts
+            assert "|" not in entity_texts
+            assert "..." not in entity_texts
+
+    def test_extract_entities_filters_related_entities(self):
+        """Test that related entities are also filtered for meaningfulness."""
+        # Create custom mock_nlp with MISC label support
+        mock_nlp = Mock()
+
+        # Mock vocab.strings to support subscripting like a dict
+        vocab_strings_dict = {
+            "ORG": "Organization",
+            "PERSON": "Person",
+            "MISC": "Miscellaneous",
+        }
+        mock_vocab_strings = MagicMock()
+        mock_vocab_strings.__getitem__.side_effect = lambda key: vocab_strings_dict.get(
+            key, "Unknown"
+        )
+        mock_nlp.vocab.strings = mock_vocab_strings
+        mock_nlp.vocab.vectors_length = 0
+
+        with patch("spacy.load", return_value=mock_nlp):
+            mock_doc = MagicMock()
+
+            # Mock doc slicing for context extraction
+            mock_context = Mock()
+            mock_context.text = "Apple Inc Company"
+            mock_doc.__getitem__.return_value = mock_context
+
+            # Create entity with mixed related entities
+            entity = Mock()
+            entity.text = "Apple"
+            entity.label_ = "ORG"
+            entity.start_char = 0
+            entity.end_char = 5
+            entity.sent = Mock()
+            entity.sent.start = 0
+            entity.sent.end = 10
+
+            # Related tokens: meaningful and garbage
+            related_token1 = Mock()
+            related_token1.text = "Inc"
+            related_token1.ent_type_ = "ORG"
+            related_token1.dep_ = "compound"
+
+            related_token2 = Mock()
+            related_token2.text = "#"
+            related_token2.ent_type_ = "MISC"
+            related_token2.dep_ = "dep"
+
+            related_token3 = Mock()
+            related_token3.text = "Company"
+            related_token3.ent_type_ = "ORG"
+            related_token3.dep_ = "appos"
+
+            entity.sent.__iter__ = Mock(
+                return_value=iter([related_token1, related_token2, related_token3])
+            )
+            mock_doc.ents = [entity]
+
+            analyzer = SemanticAnalyzer()
+            entities = analyzer._extract_entities(mock_doc)
+
+            assert len(entities) == 1
+            related = entities[0]["related_entities"]
+
+            # Should have 2 related entities (Inc, Company), not #
+            assert len(related) == 2
+            related_texts = [r["text"] for r in related]
+            assert "Inc" in related_texts
+            assert "Company" in related_texts
+            assert "#" not in related_texts
+
     def test_get_pos_tags(self, mock_nlp, mock_doc):
         """Test POS tag extraction."""
         with patch("spacy.load", return_value=mock_nlp):
@@ -251,14 +477,73 @@ class TestSemanticAnalyzer:
             assert tag1["tag"] == "NNP"
             assert tag1["lemma"] == "apple"
             assert tag1["is_stop"] is False
-            assert tag1["is_punct"] is False
-            assert tag1["is_space"] is False
+            # Note: is_punct and is_space are no longer in output (filtered)
 
             # Check second token (is)
             tag2 = pos_tags[1]
             assert tag2["text"] == "is"
             assert tag2["pos"] == "VERB"
             assert tag2["is_stop"] is True
+
+    def test_get_pos_tags_filters_punctuation_and_spaces(self, mock_nlp):
+        """Test that POS tagging filters out punctuation and space tokens."""
+        with patch("spacy.load", return_value=mock_nlp):
+            # Create mock document with tokens including spaces and punctuation
+            mock_doc = Mock()
+
+            # Mock tokens: word, space, punctuation, word
+            token1 = Mock()
+            token1.text = "Hello"
+            token1.pos_ = "NOUN"
+            token1.tag_ = "NN"
+            token1.lemma_ = "hello"
+            token1.is_stop = False
+            token1.is_punct = False
+            token1.is_space = False
+
+            token2 = Mock()
+            token2.text = " "
+            token2.pos_ = "SPACE"
+            token2.tag_ = "_SP"
+            token2.lemma_ = " "
+            token2.is_stop = False
+            token2.is_punct = False
+            token2.is_space = True  # Should be filtered
+
+            token3 = Mock()
+            token3.text = ","
+            token3.pos_ = "PUNCT"
+            token3.tag_ = ","
+            token3.lemma_ = ","
+            token3.is_stop = False
+            token3.is_punct = True  # Should be filtered
+            token3.is_space = False
+
+            token4 = Mock()
+            token4.text = "world"
+            token4.pos_ = "NOUN"
+            token4.tag_ = "NN"
+            token4.lemma_ = "world"
+            token4.is_stop = False
+            token4.is_punct = False
+            token4.is_space = False
+
+            mock_doc.__iter__ = Mock(
+                return_value=iter([token1, token2, token3, token4])
+            )
+
+            analyzer = SemanticAnalyzer()
+            pos_tags = analyzer._get_pos_tags(mock_doc)
+
+            # Should only have 2 tokens (Hello and world), spaces/punct filtered
+            assert len(pos_tags) == 2
+            assert pos_tags[0]["text"] == "Hello"
+            assert pos_tags[1]["text"] == "world"
+
+            # Verify no punctuation or spaces in output
+            for tag in pos_tags:
+                assert not tag["text"].isspace()
+                assert tag["text"] not in [",", ".", "|", ";", ":", "!"]
 
     def test_get_dependencies(self, mock_nlp, mock_doc):
         """Test dependency parsing."""


### PR DESCRIPTION
# Pull Request

## Summary

This PR create a helper function: is_meaningful_text() to removes garbage entities (|, #, ..., ---), enhance nlp for metadata:
- Related entities filtering: Also filters related entities in entity context
- POS tag filtering: Two-layer approach (spaCy flags + meaningful text check)
- Edge case handling: Catches symbol combinations spaCy might miss

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages: No
- [ ] Have you updated or added pages under `docs/`?
- [x] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced semantic text analysis to filter out punctuation and non-alphanumeric noise from entity extraction and part-of-speech tagging, improving data quality and accuracy.

* **Style**
  * Minor code formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->