### PR TITLE
feat: config semantic analysis enhancements

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/models.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/models.py
@@ -1,10 +1,12 @@
 """Search result models."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SearchResult(BaseModel):
     """Search result model with comprehensive metadata."""
+
+    model_config = {"populate_by_name": True}
 
     score: float
     text: str
@@ -69,10 +71,10 @@ class SearchResult(BaseModel):
     pos_tags: list[dict] = []
 
     # 🔥 NEW: Navigation context
-    previous_section: str | None = None
-    next_section: str | None = None
-    sibling_sections: list[str] = []
-    subsections: list[str] = []
+    previous_section: str | None = Field(default=None, exclude=True)
+    next_section: str | None = Field(default=None, exclude=True)
+    sibling_sections: list[str] = Field(default=[], exclude=True)
+    subsections: list[str] = Field(default=[], exclude=True)
     document_hierarchy: list[str] = []
 
     # 🔥 NEW: Chunking context

--- a/packages/qdrant-loader/src/qdrant_loader/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config.py
@@ -13,7 +13,7 @@ class SemanticAnalysisConfig(BaseModel):
     lda_passes: int = Field(default=10, description="Number of passes for LDA training")
 
     spacy_model: str = Field(
-        default="en_core_web_md",
+        default="en_core_web_sm",
         description="spaCy model to use for text processing. Options: en_core_web_sm (15MB, no vectors), en_core_web_md (50MB, 20k vectors), en_core_web_lg (750MB, 514k vectors)",
     )
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -44,7 +44,7 @@ class SemanticAnalyzer:
 
     def __init__(
         self,
-        spacy_model: str = "en_core_web_md",
+        spacy_model: str = "en_core_web_sm",
         num_topics: int = 5,
         passes: int = 10,
         min_topic_freq: int = 2,

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -202,7 +202,7 @@ class TestSemanticAnalyzer:
             assert analyzer.lda_model is None
             assert analyzer.dictionary is None
             assert analyzer._doc_cache == {}
-            mock_load.assert_called_once_with("en_core_web_md")
+            mock_load.assert_called_once_with("en_core_web_sm")
 
     def test_initialization_custom_params(self):
         """Test SemanticAnalyzer initialization with custom parameters."""
@@ -238,7 +238,7 @@ class TestSemanticAnalyzer:
             analyzer = SemanticAnalyzer()
 
             assert analyzer.nlp == mock_nlp
-            mock_download.assert_called_once_with("en_core_web_md")
+            mock_download.assert_called_once_with("en_core_web_sm")
             assert mock_load.call_count == 2
 
     def test_analyze_text_basic(self, mock_nlp, mock_doc):


### PR DESCRIPTION
# Pull Request

## Summary

- Add per-project semantic_analysis.enabled override
- Make SemanticAnalyzer skip spaCy model download when disabled
- Prune navigation fields from SearchResult serialization

## Type of change

- [X] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Checklist

- [X] Tests pass (`pytest -v`)
- [X] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now exclude navigation context fields (previous/next section, sibling and subsections) by default, providing cleaner and more focused output.

* **Chores**
  * Updated default semantic analysis model to use a lighter-weight variant, improving startup performance and reducing overall resource requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->