### PR TITLE
Implement expand_chunk_context mcp tool

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/handler.py
@@ -210,6 +210,10 @@ class MCPHandler:
                     return await self.intelligence_handler.handle_expand_cluster(
                         request_id, params.get("arguments", {})
                     )
+                elif tool_name == "expand_chunk_context":
+                    return await self.search_handler.handle_expand_chunk_context(
+                        request_id, params.get("arguments", {})
+                    )
                 else:
                     logger.warning("Unknown tool requested", tool_name=tool_name)
                     return self.protocol.create_response(

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/__init__.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/__init__.py
@@ -4,6 +4,7 @@ from .analyze_relationships import get_analyze_relationships_tool_schema
 from .attachment import get_attachment_search_tool_schema
 from .cluster_documents import get_cluster_documents_tool_schema
 from .detect_conflicts import get_detect_conflicts_tool_schema
+from .expand_chunk_context import get_expand_chunk_context_tool_schema
 from .expand_cluster import get_expand_cluster_tool_schema
 from .expand_document import get_expand_document_tool_schema
 from .find_complementary import get_find_complementary_tool_schema
@@ -30,6 +31,7 @@ def get_all_tool_schemas() -> list[dict[str, Any]]:
         get_cluster_documents_tool_schema(),
         get_expand_document_tool_schema(),
         get_expand_cluster_tool_schema(),
+        get_expand_chunk_context_tool_schema(),
     ]
 
 
@@ -50,6 +52,9 @@ class MCPSchemas:
     get_cluster_documents_tool_schema = staticmethod(get_cluster_documents_tool_schema)
     get_expand_document_tool_schema = staticmethod(get_expand_document_tool_schema)
     get_expand_cluster_tool_schema = staticmethod(get_expand_cluster_tool_schema)
+    get_expand_chunk_context_tool_schema = staticmethod(
+        get_expand_chunk_context_tool_schema
+    )
 
     @classmethod
     def get_all_tool_schemas(cls) -> list[dict[str, Any]]:
@@ -67,6 +72,7 @@ __all__ = [
     "get_cluster_documents_tool_schema",
     "get_expand_document_tool_schema",
     "get_expand_cluster_tool_schema",
+    "get_expand_chunk_context_tool_schema",
     "get_all_tool_schemas",
     "MCPSchemas",
 ]

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/expand_chunk_context.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/expand_chunk_context.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+
+def get_expand_chunk_context_tool_schema() -> dict[str, Any]:
+    """Get expand chunk context tool schema"""
+    return {
+        "name": "expand_chunk_context",
+        "description": "Retrieve neighboring chunks within the same document based on a given chunk_index. This helps expand context around a specific chunk.",
+        "annotations": {"read-only": True},
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "document_id": {
+                    "type": "string",
+                    "description": "Unique identifier of the document.",
+                },
+                "chunk_index": {
+                    "type": "integer",
+                    "description": "Index of the target chunk within the document.",
+                },
+                "window_size": {
+                    "type": "integer",
+                    "description": "Number of chunks to include before and after the target chunk.",
+                    "default": 2,
+                    "minimum": 0,
+                },
+            },
+            "required": ["document_id", "chunk_index"],
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "structured_results": {
+                    "type": "object",
+                    "properties": {
+                        "context_chunks": {
+                            "type": "object",
+                            "properties": {
+                                "pre": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                    "description": "Chunks before the target chunk.",
+                                },
+                                "target": {
+                                    "type": ["object", "null"],
+                                    "description": "The target chunk.",
+                                },
+                                "post": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                    "description": "Chunks after the target chunk.",
+                                },
+                            },
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "properties": {
+                                "document_id": {"type": "string"},
+                                "chunk_index": {"type": "integer"},
+                                "window_size": {"type": "integer"},
+                                "context_range": {
+                                    "type": "object",
+                                    "properties": {
+                                        "start": {"type": "integer"},
+                                        "end": {"type": "integer"},
+                                    },
+                                },
+                                "total_chunks": {"type": "integer"},
+                            },
+                        },
+                    },
+                }
+            },
+        },
+    }

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -588,3 +588,206 @@ class SearchHandler:
                     "data": str(e),
                 },
             )
+
+    async def handle_expand_chunk_context(
+        self, request_id: str | int | None, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Return neighboring chunks within the same document based on chunk_index.
+
+        Required params:
+            document_id (str): The document identifier.
+            chunk_index (int): The target chunk index to expand around.
+
+        Optional params:
+            window_size (int): Number of chunks before/after target (default=2).
+        """
+        logger.debug("Handling expand_chunk_context", params=params)
+        # =========================
+        # Validate params
+        # =========================
+        if (
+            "document_id" not in params
+            or params["document_id"] is None
+            or params["document_id"] == ""
+        ):
+            logger.error("Missing required parameter: document_id")
+            return self.protocol.create_response(
+                request_id,
+                error={
+                    "code": -32602,
+                    "message": "Invalid params",
+                    "data": "Missing required parameter: document_id",
+                },
+            )
+        if (
+            "chunk_index" not in params
+            or params["chunk_index"] is None
+            or params["chunk_index"] == ""
+        ):
+            logger.error("Missing required parameter: chunk_index")
+            return self.protocol.create_response(
+                request_id,
+                error={
+                    "code": -32602,
+                    "message": "Invalid params",
+                    "data": "Missing required parameter: chunk_index",
+                },
+            )
+
+        document_id = params["document_id"]
+        try:
+            chunk_index = int(params["chunk_index"])
+        except (ValueError, TypeError):
+            return self.protocol.create_response(
+                request_id,
+                error={
+                    "code": -32602,
+                    "message": "Invalid params",
+                    "data": "chunk_index must be a valid integer",
+                },
+            )
+        window_size = params.get("window_size", 2)
+
+        if not isinstance(window_size, int) or window_size < 0:
+            return self.protocol.create_response(
+                request_id,
+                error={
+                    "code": -32602,
+                    "message": "Invalid params",
+                    "data": "window_size must be non-negative integer",
+                },
+            )
+
+        # =========================
+        # Calculate chunk window
+        # =========================
+        start_chunk = max(chunk_index - window_size, 0)
+        end_chunk = chunk_index + window_size
+
+        logger.info(
+            f"Expanding document {document_id} "
+            f"around chunk {chunk_index} "
+            f"(window={window_size}, range={start_chunk}-{end_chunk})"
+        )
+
+        # =========================
+        # Metadata filter retrieval
+        # =========================
+
+        query_filter = models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="document_id",
+                    match=models.MatchValue(value=document_id),
+                ),
+                models.FieldCondition(
+                    key="metadata.chunk_index",
+                    range=models.Range(
+                        gte=start_chunk,
+                        lte=end_chunk,
+                    ),
+                ),
+            ]
+        )
+
+        # =========================
+        # Scroll all matching chunks
+        # =========================
+        all_points = []
+        next_offset = None
+        collection_name = self.search_engine.config.collection_name
+        try:
+            async with self.search_engine._search_semaphore:
+                while True:
+                    points, next_offset = await self.search_engine.client.scroll(
+                        collection_name=collection_name,
+                        scroll_filter=query_filter,
+                        offset=next_offset,
+                        limit=100,
+                        with_payload=True,
+                        with_vectors=False,
+                    )
+                    all_points.extend(points)
+                    if next_offset is None:
+                        break
+        except Exception as e:
+            logger.error("Error expanding chunk context", exc_info=True)
+            return self.protocol.create_response(
+                request_id,
+                error={
+                    "code": -32603,
+                    "message": "Internal error",
+                    "data": str(e),
+                },
+            )
+
+        # =========================
+        # Sort by chunk_index
+        # =========================
+        chunks = sorted(
+            [p.payload for p in all_points],
+            key=lambda x: x.get("metadata", {}).get("chunk_index", 0),
+        )
+
+        # =========================
+        # Build context sections
+        # =========================
+
+        pre_chunks = []
+        post_chunks = []
+        target_chunk = None
+
+        for chunk in chunks:
+            idx = chunk.get("metadata", {}).get("chunk_index")
+            if idx is None:
+                continue  # Skip chunks without chunk_index
+
+            if idx < chunk_index:
+                pre_chunks.append(chunk)
+
+            elif idx == chunk_index:
+                target_chunk = chunk
+
+            else:
+                post_chunks.append(chunk)
+
+        # =========================
+        # Build structured output
+        # =========================
+
+        structured_results = {
+            "context_chunks": {
+                "pre": pre_chunks,
+                "target": target_chunk,
+                "post": post_chunks,
+            },
+            "metadata": {
+                "document_id": document_id,
+                "chunk_index": chunk_index,
+                "window_size": window_size,
+                "context_range": {
+                    "start": start_chunk,
+                    "end": end_chunk,
+                },
+                "total_chunks": len(chunks),
+            },
+        }
+
+        # =========================
+        # Return response
+        # =========================
+        return self.protocol.create_response(
+            request_id,
+            result={
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Retrieved context for chunk {chunk_index} in document {document_id} "
+                        f"({len(pre_chunks)} pre, {1 if target_chunk else 0} target, {len(post_chunks)} post)",
+                    }
+                ],
+                "structuredContent": structured_results,
+                "isError": False,
+            },
+        )

--- a/packages/qdrant-loader-mcp-server/tests/integration/test_mcp_integration.py
+++ b/packages/qdrant-loader-mcp-server/tests/integration/test_mcp_integration.py
@@ -178,7 +178,7 @@ async def test_initialize_and_tools_list_workflow(integration_handler):
     # Check that we have the expected tools available
     assert "result" in tools_response
     assert "tools" in tools_response["result"]
-    assert len(tools_response["result"]["tools"]) == 10
+    assert len(tools_response["result"]["tools"]) == 11
 
 
 @pytest.mark.asyncio

--- a/packages/qdrant-loader-mcp-server/tests/integration/test_search_handler_integration.py
+++ b/packages/qdrant-loader-mcp-server/tests/integration/test_search_handler_integration.py
@@ -579,6 +579,122 @@ class TestExpandDocumentIntegration:
         assert "nonexistent-doc" in result["error"]["data"]
 
 
+class TestExpandChunkContextIntegration:
+    """Integration tests for chunk context expansion functionality."""
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_success(self, integration_search_handler):
+        """Should return correct context chunks around target chunk."""
+
+        params = {
+            "document_id": "doc-123",
+            "chunk_index": 2,
+            "window_size": 1,
+        }
+
+        # Mock Qdrant points
+        def make_point(idx, content):
+            p = Mock()
+            p.payload = {"content": content, "metadata": {"chunk_index": idx}}
+            return p
+
+        points = [
+            make_point(1, "chunk 1"),
+            make_point(2, "chunk 2"),
+            make_point(3, "chunk 3"),
+        ]
+
+        integration_search_handler.search_engine.client.scroll = AsyncMock(
+            return_value=(points, None)
+        )
+
+        result = await integration_search_handler.handle_expand_chunk_context(
+            request_id=1,
+            params=params,
+        )
+
+        assert "result" in result
+        data = result["result"]
+
+        assert "structuredContent" in data
+        structured = data["structuredContent"]
+
+        assert structured["context_chunks"]["target"]["metadata"]["chunk_index"] == 2
+        assert len(structured["context_chunks"]["pre"]) == 1
+        assert len(structured["context_chunks"]["post"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_missing_document_id(
+        self, integration_search_handler
+    ):
+        """Should return error when document_id is missing."""
+
+        params = {
+            "chunk_index": 2,
+        }
+
+        result = await integration_search_handler.handle_expand_chunk_context(
+            request_id=1,
+            params=params,
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == -32602
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_invalid_window_size(
+        self, integration_search_handler
+    ):
+        """Should return error when window_size is invalid."""
+
+        params = {
+            "document_id": "doc-123",
+            "chunk_index": 2,
+            "window_size": -1,
+        }
+
+        result = await integration_search_handler.handle_expand_chunk_context(
+            request_id=1,
+            params=params,
+        )
+
+        assert "error" in result
+        assert result["error"]["code"] == -32602
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_only_target_chunk(
+        self, integration_search_handler
+    ):
+        """Should handle case where only target chunk exists."""
+
+        params = {
+            "document_id": "doc-123",
+            "chunk_index": 2,
+            "window_size": 1,
+        }
+
+        p = Mock()
+        p.payload = {"content": "only chunk", "metadata": {"chunk_index": 2}}
+
+        integration_search_handler.search_engine.client.scroll = AsyncMock(
+            return_value=([p], None)
+        )
+
+        result = await integration_search_handler.handle_expand_chunk_context(
+            request_id=1,
+            params=params,
+        )
+
+        data = result["result"]
+
+        assert data["structuredContent"]["context_chunks"]["pre"] == []
+        assert data["structuredContent"]["context_chunks"]["post"] == []
+        assert (
+            data["structuredContent"]["context_chunks"]["target"]["content"]
+            == "only chunk"
+        )
+
+
 class TestRealWorldScenarios:
     """Integration tests simulating real-world usage scenarios."""
 
@@ -733,6 +849,49 @@ class TestRealWorldScenarios:
         )
 
         assert result3["result"]["isError"] is False
+
+        point1 = Mock()
+        point1.payload = {
+            "document_id": "confluence-doc-456",
+            "content": "Step 1: Check credentials",
+            "metadata": {"chunk_index": 4},
+        }
+
+        point2 = Mock()
+        point2.payload = {
+            "document_id": "confluence-doc-456",
+            "content": "Step 2: Reset password",
+            "metadata": {"chunk_index": 5},
+        }
+
+        point3 = Mock()
+        point3.payload = {
+            "document_id": "confluence-doc-456",
+            "content": "Step 3: Contact support",
+            "metadata": {"chunk_index": 6},
+        }
+
+        integration_search_handler.search_engine.client.scroll = AsyncMock(
+            return_value=([point1, point2, point3], None)
+        )
+
+        params_expand = {
+            "document_id": "confluence-doc-456",
+            "chunk_index": 5,
+            "window_size": 1,
+        }
+
+        result_expand = await integration_search_handler.handle_expand_chunk_context(
+            "support-2b", params_expand
+        )
+
+        assert result_expand["error"] is None
+        assert (
+            result_expand["result"]["structuredContent"]["context_chunks"]["target"][
+                "metadata"
+            ]["chunk_index"]
+            == 5
+        )
 
 
 class TestPerformanceScenarios:

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_mcp_handler.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_mcp_handler.py
@@ -17,7 +17,7 @@ async def test_handle_tools_list(mcp_handler):
     assert response["id"] == 1
     assert "result" in response
     assert "tools" in response["result"]
-    assert len(response["result"]["tools"]) == 10
+    assert len(response["result"]["tools"]) == 11
 
     tool = response["result"]["tools"][0]
     assert tool["name"] == "search"
@@ -315,8 +315,7 @@ async def test_tools_list_contains_all_three_tools(mcp_handler):
     assert "tools" in response["result"]
 
     tools = response["result"]["tools"]
-    assert len(tools) == 10
-
+    assert len(tools) == 11
     tool_names = [tool["name"] for tool in tools]
     assert "search" in tool_names
     assert "hierarchy_search" in tool_names

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_mcp_protocol.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_mcp_protocol.py
@@ -120,7 +120,7 @@ async def test_handle_list_tools(mcp_handler):
     assert response["id"] == 1
     assert "result" in response
     assert "tools" in response["result"]
-    assert len(response["result"]["tools"]) == 10
+    assert len(response["result"]["tools"]) == 11
     tool = response["result"]["tools"][0]
     assert tool["name"] == "search"
     assert "description" in tool

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_monolith_schemas.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_monolith_schemas.py
@@ -14,6 +14,7 @@ def test_monolithic_mcp_schemas_static_methods():
         MCPSchemas.get_cluster_documents_tool_schema(),
         MCPSchemas.get_expand_document_tool_schema(),
         MCPSchemas.get_expand_cluster_tool_schema(),
+        MCPSchemas.get_expand_chunk_context_tool_schema(),
     ]
 
     for s in schemas:

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_protocol_2025_06_18.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_protocol_2025_06_18.py
@@ -356,7 +356,7 @@ class TestToolCapabilities:
         tools_response = await mcp_handler.handle_request(tools_list_request)
         tools_count = len(tools_response["result"]["tools"])
 
-        # Should have exactly 10 tools (3 search + 5 analysis + 2 lazy loading)
+        # Should have exactly 11 tools (3 search + 5 analysis + 3 lazy loading)
         expected_tools = [
             "search",
             "hierarchy_search",
@@ -368,6 +368,7 @@ class TestToolCapabilities:
             "cluster_documents",
             "expand_document",
             "expand_cluster",
+            "expand_chunk_context",
         ]
 
         assert tools_count == len(expected_tools)

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
@@ -714,7 +714,7 @@ class TestHandleExpandChunkContext:
         assert "window_size" in result["error"]["data"]
 
     @pytest.mark.asyncio
-    async def expand_chunk_context_sorted_correctly(self, search_handler):
+    async def test_expand_chunk_context_sorted_correctly(self, search_handler):
         """Should sort chunks by metadata.chunk_index."""
 
         params = {

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
@@ -587,6 +587,178 @@ class TestHandleExpandDocument:
         assert content["chunks"][1]["chunk_index"] == 1
 
 
+class TestHandleExpandChunkContext:
+    """Test chunk context expansion functionality."""
+
+    def _mock_protocol(self, search_handler):
+        search_handler.protocol.create_response = Mock(
+            side_effect=lambda request_id, result=None, error=None: {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": result,
+                "error": error,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_success(self, search_handler):
+        """Should return correct pre, target, post chunks"""
+
+        params = {
+            "document_id": "doc1",
+            "chunk_index": 1,
+            "window_size": 1,
+        }
+
+        # mock chunk
+        chunk0 = Mock()
+        chunk0.payload = {
+            "content": "chunk 0",
+            "metadata": {"chunk_index": 0},
+        }
+
+        chunk1 = Mock()
+        chunk1.payload = {
+            "content": "chunk 1",
+            "metadata": {"chunk_index": 1},
+        }
+        chunk2 = Mock()
+        chunk2.payload = {
+            "content": "chunk 2",
+            "metadata": {"chunk_index": 2},
+        }
+
+        search_handler.search_engine.client.scroll = AsyncMock(
+            return_value=([chunk0, chunk1, chunk2], None)
+        )
+
+        self._mock_protocol(search_handler)
+
+        result = await search_handler.handle_expand_chunk_context(1, params)
+
+        data = result["result"]
+        structured = data["structuredContent"]
+
+        assert structured["metadata"]["document_id"] == "doc1"
+        assert structured["metadata"]["chunk_index"] == 1
+        assert structured["metadata"]["total_chunks"] == 3
+
+        assert len(structured["context_chunks"]["pre"]) == 1
+        assert structured["context_chunks"]["target"]["content"] == "chunk 1"
+        assert len(structured["context_chunks"]["post"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_multiple_scroll_pages(self, search_handler):
+        """Should collect chunks across multiple scroll pages."""
+
+        params = {"document_id": "doc1", "chunk_index": 1}
+
+        chunk0 = Mock()
+        chunk0.payload = {"content": "chunk 0", "metadata": {"chunk_index": 0}}
+
+        chunk1 = Mock()
+        chunk1.payload = {"content": "chunk 1", "metadata": {"chunk_index": 1}}
+
+        calls = [
+            ([chunk0], "next"),
+            ([chunk1], None),
+        ]
+
+        async def scroll_mock(*args, **kwargs):
+            return calls.pop(0)
+
+        search_handler.search_engine.client.scroll = AsyncMock(side_effect=scroll_mock)
+
+        self._mock_protocol(search_handler)
+        result = await search_handler.handle_expand_chunk_context(1, params)
+        structured = result["result"]["structuredContent"]
+        assert structured["metadata"]["total_chunks"] == 2
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_missing_document_id(self, search_handler):
+        """Should return error id document_id is missing."""
+
+        self._mock_protocol(search_handler)
+        result = await search_handler.handle_expand_chunk_context(1, {"chunk_index": 1})
+        assert result["error"]["code"] == -32602
+        assert "document_id" in result["error"]["data"]
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_missing_chunk_index(self, search_handler):
+        """Should return error if chunk_index is missing."""
+
+        self._mock_protocol(search_handler)
+
+        result = await search_handler.handle_expand_chunk_context(
+            1, {"document_id": "doc1"}
+        )
+
+        assert result["error"]["code"] == -32602
+        assert "chunk_index" in result["error"]["data"]
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_invalid_window_size(self, search_handler):
+        """Should validate window_size"""
+
+        params = {
+            "document_id": "doc1",
+            "chunk_index": 1,
+            "window_size": -1,
+        }
+
+        self._mock_protocol(search_handler)
+
+        result = await search_handler.handle_expand_chunk_context(1, params)
+
+        assert result["error"]["code"] == -32602
+        assert "window_size" in result["error"]["data"]
+
+    @pytest.mark.asyncio
+    async def expand_chunk_context_sorted_correctly(self, search_handler):
+        """Should sort chunks by metadata.chunk_index."""
+
+        params = {
+            "document_id": "doc1",
+            "chunk_index": 1,
+        }
+
+        chunk2 = Mock()
+        chunk2.payload = {
+            "content": "chunk 2",
+            "metadata": {"chunk_index": 2},
+        }
+
+        chunk0 = Mock()
+        chunk0.payload = {
+            "content": "chunk 0",
+            "metadata": {"chunk_index": 0},
+        }
+
+        chunk1 = Mock()
+        chunk1.payload = {
+            "content": "chunk 1",
+            "metadata": {"chunk_index": 1},
+        }
+
+        search_handler.search_engine.client.scroll = AsyncMock(
+            return_value=([chunk2, chunk0, chunk1], None)
+        )
+
+        self._mock_protocol(search_handler)
+
+        result = await search_handler.handle_expand_chunk_context(1, params)
+
+        chunks = (
+            result["result"]["structuredContent"]["context_chunks"]["pre"]
+            + [result["result"]["structuredContent"]["context_chunks"]["target"]]
+            + result["result"]["structuredContent"]["context_chunks"]["post"]
+        )
+
+        assert chunks[0]["metadata"]["chunk_index"] == 0
+        assert chunks[1]["metadata"]["chunk_index"] == 1
+        assert chunks[2]["metadata"]["chunk_index"] == 2
+
+
 class TestHierarchyFilters:
     """Test hierarchy filtering methods."""
 


### PR DESCRIPTION
# Pull Request

## Summary

The tool will retrieve neighboring chunks based on `document_id` and `chunk_index`

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

* Create `TestExpandChunkContextIntegration` and `TestHandleExpandChunkContext`

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `expand_chunk_context` tool to retrieve surrounding context chunks from documents. Users can now fetch a target chunk along with neighboring chunks using a configurable window size, enabling better understanding of chunk relationships within documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->