### PR TITLE
fix: add validation and error handling for expand_chunk_context endpoint

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/cluster_documents.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/cluster_documents.py
@@ -170,7 +170,7 @@ def get_cluster_documents_tool_schema() -> dict[str, Any]:
                     "example": "550e8400-e29b-41d4-a716-446655440000",
                 },
             },
-            "required": ["clusters", "clustering_metadata"],
+            "required": ["clusters", "clustering_metadata", "cluster_session_id"],
             "additionalProperties": False,
         },
     }

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/expand_chunk_context.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/schemas/expand_chunk_context.py
@@ -17,6 +17,7 @@ def get_expand_chunk_context_tool_schema() -> dict[str, Any]:
                 "chunk_index": {
                     "type": "integer",
                     "description": "Index of the target chunk within the document.",
+                    "minimum": 0,
                 },
                 "window_size": {
                     "type": "integer",

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -647,15 +647,31 @@ class SearchHandler:
                     "data": "chunk_index must be a valid integer",
                 },
             )
-        window_size = params.get("window_size", 2)
 
-        if not isinstance(window_size, int) or window_size < 0:
+        if chunk_index < 0:
             return self.protocol.create_response(
                 request_id,
                 error={
                     "code": -32602,
                     "message": "Invalid params",
-                    "data": "window_size must be non-negative integer",
+                    "data": "chunk_index must be a non-negative integer",
+                },
+            )
+        
+        MAX_WINDOW_SIZE = 25
+        window_size = params.get("window_size", 2)
+
+        if (
+            not isinstance(window_size, int)
+            or window_size < 0
+            or window_size > MAX_WINDOW_SIZE
+        ):
+            return self.protocol.create_response(
+                request_id,
+                error={
+                    "code": -32602,
+                    "message": "Invalid params",
+                    "data": f"window_size must be a non-negative integer between 0 and {MAX_WINDOW_SIZE}",
                 },
             )
 
@@ -680,7 +696,9 @@ class SearchHandler:
                 models.FieldCondition(
                     key="document_id",
                     match=models.MatchValue(value=document_id),
-                ),
+                )
+            ],
+            should=[
                 models.FieldCondition(
                     key="metadata.chunk_index",
                     range=models.Range(
@@ -688,7 +706,15 @@ class SearchHandler:
                         lte=end_chunk,
                     ),
                 ),
-            ]
+                models.FieldCondition(
+                    key="chunk_index",
+                    range=models.Range(
+                        gte=start_chunk,
+                        lte=end_chunk,
+                    ),
+                ),
+            ],
+            must_not=[],
         )
 
         # =========================
@@ -723,11 +749,11 @@ class SearchHandler:
             )
 
         # =========================
-        # Sort by chunk_index
+        # Sort by chunk_index with fallback
         # =========================
         chunks = sorted(
             [p.payload for p in all_points],
-            key=lambda x: x.get("metadata", {}).get("chunk_index", 0),
+            key=lambda x: x.get("metadata", {}).get("chunk_index", x.get("chunk_index", 0)),
         )
 
         # =========================
@@ -752,6 +778,18 @@ class SearchHandler:
             else:
                 post_chunks.append(chunk)
 
+        if target_chunk is None:
+            return self.protocol.create_response(
+                request_id,
+                error={
+                    "code": -32001,
+                    "message": "Chunk not found",
+                    "data": (
+                        f"No chunk found for document_id: {document_id}, "
+                        f"chunk_index: {chunk_index}"
+                    ),
+                },
+            )
         # =========================
         # Build structured output
         # =========================

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/search_handler.py
@@ -657,7 +657,7 @@ class SearchHandler:
                     "data": "chunk_index must be a non-negative integer",
                 },
             )
-        
+
         MAX_WINDOW_SIZE = 25
         window_size = params.get("window_size", 2)
 
@@ -753,7 +753,9 @@ class SearchHandler:
         # =========================
         chunks = sorted(
             [p.payload for p in all_points],
-            key=lambda x: x.get("metadata", {}).get("chunk_index", x.get("chunk_index", 0)),
+            key=lambda x: x.get("metadata", {}).get(
+                "chunk_index", x.get("chunk_index", 0)
+            ),
         )
 
         # =========================

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_search_handler_comprehensive.py
@@ -697,13 +697,26 @@ class TestHandleExpandChunkContext:
         assert "chunk_index" in result["error"]["data"]
 
     @pytest.mark.asyncio
+    async def test_expand_chunk_context_negative_chunk_index(self, search_handler):
+        """Should return error if chunk_index is negative."""
+
+        params = {"document_id": "doc1", "chunk_index": -1}
+
+        self._mock_protocol(search_handler)
+
+        result = await search_handler.handle_expand_chunk_context(1, params)
+
+        assert result["error"]["code"] == -32602
+        assert "chunk_index must be a non-negative integer" in result["error"]["data"]
+
+    @pytest.mark.asyncio
     async def test_expand_chunk_context_invalid_window_size(self, search_handler):
-        """Should validate window_size"""
+        """Should return error if window_size is invalid."""
 
         params = {
             "document_id": "doc1",
             "chunk_index": 1,
-            "window_size": -1,
+            "window_size": 30,  # Exceeds MAX_WINDOW_SIZE
         }
 
         self._mock_protocol(search_handler)
@@ -711,7 +724,28 @@ class TestHandleExpandChunkContext:
         result = await search_handler.handle_expand_chunk_context(1, params)
 
         assert result["error"]["code"] == -32602
-        assert "window_size" in result["error"]["data"]
+        assert (
+            "window_size must be a non-negative integer between 0 and 25"
+            in result["error"]["data"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_expand_chunk_context_chunk_not_found(self, search_handler):
+        """Should return error if target chunk is not found."""
+
+        params = {"document_id": "doc1", "chunk_index": 5}
+
+        search_handler.search_engine.client.scroll = AsyncMock(return_value=([], None))
+
+        self._mock_protocol(search_handler)
+
+        result = await search_handler.handle_expand_chunk_context(1, params)
+
+        assert result["error"]["code"] == -32001
+        assert (
+            "No chunk found for document_id: doc1, chunk_index: 5"
+            in result["error"]["data"]
+        )
 
     @pytest.mark.asyncio
     async def test_expand_chunk_context_sorted_correctly(self, search_handler):


### PR DESCRIPTION
# Pull Request

## Summary

 Improve input validation and error handling for the `expand_chunk_context` MCP tool:
  - Reject negative `chunk_index` with proper error response
  - Enforce `window_size` maximum limit (25) to prevent oversized queries
  - Return structured error when target chunk is not found instead of silently passing
  `None`
  - Support `chunk_index` at both `metadata.chunk_index` and top-level `chunk_index`
  paths (backward compatibility)
  - Add `cluster_session_id` to required fields in `cluster_documents` response schema

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [x] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

  - Added unit test for negative `chunk_index` validation
  (`test_expand_chunk_context_negative_chunk_index`)
  - Added unit test for `window_size` exceeding max limit
  (`test_expand_chunk_context_invalid_window_size`)
  - Added unit test for chunk-not-found error
  (`test_expand_chunk_context_chunk_not_found`)

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Cluster operations now include session ID tracking in API responses.

* **Improvements**
  - Chunk indexing operations enforce stricter validation to prevent invalid parameters.
  - Improved error handling with clearer messages when requested chunks cannot be located.
  - Added maximum size constraint for chunk context window expansion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->