### PR TITLE
add advanced nlp opt-in flag enable_enhanced_semantic_analysis

### DIFF
--- a/docs/users/configuration/config-file-reference.md
+++ b/docs/users/configuration/config-file-reference.md
@@ -360,7 +360,7 @@ global:
     max_chunks_per_document: 500
     # Optional: Master switch for NLP enrichment (spaCy + LDA) across all strategies (default: true)
     enable_semantic_analysis: true
-    # Optional: Advanced NLP fields: pos_tags, dependencies, document_similarity, topic_analysis (default: false)
+    # Optional: Advanced NLP fields: pos_tags, dependencies, document_similarity (default: false)
     enable_enhanced_semantic_analysis: false
     # Optional: Strategy-specific configurations for different content types
     strategies:
@@ -410,7 +410,7 @@ The `strategies` section allows you to fine-tune how different content types are
 **Chunking (top-level flags):**
 
 - `enable_semantic_analysis`: Master switch for NLP enrichment (spaCy + LDA) across **all** chunking strategies. Set to `false` for faster ingestion when semantic enrichment is not needed.
-- `enable_enhanced_semantic_analysis`: Opt-in flag (default: `false`) that enables advanced NLP fields: `pos_tags`, `dependencies`, `document_similarity`, `topic_analysis`. Requires `enable_semantic_analysis: true`. Increases payload size and ingestion time.
+- `enable_enhanced_semantic_analysis`: Opt-in flag (default: `false`) that enables advanced NLP fields: `pos_tags`, `dependencies`, `document_similarity`. Requires `enable_semantic_analysis: true`. Increases payload size and ingestion time.
 
 **Default Strategy (Text Files):**
 

--- a/docs/users/configuration/config-file-reference.md
+++ b/docs/users/configuration/config-file-reference.md
@@ -143,6 +143,7 @@ global:
     chunk_overlap: 200
     max_chunks_per_document: 500
     enable_semantic_analysis: true
+    enable_enhanced_semantic_analysis: false
     strategies:
       default:
         min_chunk_size: 100
@@ -359,6 +360,8 @@ global:
     max_chunks_per_document: 500
     # Optional: Master switch for NLP enrichment (spaCy + LDA) across all strategies (default: true)
     enable_semantic_analysis: true
+    # Optional: Advanced NLP fields: pos_tags, dependencies, document_similarity, topic_analysis (default: false)
+    enable_enhanced_semantic_analysis: false
     # Optional: Strategy-specific configurations for different content types
     strategies:
       default:
@@ -407,6 +410,7 @@ The `strategies` section allows you to fine-tune how different content types are
 **Chunking (top-level flags):**
 
 - `enable_semantic_analysis`: Master switch for NLP enrichment (spaCy + LDA) across **all** chunking strategies. Set to `false` for faster ingestion when semantic enrichment is not needed.
+- `enable_enhanced_semantic_analysis`: Opt-in flag (default: `false`) that enables advanced NLP fields: `pos_tags`, `dependencies`, `document_similarity`, `topic_analysis`. Requires `enable_semantic_analysis: true`. Increases payload size and ingestion time.
 
 **Default Strategy (Text Files):**
 
@@ -800,10 +804,11 @@ global:
     chunk_size: 1500
     chunk_overlap: 200
     max_chunks_per_document: 500
+    enable_semantic_analysis: true
+    enable_enhanced_semantic_analysis: false
     strategies:
       default:
         min_chunk_size: 100
-        enable_semantic_analysis: true
         enable_entity_extraction: true
       html:
         simple_parsing_threshold: 100000

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -46,7 +46,7 @@ global:
     chunk_overlap: 200 # Number of characters to overlap between chunks
     max_chunks_per_document: 500 # Maximum number of chunks per document (safety limit)
     enable_semantic_analysis: true # Master switch for NLP enrichment (spaCy + LDA) across all strategies. Disable for faster ingestion.
-    enable_enhanced_semantic_analysis: false # Opt-in: pos_tags, dependencies, document_similarity, topic_analysis. Requires enable_semantic_analysis: true.
+    enable_enhanced_semantic_analysis: false # Opt-in: pos_tags, dependencies, document_similarity. Requires enable_semantic_analysis: true.
 
     # Strategy-specific configurations for different content types
     strategies:

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -46,6 +46,7 @@ global:
     chunk_overlap: 200 # Number of characters to overlap between chunks
     max_chunks_per_document: 500 # Maximum number of chunks per document (safety limit)
     enable_semantic_analysis: true # Master switch for NLP enrichment (spaCy + LDA) across all strategies. Disable for faster ingestion.
+    enable_enhanced_semantic_analysis: false # Opt-in: pos_tags, dependencies, document_similarity, topic_analysis. Requires enable_semantic_analysis: true.
 
     # Strategy-specific configurations for different content types
     strategies:

--- a/packages/qdrant-loader/src/qdrant_loader/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config.py
@@ -37,8 +37,7 @@ class ChunkingConfig(BaseModel):
 
     enable_enhanced_semantic_analysis: bool = Field(
         default=False,
-        description="Enable advanced NLP fields: pos_tags, dependencies, "
-        "document_similarity, topic_analysis. "
+        description="Enable advanced NLP fields: pos_tags, dependencies,document_similarity."
         "Requires enable_semantic_analysis=true. "
         "Increases payload size and ingestion time.",
     )

--- a/packages/qdrant-loader/src/qdrant_loader/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config.py
@@ -35,6 +35,14 @@ class ChunkingConfig(BaseModel):
         "Disable for faster ingestion when semantic enrichment is not needed.",
     )
 
+    enable_enhanced_semantic_analysis: bool = Field(
+        default=False,
+        description="Enable advanced NLP fields: pos_tags, dependencies, "
+        "document_similarity, topic_analysis. "
+        "Requires enable_semantic_analysis=true. "
+        "Increases payload size and ingestion time.",
+    )
+
 
 class GlobalConfig(BaseModel):
     """Global configuration settings."""

--- a/packages/qdrant-loader/src/qdrant_loader/config/chunking.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/chunking.py
@@ -202,6 +202,13 @@ class ChunkingConfig(BaseModel):
         description="Master switch for semantic analysis (spaCy + LDA) across all chunking strategies. "
         "Disable for faster ingestion when NLP enrichment is not needed.",
     )
+    enable_enhanced_semantic_analysis: bool = Field(
+        default=False,
+        description="Enable advanced NLP fields: pos_tags, dependencies, "
+        "document_similarity, topic_analysis. "
+        "Requires enable_semantic_analysis=true. "
+        "Increases payload size and ingestion time.",
+    )
 
     # Strategy-specific configurations
     strategies: StrategySpecificConfig = Field(

--- a/packages/qdrant-loader/src/qdrant_loader/config/chunking.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/chunking.py
@@ -204,8 +204,7 @@ class ChunkingConfig(BaseModel):
     )
     enable_enhanced_semantic_analysis: bool = Field(
         default=False,
-        description="Enable advanced NLP fields: pos_tags, dependencies, "
-        "document_similarity, topic_analysis. "
+        description="Enable advanced NLP fields: pos_tags, dependencies, document_similarity. "
         "Requires enable_semantic_analysis=true. "
         "Increases payload size and ingestion time.",
     )
@@ -222,4 +221,16 @@ class ChunkingConfig(BaseModel):
         chunk_size = info.data.get("chunk_size", 1500)
         if v >= chunk_size:
             raise ValueError("Chunk overlap must be less than chunk size")
+        return v
+
+    @field_validator("enable_enhanced_semantic_analysis")
+    def validate_enhanced_semantic_analysis_dependency(
+        cls, v: bool, info: ValidationInfo
+    ) -> bool:
+        """Validate enhanced semantic analysis requires base semantic analysis."""
+        enable_semantic_analysis = info.data.get("enable_semantic_analysis", True)
+        if v and enable_semantic_analysis is not True:
+            raise ValueError(
+                "enable_enhanced_semantic_analysis requires enable_semantic_analysis=True"
+            )
         return v

--- a/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
@@ -76,6 +76,7 @@ class GlobalConfig(BaseConfig):
                 "chunk_size": self.chunking.chunk_size,
                 "chunk_overlap": self.chunking.chunk_overlap,
                 "enable_semantic_analysis": self.chunking.enable_semantic_analysis,
+                "enable_enhanced_semantic_analysis": self.chunking.enable_enhanced_semantic_analysis,
             },
             "embedding": self.embedding.model_dump(),
             "llm": self.llm,

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/chunk_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/chunk_processor.py
@@ -29,6 +29,11 @@ class ChunkProcessor:
         self._semantic_analysis_enabled = (
             settings.global_config.chunking.enable_semantic_analysis
         )
+
+        self._enhanced_semantic_analysis_enabled = (
+            settings.global_config.chunking.enable_enhanced_semantic_analysis
+        )
+
         if self._semantic_analysis_enabled:
             self.semantic_analyzer = SemanticAnalyzer(
                 spacy_model=settings.global_config.semantic_analysis.spacy_model,
@@ -85,6 +90,15 @@ class ChunkProcessor:
             logger.debug(
                 "Completed semantic analysis for chunk", chunk_index=chunk_index
             )
+            if self._enhanced_semantic_analysis_enabled:
+                results.update(
+                    {
+                        "pos_tags": analysis_result.pos_tags,
+                        "dependencies": analysis_result.dependencies,
+                        "document_similarity": analysis_result.document_similarity,
+                        "topic_analysis": analysis_result.topic_analysis,
+                    }
+                )
         else:
             results = {
                 "entities": [],

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/chunk_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/chunk_processor.py
@@ -79,7 +79,9 @@ class ChunkProcessor:
                 "Starting semantic analysis for chunk", chunk_index=chunk_index
             )
             analysis_result = self.semantic_analyzer.analyze_text(
-                chunk, doc_id=f"chunk_{chunk_index}"
+                chunk,
+                doc_id=f"chunk_{chunk_index}",
+                include_enhanced=self._enhanced_semantic_analysis_enabled,
             )
             results = {
                 "entities": analysis_result.entities,
@@ -96,7 +98,6 @@ class ChunkProcessor:
                         "pos_tags": analysis_result.pos_tags,
                         "dependencies": analysis_result.dependencies,
                         "document_similarity": analysis_result.document_similarity,
-                        "topic_analysis": analysis_result.topic_analysis,
                     }
                 )
         else:

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -22,31 +22,6 @@ def is_meaningful_text(text: str) -> bool:
     - Whitespace characters
     - Special symbols without semantic meaning (---, ..., |||, etc.)
 
-    This is used to filter both entities and tokens in NLP processing,
-    especially important for Excel/table processing where markdown tables
-    generate excessive pipe characters, commas, and spaces.
-
-    Args:
-        text: Text string to check
-
-    Returns:
-        True if text contains at least one letter or digit, False otherwise
-
-    Example:
-        >>> is_meaningful_text("Apple")
-        True
-        >>> is_meaningful_text("#")
-        False
-        >>> is_meaningful_text("|")
-        False
-        >>> is_meaningful_text("...")
-        False
-        >>> is_meaningful_text("---")
-        False
-        >>> is_meaningful_text("Apple123")
-        True
-        >>> is_meaningful_text("COVID-19")  # Has alphanumeric
-        True
     """
     # Check if text contains at least one alphanumeric character
     return any(c.isalnum() for c in text)
@@ -105,20 +80,26 @@ class SemanticAnalyzer:
         self._doc_cache = {}
 
     def analyze_text(
-        self, text: str, doc_id: str | None = None
+        self,
+        text: str,
+        doc_id: str | None = None,
+        include_enhanced: bool = False,
     ) -> SemanticAnalysisResult:
         """Perform comprehensive semantic analysis on text.
 
         Args:
             text: Text to analyze
             doc_id: Optional document ID for caching
+            include_enhanced: Whether to compute enhanced NLP fields
+                (pos_tags, dependencies, document_similarity)
 
         Returns:
             SemanticAnalysisResult containing all analysis results
         """
         # Check cache
-        if doc_id and doc_id in self._doc_cache:
-            return self._doc_cache[doc_id]
+        cache_key = (doc_id, include_enhanced) if doc_id else None
+        if cache_key and cache_key in self._doc_cache:
+            return self._doc_cache[cache_key]
 
         # Process with spaCy
         doc = self.nlp(text)
@@ -126,11 +107,15 @@ class SemanticAnalyzer:
         # Extract entities with linking
         entities = self._extract_entities(doc)
 
-        # Get part-of-speech tags
-        pos_tags = self._get_pos_tags(doc)
+        if include_enhanced:
+            # Get part-of-speech tags
+            pos_tags = self._get_pos_tags(doc)
 
-        # Get dependency parse
-        dependencies = self._get_dependencies(doc)
+            # Get dependency parse
+            dependencies = self._get_dependencies(doc)
+        else:
+            pos_tags = []
+            dependencies = []
 
         # Extract topics
         topics = self._extract_topics(text)
@@ -139,7 +124,9 @@ class SemanticAnalyzer:
         key_phrases = self._extract_key_phrases(doc)
 
         # Calculate document similarity
-        doc_similarity = self._calculate_document_similarity(text)
+        doc_similarity = (
+            self._calculate_document_similarity(text) if include_enhanced else {}
+        )
 
         # Create result
         result = SemanticAnalysisResult(
@@ -152,8 +139,8 @@ class SemanticAnalyzer:
         )
 
         # Cache result
-        if doc_id:
-            self._doc_cache[doc_id] = result
+        if cache_key:
+            self._doc_cache[cache_key] = result
 
         return result
 
@@ -410,7 +397,11 @@ class SemanticAnalyzer:
         # Check if the model has word vectors
         has_vectors = self.nlp.vocab.vectors_length > 0
 
-        for doc_id, cached_result in self._doc_cache.items():
+        for cache_key, cached_result in self._doc_cache.items():
+            doc_id = cache_key[0] if isinstance(cache_key, tuple) else cache_key
+            if doc_id is None:
+                continue
+
             # Check if cached_result has entities and the first entity has context
             if not cached_result.entities or not cached_result.entities[0].get(
                 "context"

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -99,7 +99,23 @@ class SemanticAnalyzer:
         # Check cache
         cache_key = (doc_id, include_enhanced) if doc_id else None
         if cache_key and cache_key in self._doc_cache:
-            return self._doc_cache[cache_key]
+            cached = self._doc_cache[cache_key]
+            if include_enhanced:
+                # Reuse cached base fields but refresh document_similarity to reflect
+                # any newly-analyzed docs added to the cache since last computation
+                refreshed = SemanticAnalysisResult(
+                    entities=cached.entities,
+                    pos_tags=cached.pos_tags,
+                    dependencies=cached.dependencies,
+                    topics=cached.topics,
+                    key_phrases=cached.key_phrases,
+                    document_similarity=self._calculate_document_similarity(
+                        text, doc_id=doc_id
+                    ),
+                )
+                self._doc_cache[cache_key] = refreshed
+                return refreshed
+            return cached
 
         # Process with spaCy
         doc = self.nlp(text)

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -125,7 +125,9 @@ class SemanticAnalyzer:
 
         # Calculate document similarity
         doc_similarity = (
-            self._calculate_document_similarity(text) if include_enhanced else {}
+            self._calculate_document_similarity(text, doc_id=doc_id)
+            if include_enhanced
+            else {}
         )
 
         # Create result
@@ -382,24 +384,29 @@ class SemanticAnalyzer:
 
         return list(set(key_phrases))  # Remove duplicates
 
-    def _calculate_document_similarity(self, text: str) -> dict[str, float]:
+    def _calculate_document_similarity(
+        self, text: str, doc_id: str | None = None
+    ) -> dict[str, float]:
         """Calculate similarity with other processed documents.
 
         Args:
             text: Text to compare
+            doc_id: Optional current document ID to exclude from results
 
         Returns:
             Dictionary of document similarities
         """
         similarities = {}
+        skipped_ids = {doc_id} if doc_id else set()
+
         doc = self.nlp(text)
 
         # Check if the model has word vectors
         has_vectors = self.nlp.vocab.vectors_length > 0
 
         for cache_key, cached_result in self._doc_cache.items():
-            doc_id = cache_key[0] if isinstance(cache_key, tuple) else cache_key
-            if doc_id is None:
+            cached_doc_id = cache_key[0] if isinstance(cache_key, tuple) else cache_key
+            if cached_doc_id is None or cached_doc_id in skipped_ids:
                 continue
 
             # Check if cached_result has entities and the first entity has context
@@ -418,7 +425,8 @@ class SemanticAnalyzer:
                 # This avoids the spaCy warning about missing word vectors
                 similarity = self._calculate_alternative_similarity(doc, cached_doc)
 
-            similarities[doc_id] = float(similarity)
+            similarities[cached_doc_id] = float(similarity)
+            skipped_ids.add(cached_doc_id)
 
         return similarities
 

--- a/packages/qdrant-loader/tests/integration/core/test_chunking_consistency.py
+++ b/packages/qdrant-loader/tests/integration/core/test_chunking_consistency.py
@@ -26,14 +26,13 @@ class TestChunkingConsistency:
         settings.global_config.chunking.chunk_size = 200  # characters
         settings.global_config.chunking.chunk_overlap = 50  # characters
         settings.global_config.chunking.max_chunks_per_document = 1000
+        settings.global_config.chunking.enable_semantic_analysis = True
+        settings.global_config.chunking.enable_enhanced_semantic_analysis = False
 
         # Add strategy-specific configurations
         settings.global_config.chunking.strategies = Mock()
         settings.global_config.chunking.strategies.default = Mock()
         settings.global_config.chunking.strategies.default.min_chunk_size = 50
-        settings.global_config.chunking.strategies.default.enable_semantic_analysis = (
-            True
-        )
         settings.global_config.chunking.strategies.default.enable_entity_extraction = (
             True
         )

--- a/packages/qdrant-loader/tests/unit/config/test_chunking_strategy_configs.py
+++ b/packages/qdrant-loader/tests/unit/config/test_chunking_strategy_configs.py
@@ -295,6 +295,23 @@ class TestChunkingConfigIntegration:
         ):
             ChunkingConfig(chunk_size=1000, chunk_overlap=1500)
 
+    def test_enhanced_semantic_analysis_requires_semantic_analysis(self):
+        """Test enhanced semantic analysis requires base semantic analysis."""
+        config = ChunkingConfig(
+            enable_semantic_analysis=True,
+            enable_enhanced_semantic_analysis=True,
+        )
+        assert config.enable_enhanced_semantic_analysis is True
+
+        with pytest.raises(
+            ValueError,
+            match="enable_enhanced_semantic_analysis requires enable_semantic_analysis=True",
+        ):
+            ChunkingConfig(
+                enable_semantic_analysis=False,
+                enable_enhanced_semantic_analysis=True,
+            )
+
     def test_global_config_integration(self):
         """Test that GlobalConfig properly includes all chunking configurations."""
         config = GlobalConfig()

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/default/test_default_strategy_modular.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/default/test_default_strategy_modular.py
@@ -24,12 +24,11 @@ class TestDefaultChunkingStrategyModular:
         settings.global_config.chunking.chunk_size = 1500
         settings.global_config.chunking.chunk_overlap = 200
         settings.global_config.chunking.max_chunks_per_document = 500
+        settings.global_config.chunking.enable_semantic_analysis = True
+        settings.global_config.chunking.enable_enhanced_semantic_analysis = False
         settings.global_config.chunking.strategies = Mock()
         settings.global_config.chunking.strategies.default = Mock()
         settings.global_config.chunking.strategies.default.min_chunk_size = 100
-        settings.global_config.chunking.strategies.default.enable_semantic_analysis = (
-            True
-        )
         settings.global_config.chunking.strategies.default.enable_entity_extraction = (
             True
         )

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/test_default_strategy.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/test_default_strategy.py
@@ -25,14 +25,13 @@ class TestDefaultChunkingStrategy:
         settings.global_config.chunking.chunk_size = 100
         settings.global_config.chunking.chunk_overlap = 20
         settings.global_config.chunking.max_chunks_per_document = 500
+        settings.global_config.chunking.enable_semantic_analysis = True
+        settings.global_config.chunking.enable_enhanced_semantic_analysis = False
 
         # Add strategy-specific configuration
         settings.global_config.chunking.strategies = Mock()
         settings.global_config.chunking.strategies.default = Mock()
         settings.global_config.chunking.strategies.default.min_chunk_size = 50
-        settings.global_config.chunking.strategies.default.enable_semantic_analysis = (
-            True
-        )
         settings.global_config.chunking.strategies.default.enable_entity_extraction = (
             True
         )
@@ -50,14 +49,13 @@ class TestDefaultChunkingStrategy:
         settings.global_config.chunking.chunk_size = 50
         settings.global_config.chunking.chunk_overlap = 10
         settings.global_config.chunking.max_chunks_per_document = 500
+        settings.global_config.chunking.enable_semantic_analysis = True
+        settings.global_config.chunking.enable_enhanced_semantic_analysis = False
 
         # Add strategy-specific configuration
         settings.global_config.chunking.strategies = Mock()
         settings.global_config.chunking.strategies.default = Mock()
         settings.global_config.chunking.strategies.default.min_chunk_size = 25
-        settings.global_config.chunking.strategies.default.enable_semantic_analysis = (
-            True
-        )
         settings.global_config.chunking.strategies.default.enable_entity_extraction = (
             True
         )

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -255,7 +255,7 @@ class TestSemanticAnalyzer:
             mock_nlp.return_value = mock_doc
             analyzer = SemanticAnalyzer()
 
-            result = analyzer.analyze_text("Apple is a company")
+            result = analyzer.analyze_text("Apple is a company", include_enhanced=True)
 
             assert isinstance(result, SemanticAnalysisResult)
             assert len(result.entities) > 0
@@ -278,13 +278,45 @@ class TestSemanticAnalyzer:
             analyzer = SemanticAnalyzer()
 
             # First call should process and cache
-            result1 = analyzer.analyze_text("Apple is a company", doc_id="doc1")
+            result1 = analyzer.analyze_text(
+                "Apple is a company", doc_id="doc1", include_enhanced=True
+            )
 
             # Second call should return cached result
-            result2 = analyzer.analyze_text("Apple is a company", doc_id="doc1")
+            result2 = analyzer.analyze_text(
+                "Apple is a company", doc_id="doc1", include_enhanced=True
+            )
 
             assert result1 is result2
-            assert "doc1" in analyzer._doc_cache
+            assert ("doc1", True) in analyzer._doc_cache
+
+    def test_analyze_text_without_enhanced_fields(self, mock_nlp, mock_doc):
+        """Test text analysis short-circuits enhanced computations when disabled."""
+        with (
+            patch("spacy.load", return_value=mock_nlp),
+            patch.object(SemanticAnalyzer, "_extract_topics", return_value=[]),
+            patch.object(
+                SemanticAnalyzer,
+                "_calculate_document_similarity",
+                return_value={"doc1": 0.8},
+            ) as mock_similarity,
+            patch.object(SemanticAnalyzer, "_get_pos_tags") as mock_pos_tags,
+            patch.object(SemanticAnalyzer, "_get_dependencies") as mock_dependencies,
+        ):
+            mock_nlp.return_value = mock_doc
+            analyzer = SemanticAnalyzer()
+
+            result = analyzer.analyze_text(
+                "Apple is a company", doc_id="doc2", include_enhanced=False
+            )
+
+            assert result.pos_tags == []
+            assert result.dependencies == []
+            assert result.document_similarity == {}
+            mock_pos_tags.assert_not_called()
+            mock_dependencies.assert_not_called()
+            mock_similarity.assert_not_called()
+            assert ("doc2", False) in analyzer._doc_cache
 
     def test_extract_entities(self, mock_nlp, mock_doc):
         """Test entity extraction."""
@@ -825,7 +857,7 @@ class TestSemanticAnalyzer:
             ):
                 analyzer = SemanticAnalyzer()
                 result = analyzer.analyze_text(
-                    "Apple Inc is a company", doc_id="test_doc"
+                    "Apple Inc is a company", doc_id="test_doc", include_enhanced=True
                 )
 
                 # Verify all components are present
@@ -836,4 +868,4 @@ class TestSemanticAnalyzer:
                 assert isinstance(result.document_similarity, dict)
 
                 # Verify caching
-                assert "test_doc" in analyzer._doc_cache
+                assert ("test_doc", True) in analyzer._doc_cache

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -282,12 +282,17 @@ class TestSemanticAnalyzer:
                 "Apple is a company", doc_id="doc1", include_enhanced=True
             )
 
-            # Second call should return cached result
+            # Second call should return cached result (deep-copied when include_enhanced=True)
             result2 = analyzer.analyze_text(
                 "Apple is a company", doc_id="doc1", include_enhanced=True
             )
 
-            assert result1 is result2
+            # With include_enhanced=True, cache hit returns a deep copy with refreshed similarity
+            # So result1 and result2 are different objects, but have same content
+            assert result1 is not result2
+            assert result1.entities == result2.entities
+            assert result1.pos_tags == result2.pos_tags
+            assert result1.topics == result2.topics
             assert ("doc1", True) in analyzer._doc_cache
 
     def test_analyze_text_without_enhanced_fields(self, mock_nlp, mock_doc):
@@ -766,6 +771,53 @@ class TestSemanticAnalyzer:
             # Verify enhanced fields differ
             assert len(result_enhanced_false.pos_tags) == 0
             assert len(result_enhanced_true.pos_tags) > 0
+
+    def test_analyze_text_cache_hit_refreshes_similarity(self, mock_nlp, mock_doc):
+        """Test that cache hit with include_enhanced=True refreshes similarity."""
+        with (
+            patch("spacy.load", return_value=mock_nlp),
+            patch.object(SemanticAnalyzer, "_extract_topics", return_value=[]),
+            patch.object(
+                SemanticAnalyzer, "_calculate_document_similarity"
+            ) as mock_similarity,
+        ):
+            mock_nlp.return_value = mock_doc
+            analyzer = SemanticAnalyzer()
+
+            # Mock _calculate_document_similarity to return different results on each call
+            mock_similarity.side_effect = [
+                {"other_doc": 0.5},  # First call (initial analysis of doc1)
+                {
+                    "doc2": 0.7
+                },  # Second call (cache hit, refreshed with doc2 now in cache)
+            ]
+
+            # First call - analyze doc1 and cache it
+            result1 = analyzer.analyze_text(
+                "Apple is a company", doc_id="doc1", include_enhanced=True
+            )
+            assert result1.document_similarity == {"other_doc": 0.5}
+
+            # Add doc2 to cache (simulating another document being analyzed)
+            doc2_result = SemanticAnalysisResult(
+                entities=[{"context": "Microsoft is a company"}],
+                pos_tags=[],
+                dependencies=[],
+                topics=[],
+                key_phrases=[],
+                document_similarity={},
+            )
+            analyzer._doc_cache[("doc2", True)] = doc2_result
+
+            # Second call - cache hit for doc1, should refresh similarity
+            result2 = analyzer.analyze_text(
+                "Apple is a company", doc_id="doc1", include_enhanced=True
+            )
+
+            # Result should have refreshed similarity (now includes doc2)
+            assert result2.document_similarity == {"doc2": 0.7}
+            # Verify _calculate_document_similarity was called twice (initial + refresh)
+            assert mock_similarity.call_count == 2
 
     def test_calculate_topic_coherence(self, mock_nlp):
         """Test topic coherence calculation."""

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -705,6 +705,68 @@ class TestSemanticAnalyzer:
             assert "doc1" in similarities
             assert isinstance(similarities["doc1"], float)
 
+    def test_calculate_document_similarity_excludes_current_doc_id(
+        self, mock_nlp, mock_doc
+    ):
+        """Test similarity excludes the current doc_id from results."""
+        with patch("spacy.load", return_value=mock_nlp):
+            mock_nlp.return_value = mock_doc
+
+            analyzer = SemanticAnalyzer()
+
+            # Add multiple cached results
+            for doc_id in ["doc1", "doc2", "doc3"]:
+                cached_result = SemanticAnalysisResult(
+                    entities=[{"context": f"{doc_id} context"}],
+                    pos_tags=[],
+                    dependencies=[],
+                    topics=[],
+                    key_phrases=[],
+                    document_similarity={},
+                )
+                analyzer._doc_cache[doc_id] = cached_result
+
+            # Calculate similarity excluding doc2
+            similarities = analyzer._calculate_document_similarity(
+                "Apple is a company", doc_id="doc2"
+            )
+
+            # doc1 and doc3 should be in results, but not doc2 (current id)
+            assert "doc1" in similarities
+            assert "doc3" in similarities
+            assert "doc2" not in similarities
+
+    def test_analyze_text_cache_separate_by_include_enhanced(self, mock_nlp, mock_doc):
+        """Test that same doc_id with different include_enhanced values are cached separately."""
+        with (
+            patch("spacy.load", return_value=mock_nlp),
+            patch.object(SemanticAnalyzer, "_extract_topics", return_value=[]),
+            patch.object(
+                SemanticAnalyzer, "_calculate_document_similarity", return_value={}
+            ),
+        ):
+            mock_nlp.return_value = mock_doc
+            analyzer = SemanticAnalyzer()
+
+            # Analyze same text with same doc_id but different include_enhanced
+            result_enhanced_false = analyzer.analyze_text(
+                "Apple is a company", doc_id="same_doc", include_enhanced=False
+            )
+            result_enhanced_true = analyzer.analyze_text(
+                "Apple is a company", doc_id="same_doc", include_enhanced=True
+            )
+
+            # Should be different objects (separate cache entries)
+            assert result_enhanced_false is not result_enhanced_true
+
+            # Cache should have separate keys
+            assert ("same_doc", False) in analyzer._doc_cache
+            assert ("same_doc", True) in analyzer._doc_cache
+
+            # Verify enhanced fields differ
+            assert len(result_enhanced_false.pos_tags) == 0
+            assert len(result_enhanced_true.pos_tags) > 0
+
     def test_calculate_topic_coherence(self, mock_nlp):
         """Test topic coherence calculation."""
         with patch("spacy.load", return_value=mock_nlp):


### PR DESCRIPTION

# Pull Request

## Summary

Add a new opt-in flag enable_enhanced_semantic_analysis (default: false). The heavy fields (pos_tags, dependencies, document_similarity) are only computed and stored when explicitly enabled.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages: docs/users/configuration/config-file-reference.md
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in "enhanced semantic analysis" mode that enriches content with POS tags, dependency relations, document similarity, and improved topic signals.
  * The enhancement is disabled by default and requires the existing semantic analysis setting to be enabled.
  * Caching and serialization were updated so enriched and non-enriched outputs are handled distinctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->