### PR TITLE
chore: add log time for total ingestion pipline.

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/ingest_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/ingest_cmd.py
@@ -192,10 +192,12 @@ async def run_ingest_command(
     except Exception as e:
         logger = LoggingConfig.get_logger(__name__)
         error_msg = str(e) if str(e) else f"Empty exception of type: {type(e).__name__}"
+        end_to_end_duration = time.perf_counter() - ingest_start_time
         logger.error(
             "Unexpected error during ingestion command execution",
             error=error_msg,
             error_type=type(e).__name__,
+            end_to_end_duration_seconds=round(end_to_end_duration, 2),
             suggestion="Check logs above for specific error details and verify system configuration",
             exc_info=True,
         )

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/ingest_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/ingest_cmd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import signal
+import time
 from pathlib import Path
 
 from click.exceptions import ClickException
@@ -35,6 +36,8 @@ async def run_ingest_command(
     force: bool,
 ) -> None:
     """Implementation for the `ingest` CLI command with identical behavior."""
+
+    ingest_start_time = time.perf_counter()
 
     try:
         # Validate flag combinations
@@ -149,6 +152,10 @@ async def run_ingest_command(
                             exc_info=True,
                         )
             await asyncio.sleep(0.1)
+            end_to_end_duration = time.perf_counter() - ingest_start_time
+            logger.info(
+                f"Ingestion end-to-end completed in {end_to_end_duration:.2f} seconds"
+            )
         except asyncio.CancelledError:
             # Preserve cancellation semantics so Ctrl+C results in a normal exit
             raise
@@ -157,10 +164,12 @@ async def run_ingest_command(
             error_msg = (
                 str(e) if str(e) else f"Empty exception of type: {type(e).__name__}"
             )
+            end_to_end_duration = time.perf_counter() - ingest_start_time
             logger.error(
                 "Document ingestion process failed during execution",
                 error=error_msg,
                 error_type=type(e).__name__,
+                end_to_end_duration_seconds=round(end_to_end_duration, 2),
                 suggestion=(
                     "Check data sources, configuration, and system resources. "
                     "Run 'qdrant-loader project validate' to verify setup"

--- a/packages/qdrant-loader/tests/unit/cli/test_ingest_cmd_sigint.py
+++ b/packages/qdrant-loader/tests/unit/cli/test_ingest_cmd_sigint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import signal
 from types import SimpleNamespace
 
@@ -158,3 +159,95 @@ async def test_sigint_handler_schedules_cancellation_windows_fallback(mocker):
 
     # Ensure command completes cleanly
     await asyncio.wait_for(task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_ingest_logs_end_to_end_duration_on_success(mocker, caplog):
+    from qdrant_loader.cli.commands import ingest_cmd as ingest_module
+
+    mocker.patch.object(ingest_module, "_load_config_with_workspace", return_value=None)
+    mocker.patch.object(ingest_module, "validate_workspace_flags", return_value=None)
+    mocker.patch("qdrant_loader.config.get_settings", return_value=SimpleNamespace())
+    mocker.patch(
+        "qdrant_loader.core.qdrant_manager.QdrantManager", return_value=object()
+    )
+
+    async def _fake_run_pipeline(*_args, **_kwargs):
+        return None
+
+    mocker.patch.object(
+        ingest_module, "_run_ingest_pipeline", side_effect=_fake_run_pipeline
+    )
+    mocker.patch.object(ingest_module.asyncio, "all_tasks", return_value=[])
+
+    with caplog.at_level(logging.INFO):
+        await ingest_module.run_ingest_command(
+            workspace=None,
+            config=None,
+            env=None,
+            project=None,
+            source_type=None,
+            source=None,
+            log_level="INFO",
+            profile=False,
+            force=False,
+        )
+
+    assert any(
+        "Ingestion end-to-end completed in" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_logs_end_to_end_duration_on_failure(mocker):
+    from click.exceptions import ClickException
+    from qdrant_loader.cli.commands import ingest_cmd as ingest_module
+
+    mocker.patch.object(ingest_module, "_load_config_with_workspace", return_value=None)
+    mocker.patch.object(ingest_module, "validate_workspace_flags", return_value=None)
+    mocker.patch("qdrant_loader.config.get_settings", return_value=SimpleNamespace())
+    mocker.patch(
+        "qdrant_loader.core.qdrant_manager.QdrantManager", return_value=object()
+    )
+
+    async def _failing_run_pipeline(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    mocker.patch.object(
+        ingest_module, "_run_ingest_pipeline", side_effect=_failing_run_pipeline
+    )
+    mocker.patch.object(ingest_module.asyncio, "all_tasks", return_value=[])
+
+    mock_logger = mocker.Mock()
+    get_logger_mock = mocker.patch.object(
+        ingest_module.LoggingConfig, "get_logger", return_value=mock_logger
+    )
+
+    with pytest.raises(ClickException, match="Failed to run ingestion: boom"):
+        await ingest_module.run_ingest_command(
+            workspace=None,
+            config=None,
+            env=None,
+            project=None,
+            source_type=None,
+            source=None,
+            log_level="INFO",
+            profile=False,
+            force=False,
+        )
+
+    assert get_logger_mock.called
+
+    failure_call = None
+    for call in mock_logger.error.call_args_list:
+        if (
+            call.args
+            and call.args[0] == "Document ingestion process failed during execution"
+        ):
+            failure_call = call
+            break
+
+    assert failure_call is not None
+    assert "end_to_end_duration_seconds" in failure_call.kwargs
+    assert isinstance(failure_call.kwargs["end_to_end_duration_seconds"], float)

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_chunk_processor.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_chunk_processor.py
@@ -1,0 +1,156 @@
+"""Unit tests for markdown ChunkProcessor semantic-analysis flags."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from qdrant_loader.core.chunking.strategy.markdown.chunk_processor import ChunkProcessor
+
+
+def _make_settings(
+    *,
+    enable_semantic_analysis: bool,
+    enable_enhanced_semantic_analysis: bool,
+):
+    """Build minimal settings object required by ChunkProcessor."""
+    return SimpleNamespace(
+        global_config=SimpleNamespace(
+            chunking=SimpleNamespace(
+                enable_semantic_analysis=enable_semantic_analysis,
+                enable_enhanced_semantic_analysis=enable_enhanced_semantic_analysis,
+                chunk_size=1200,
+                strategies=SimpleNamespace(
+                    markdown=SimpleNamespace(max_workers=1, estimation_buffer=0.25)
+                ),
+            ),
+            semantic_analysis=SimpleNamespace(
+                spacy_model="en_core_web_sm",
+                num_topics=3,
+                lda_passes=5,
+            ),
+        )
+    )
+
+
+def test_init_skips_semantic_analyzer_when_semantic_disabled():
+    settings = _make_settings(
+        enable_semantic_analysis=False,
+        enable_enhanced_semantic_analysis=False,
+    )
+
+    with patch(
+        "qdrant_loader.core.chunking.strategy.markdown.chunk_processor.SemanticAnalyzer"
+    ) as mock_analyzer:
+        processor = ChunkProcessor(settings)
+        try:
+            assert processor.semantic_analyzer is None
+            mock_analyzer.assert_not_called()
+        finally:
+            processor.shutdown()
+
+
+def test_init_creates_semantic_analyzer_when_semantic_enabled():
+    settings = _make_settings(
+        enable_semantic_analysis=True,
+        enable_enhanced_semantic_analysis=False,
+    )
+
+    with patch(
+        "qdrant_loader.core.chunking.strategy.markdown.chunk_processor.SemanticAnalyzer"
+    ) as mock_analyzer:
+        processor = ChunkProcessor(settings)
+        try:
+            mock_analyzer.assert_called_once_with(
+                spacy_model="en_core_web_sm",
+                num_topics=3,
+                passes=5,
+            )
+        finally:
+            processor.shutdown()
+
+
+def test_process_chunk_uses_base_semantic_fields_when_enhanced_disabled():
+    settings = _make_settings(
+        enable_semantic_analysis=True,
+        enable_enhanced_semantic_analysis=False,
+    )
+
+    analysis_result = Mock()
+    analysis_result.entities = [{"text": "Apple", "label": "ORG"}]
+    analysis_result.topics = [{"id": 0}]
+    analysis_result.key_phrases = ["Apple Inc"]
+    analysis_result.pos_tags = [{"text": "Apple", "pos": "NOUN"}]
+    analysis_result.dependencies = [{"text": "Apple", "dep": "nsubj"}]
+    analysis_result.document_similarity = {"doc1": 0.8}
+
+    with patch(
+        "qdrant_loader.core.chunking.strategy.markdown.chunk_processor.SemanticAnalyzer"
+    ) as mock_analyzer:
+        mock_analyzer.return_value.analyze_text.return_value = analysis_result
+        processor = ChunkProcessor(settings)
+        try:
+            result = processor.process_chunk("Apple builds products", 0, 1)
+
+            processor.semantic_analyzer.analyze_text.assert_called_once_with(
+                "Apple builds products",
+                doc_id="chunk_0",
+                include_enhanced=False,
+            )
+            assert "entities" in result
+            assert "topics" in result
+            assert "key_phrases" in result
+            assert "pos_tags" not in result
+            assert "dependencies" not in result
+            assert "document_similarity" not in result
+        finally:
+            processor.shutdown()
+
+
+def test_process_chunk_includes_enhanced_fields_when_enhanced_enabled():
+    settings = _make_settings(
+        enable_semantic_analysis=True,
+        enable_enhanced_semantic_analysis=True,
+    )
+
+    analysis_result = Mock()
+    analysis_result.entities = [{"text": "Apple", "label": "ORG"}]
+    analysis_result.topics = [{"id": 0}]
+    analysis_result.key_phrases = ["Apple Inc"]
+    analysis_result.pos_tags = [{"text": "Apple", "pos": "NOUN"}]
+    analysis_result.dependencies = [{"text": "Apple", "dep": "nsubj"}]
+    analysis_result.document_similarity = {"doc1": 0.8}
+
+    with patch(
+        "qdrant_loader.core.chunking.strategy.markdown.chunk_processor.SemanticAnalyzer"
+    ) as mock_analyzer:
+        mock_analyzer.return_value.analyze_text.return_value = analysis_result
+        processor = ChunkProcessor(settings)
+        try:
+            result = processor.process_chunk("Apple builds products", 1, 3)
+
+            processor.semantic_analyzer.analyze_text.assert_called_once_with(
+                "Apple builds products",
+                doc_id="chunk_1",
+                include_enhanced=True,
+            )
+            assert "pos_tags" in result
+            assert "dependencies" in result
+            assert "document_similarity" in result
+        finally:
+            processor.shutdown()
+
+
+def test_process_chunk_returns_empty_semantic_data_when_semantic_disabled():
+    settings = _make_settings(
+        enable_semantic_analysis=False,
+        enable_enhanced_semantic_analysis=False,
+    )
+
+    with patch(
+        "qdrant_loader.core.chunking.strategy.markdown.chunk_processor.SemanticAnalyzer"
+    ):
+        processor = ChunkProcessor(settings)
+        try:
+            result = processor.process_chunk("Plain text", 0, 1)
+            assert result == {"entities": [], "topics": [], "key_phrases": []}
+        finally:
+            processor.shutdown()


### PR DESCRIPTION
# Pull Request

## Summary

Add logging time for end-to-end ingestion pipeline

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [x] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingestion operations now capture and log end-to-end duration. Total elapsed time is reported on successful completion and included in error logs, giving clearer visibility into ingestion performance and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->