### PR TITLE
fix(ci): skip secrets and integration tests for fork/Dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,11 +120,16 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-loader-${{ hashFiles('packages/qdrant-loader-core/pyproject.toml', 'packages/qdrant-loader/pyproject.toml', 'pyproject.toml') }}
 
+      # Skip secret injection for fork PRs and Dependabot — unit tests use mocks (no secrets needed).
       - name: Create .env.test file for loader
+        if: >-
+          github.event_name == 'push' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]')
         run: |
           cd packages/qdrant-loader
           cp tests/.env.test.template tests/.env.test
-          
+
           # Check if required secrets are set
           if [ -z "${{ secrets.QDRANT_URL }}" ]; then
             echo "Error: QDRANT_URL secret is not set"
@@ -142,14 +147,14 @@ jobs:
             echo "Error: OPENAI_API_KEY secret is not set"
             exit 1
           fi
-          
+
           # Replace environment variables with proper escaping
           sed -i "s|QDRANT_URL=.*|QDRANT_URL=${{ secrets.QDRANT_URL }}|g" tests/.env.test
           sed -i "s|QDRANT_API_KEY=.*|QDRANT_API_KEY=${{ secrets.QDRANT_API_KEY }}|g" tests/.env.test
           sed -i "s|QDRANT_COLLECTION_NAME=.*|QDRANT_COLLECTION_NAME=${{ secrets.QDRANT_COLLECTION_NAME }}|g" tests/.env.test
           sed -i "s|OPENAI_API_KEY=.*|OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}|g" tests/.env.test
           sed -i "s|STATE_DB_PATH=.*|STATE_DB_PATH=:memory:|g" tests/.env.test
-          
+
           # Optional secrets - only replace if they exist
           if [ -n "${{ secrets.REPO_TOKEN }}" ]; then
             sed -i "s|REPO_TOKEN=.*|REPO_TOKEN=${{ secrets.REPO_TOKEN }}|g" tests/.env.test
@@ -181,21 +186,25 @@ jobs:
           if [ -n "${{ secrets.JIRA_PROJECT_KEY }}" ]; then
             sed -i "s|JIRA_PROJECT_KEY=.*|JIRA_PROJECT_KEY=${{ secrets.JIRA_PROJECT_KEY }}|g" tests/.env.test
           fi
-          
+
           echo "Created .env.test file successfully"
           echo "Contents (with secrets masked):"
           sed 's/=.*/=***/' tests/.env.test
 
       - name: Create config.test.yaml file for loader
+        if: >-
+          github.event_name == 'push' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]')
         run: |
           cd packages/qdrant-loader
           cp tests/config.test.template.yaml tests/config.test.yaml
-          
+
           # Replace environment variables in YAML config
           sed -i "s|\${QDRANT_URL}|${{ secrets.QDRANT_URL }}|g" tests/config.test.yaml
           sed -i "s|\${QDRANT_API_KEY}|${{ secrets.QDRANT_API_KEY }}|g" tests/config.test.yaml
           sed -i "s|\${QDRANT_COLLECTION_NAME}|${{ secrets.QDRANT_COLLECTION_NAME }}|g" tests/config.test.yaml
-          
+
           # Optional environment variables - only replace if they exist
           if [ -n "${{ secrets.REPO_TOKEN }}" ]; then
             sed -i "s|\${REPO_TOKEN}|${{ secrets.REPO_TOKEN }}|g" tests/config.test.yaml
@@ -227,7 +236,7 @@ jobs:
           if [ -n "${{ secrets.JIRA_PROJECT_KEY }}" ]; then
             sed -i "s|\${JIRA_PROJECT_KEY}|${{ secrets.JIRA_PROJECT_KEY }}|g" tests/config.test.yaml
           fi
-          
+
           echo "Created config.test.yaml file successfully"
           echo "YAML config structure:"
           head -20 tests/config.test.yaml
@@ -240,6 +249,8 @@ jobs:
       - name: Run loader integration tests
         if: |
           (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.actor != 'dependabot[bot]' &&
           (github.event.pull_request.base.ref == 'develop' ||
             github.event.pull_request.base.ref == 'main')) ||
           (github.event_name == 'push' &&
@@ -306,11 +317,16 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-mcp-${{ hashFiles('packages/qdrant-loader-core/pyproject.toml', 'packages/qdrant-loader/pyproject.toml', 'packages/qdrant-loader-mcp-server/pyproject.toml', 'pyproject.toml') }}
 
+      # Skip secret injection for fork PRs and Dependabot — unit tests use mocks (no secrets needed).
       - name: Create .env.test file for MCP server
+        if: >-
+          github.event_name == 'push' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]')
         run: |
           cd packages/qdrant-loader-mcp-server
           cp tests/.env.test.template tests/.env.test
-          
+
           # Check if required secrets are set
           if [ -z "${{ secrets.QDRANT_URL }}" ]; then
             echo "Error: QDRANT_URL secret is not set"
@@ -328,13 +344,13 @@ jobs:
             echo "Error: OPENAI_API_KEY secret is not set"
             exit 1
           fi
-          
+
           # Replace environment variables with secrets for integration tests
           sed -i "s|QDRANT_URL=.*|QDRANT_URL=${{ secrets.QDRANT_URL }}|g" tests/.env.test
           sed -i "s|QDRANT_API_KEY=.*|QDRANT_API_KEY=${{ secrets.QDRANT_API_KEY }}|g" tests/.env.test
           sed -i "s|QDRANT_COLLECTION_NAME=.*|QDRANT_COLLECTION_NAME=${{ secrets.QDRANT_COLLECTION_NAME }}|g" tests/.env.test
           sed -i "s|OPENAI_API_KEY=.*|OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}|g" tests/.env.test
-          
+
           echo "Created .env.test file for MCP server successfully"
           echo "Contents (with secrets masked):"
           sed 's/=.*/=***/' tests/.env.test
@@ -347,6 +363,8 @@ jobs:
       - name: Run MCP server integration tests
         if: |
           (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.actor != 'dependabot[bot]' &&
           (github.event.pull_request.base.ref == 'develop' ||
             github.event.pull_request.base.ref == 'main')) ||
           (github.event_name == 'push' &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,12 +120,17 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-loader-${{ hashFiles('packages/qdrant-loader-core/pyproject.toml', 'packages/qdrant-loader/pyproject.toml', 'pyproject.toml') }}
 
-      # Skip secret injection for fork PRs and Dependabot — unit tests use mocks (no secrets needed).
+      # Skip secret injection for fork PRs, Dependabot, and non-protected branches —
+      # secrets are only needed when integration tests run (develop/main).
       - name: Create .env.test file for loader
-        if: >-
-          github.event_name == 'push' ||
-          (github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]')
+        if: |
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.actor != 'dependabot[bot]' &&
+            (github.event.pull_request.base.ref == 'develop' ||
+              github.event.pull_request.base.ref == 'main')) ||
+          (github.event_name == 'push' &&
+            (github.ref_name == 'develop' || github.ref_name == 'main'))
         run: |
           cd packages/qdrant-loader
           cp tests/.env.test.template tests/.env.test
@@ -192,10 +197,14 @@ jobs:
           sed 's/=.*/=***/' tests/.env.test
 
       - name: Create config.test.yaml file for loader
-        if: >-
-          github.event_name == 'push' ||
-          (github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]')
+        if: |
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.actor != 'dependabot[bot]' &&
+            (github.event.pull_request.base.ref == 'develop' ||
+              github.event.pull_request.base.ref == 'main')) ||
+          (github.event_name == 'push' &&
+            (github.ref_name == 'develop' || github.ref_name == 'main'))
         run: |
           cd packages/qdrant-loader
           cp tests/config.test.template.yaml tests/config.test.yaml
@@ -317,12 +326,17 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-mcp-${{ hashFiles('packages/qdrant-loader-core/pyproject.toml', 'packages/qdrant-loader/pyproject.toml', 'packages/qdrant-loader-mcp-server/pyproject.toml', 'pyproject.toml') }}
 
-      # Skip secret injection for fork PRs and Dependabot — unit tests use mocks (no secrets needed).
+      # Skip secret injection for fork PRs, Dependabot, and non-protected branches —
+      # secrets are only needed when integration tests run (develop/main).
       - name: Create .env.test file for MCP server
-        if: >-
-          github.event_name == 'push' ||
-          (github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]')
+        if: |
+          (github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.actor != 'dependabot[bot]' &&
+            (github.event.pull_request.base.ref == 'develop' ||
+              github.event.pull_request.base.ref == 'main')) ||
+          (github.event_name == 'push' &&
+            (github.ref_name == 'develop' || github.ref_name == 'main'))
         run: |
           cd packages/qdrant-loader-mcp-server
           cp tests/.env.test.template tests/.env.test


### PR DESCRIPTION
# Pull Request

## Summary

Guard secret-requiring CI steps with `head.repo.full_name` and `github.actor` checks so Dependabot and fork PRs run unit tests only (which use mocks). Fixes CI failures on 6 Dependabot PRs (#168-#173) caused by missing secrets.

**Pattern:** Job-level `if` conditions (same approach as Anthropic's claude-agent-sdk). Validated against 8 mainstream repos — industry standard.

**Changes to `.github/workflows/test.yml`:**
- `Create .env.test` steps: skip for forks/Dependabot (3 steps)
- `Create config.test.yaml` step: skip for forks/Dependabot
- `Run integration tests` steps: add fork/Dependabot guard to existing conditions (2 steps)
- Unit test steps: unchanged (always run for all PRs)

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker?
- [ ] Did you avoid banned placeholders?

Ref: AIKH-1421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced CI/CD workflow security by preventing sensitive operations (environment file and config file creation) from executing on fork pull requests and Dependabot-initiated runs, reducing the risk of secret exposure in untrusted contexts.
* Tightened execution conditions for integration tests to validate these restrictions are consistently applied across testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->