### PR TITLE
fix: resolve 5 bugs from CodeRabbit review in search, transport, and CLI

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/cli.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/cli.py
@@ -6,6 +6,7 @@ import logging
 import os
 import signal
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import click
@@ -67,11 +68,14 @@ def _setup_logging(log_level: str, transport: str | None = None) -> None:
         print(f"Failed to setup logging: {e}", file=sys.stderr)
 
 
-async def read_stdin_lines():
+async def read_stdin_lines(executor=None):
     """Cross-platform async generator that yields lines from stdin."""
     loop = asyncio.get_event_loop()
     while True:
-        line = await loop.run_in_executor(None, sys.stdin.readline)
+        try:
+            line = await loop.run_in_executor(executor, sys.stdin.readline)
+        except (ValueError, OSError):
+            break  # stdin was closed during shutdown
         if not line:  # EOF
             break
         yield line
@@ -98,7 +102,7 @@ async def shutdown(
     logger.info("Shutdown signal dispatched")
 
 
-async def handle_stdio(config: Config, log_level: str):
+async def handle_stdio(config: Config, log_level: str, executor=None):
     """Handle stdio communication with Cursor."""
     logger = LoggingConfig.get_logger(__name__)
 
@@ -130,7 +134,7 @@ async def handle_stdio(config: Config, log_level: str):
         if not disable_console_logging:
             logger.info("Server ready to handle requests")
 
-        async for line in read_stdin_lines():
+        async for line in read_stdin_lines(executor):
             try:
                 raw_input = line.strip()
                 if not raw_input:
@@ -234,6 +238,12 @@ async def handle_stdio(config: Config, log_level: str):
         if not disable_console_logging:
             logger.error("Error in stdio handler", exc_info=True)
         raise
+    finally:
+        # Close stdin to unblock the executor thread waiting on readline()
+        try:
+            sys.stdin.close()
+        except Exception:
+            pass
 
 
 @click.command(name="mcp-qdrant-loader")
@@ -397,11 +407,15 @@ def cli(
 
             shutdown_event = asyncio.Event()
             shutdown_task = None
+            main_task = None
+            stdin_executor = None
 
             def signal_handler():
-                nonlocal shutdown_task
+                nonlocal shutdown_task, main_task
                 if shutdown_task is None:
                     shutdown_task = loop.create_task(shutdown(loop, shutdown_event))
+                if main_task is not None and not main_task.done():
+                    main_task.cancel()
 
             for sig in (signal.SIGTERM, signal.SIGINT):
                 try:
@@ -416,7 +430,15 @@ def cli(
                         pass
 
             try:
-                loop.run_until_complete(handle_stdio(config_obj, log_level))
+                stdin_executor = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="stdin-"
+                )
+                main_task = loop.create_task(
+                    handle_stdio(config_obj, log_level, stdin_executor)
+                )
+                loop.run_until_complete(main_task)
+            except asyncio.CancelledError:
+                pass  # Expected during signal-driven shutdown
             except Exception:
                 logger = LoggingConfig.get_logger(__name__)
                 logger.error("Error in main", exc_info=True)
@@ -461,6 +483,11 @@ def cli(
                     logger = LoggingConfig.get_logger(__name__)
                     logger.error("Error during final cleanup", exc_info=True)
                 finally:
+                    if stdin_executor is not None:
+                        try:
+                            stdin_executor.shutdown(wait=False)
+                        except Exception:
+                            pass
                     loop.close()
                     logger = LoggingConfig.get_logger(__name__)
                     logger.info("Server shutdown complete")

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/engine/core.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/engine/core.py
@@ -445,7 +445,8 @@ class SearchEngine:
                     query=query, limit=limit
                 )
             else:
-                search_results = await self._search_ops.search(query, limit=limit)
+                async with self._search_semaphore:
+                    search_results = await self._search_ops.search(query, limit=limit)
 
             # Use the hybrid search engine's suggestion method
             if hasattr(self.hybrid_search, "suggest_facet_refinements"):
@@ -479,9 +480,10 @@ class SearchEngine:
 
         # If query is provided, perform search to get documents
         if query is not None:
-            search_results = await self._search_ops.search(
-                query, source_types, limit, project_ids
-            )
+            async with self._search_semaphore:
+                search_results = await self._search_ops.search(
+                    query, source_types, limit, project_ids
+                )
 
             # Check if we have sufficient documents for relationship analysis
             if len(search_results) < 2:
@@ -556,16 +558,18 @@ class SearchEngine:
             raise RuntimeError("Search engine not initialized")
 
         # First, search for target documents
-        target_documents = await self._search_ops.search(
-            target_query, source_types, 1, project_ids
-        )
+        async with self._search_semaphore:
+            target_documents = await self._search_ops.search(
+                target_query, source_types, 1, project_ids
+            )
         if not target_documents:
             return {}
 
         # Then search for comparison documents
-        comparison_documents = await self._search_ops.search(
-            comparison_query or target_query, source_types, limit, project_ids
-        )
+        async with self._search_semaphore:
+            comparison_documents = await self._search_ops.search(
+                comparison_query or target_query, source_types, limit, project_ids
+            )
 
         # Use the hybrid search engine's method to find similarities
         # API expects a single target document and a list of comparison documents.
@@ -632,9 +636,10 @@ class SearchEngine:
             raise RuntimeError("Search engine not initialized")
 
         # First, search for documents related to the query
-        search_results = await self._search_ops.search(
-            query, source_types, limit, project_ids
-        )
+        async with self._search_semaphore:
+            search_results = await self._search_ops.search(
+                query, source_types, limit, project_ids
+            )
 
         # Check if we have sufficient documents for conflict detection
         if len(search_results) < 2:
@@ -734,9 +739,10 @@ class SearchEngine:
         if isinstance(strategy, str):
             if strategy == "adaptive":
                 # First, get documents to analyze for optimal strategy selection
-                documents = await self._search_ops.search(
-                    query, source_types, limit, project_ids
-                )
+                async with self._search_semaphore:
+                    documents = await self._search_ops.search(
+                        query, source_types, limit, project_ids
+                    )
                 optimal_strategy = self._select_optimal_strategy(documents)
                 strategy_map = {
                     "mixed_features": ClusteringStrategy.MIXED_FEATURES,

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/orchestration/search.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/orchestration/search.py
@@ -41,17 +41,15 @@ async def run_search(
     combined_results: list[HybridSearchResult]
     fetch_limit = limit
 
-    # Build a request-scoped combiner clone to avoid mutating shared engine state
+    # Resolve effective weights first so the combiner's internal scorer
+    # is built with the final values (scorer snapshots weights at construction).
     base_combiner = engine.result_combiner
-    local_combiner = ResultCombiner(
-        vector_weight=getattr(base_combiner, "vector_weight", 0.6),
-        keyword_weight=getattr(base_combiner, "keyword_weight", 0.3),
-        metadata_weight=getattr(base_combiner, "metadata_weight", 0.1),
-        min_score=getattr(base_combiner, "min_score", 0.3),
-        spacy_analyzer=getattr(base_combiner, "spacy_analyzer", None),
-    )
+    vector_weight = getattr(base_combiner, "vector_weight", 0.6)
+    keyword_weight = getattr(base_combiner, "keyword_weight", 0.3)
+    metadata_weight = getattr(base_combiner, "metadata_weight", 0.1)
+    min_score = getattr(base_combiner, "min_score", 0.3)
 
-    # Intent classification and adaptive adjustments (applied to local combiner only)
+    # Intent classification and adaptive adjustments
     search_intent = None
     adaptive_config = None
     if engine.enable_intent_adaptation and engine.intent_classifier:
@@ -60,10 +58,19 @@ async def run_search(
         )
         adaptive_config = engine.adaptive_strategy.adapt_search(search_intent, query)
         if adaptive_config:
-            local_combiner.vector_weight = adaptive_config.vector_weight
-            local_combiner.keyword_weight = adaptive_config.keyword_weight
-            local_combiner.min_score = adaptive_config.min_score_threshold
+            vector_weight = adaptive_config.vector_weight
+            keyword_weight = adaptive_config.keyword_weight
+            min_score = adaptive_config.min_score_threshold
             fetch_limit = min(adaptive_config.max_results, limit * 2)
+
+    # Build combiner with final resolved weights (scorer will use these)
+    local_combiner = ResultCombiner(
+        vector_weight=vector_weight,
+        keyword_weight=keyword_weight,
+        metadata_weight=metadata_weight,
+        min_score=min_score,
+        spacy_analyzer=getattr(base_combiner, "spacy_analyzer", None),
+    )
 
     # TODO: Evaluate the expanded_query logic to see it's impacts on vector and keyword searches
     expanded_query = await engine._expand_query(query)

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/transport/routes.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/transport/routes.py
@@ -31,6 +31,13 @@ async def handle_mcp_post(
             "error": {"code": -32700, "message": "Invalid JSON in request"},
         }
 
+    if not isinstance(body, dict):
+        return {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32600, "message": "Invalid Request"},
+        }
+
     try:
         logger.debug("Processing MCP request: %s", body.get("method", "unknown"))
         response = await mcp_handler.handle_request(body, headers=dict(request.headers))

--- a/packages/qdrant-loader-mcp-server/tests/unit/search/test_result_combiner_comprehensive.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/search/test_result_combiner_comprehensive.py
@@ -855,3 +855,25 @@ class TestEdgeCasesAndErrorHandling:
         # Should be sorted by score
         scores = [result.score for result in combined]
         assert scores == sorted(scores, reverse=True)
+
+
+class TestResultCombinerWeightsSync:
+    """Verify _scorer gets adaptive weights, not base weights."""
+
+    def test_scorer_uses_constructor_weights(self):
+        combiner = ResultCombiner(vector_weight=0.8, keyword_weight=0.15)
+        assert combiner._scorer.vector_weight == 0.8
+        assert combiner._scorer.keyword_weight == 0.15
+
+    def test_post_construction_weight_change_not_reflected_in_scorer(self):
+        """Changing weights after construction does NOT update _scorer."""
+        combiner = ResultCombiner(vector_weight=0.6, keyword_weight=0.3)
+        combiner.vector_weight = 0.9
+        assert combiner._scorer.vector_weight == 0.6  # Stale
+        assert combiner.vector_weight == 0.9
+
+    def test_creating_combiner_with_final_weights_works(self):
+        """The fix: create combiner with resolved weights so _scorer is correct."""
+        combiner = ResultCombiner(vector_weight=0.85, keyword_weight=0.1)
+        assert combiner._scorer.vector_weight == 0.85
+        assert combiner._scorer.keyword_weight == 0.1

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_cli.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_cli.py
@@ -606,3 +606,41 @@ class TestCLICommand:
 
         assert result.exit_code != 0
         assert "does not exist" in result.output
+
+
+class TestReadStdinLinesClosedStdin:
+    """read_stdin_lines should handle closed stdin gracefully."""
+
+    @pytest.mark.asyncio
+    async def test_breaks_on_value_error(self):
+        """When stdin is closed, readline raises ValueError -- should break."""
+        mock_executor = MagicMock()
+
+        async def mock_run_in_executor(executor, func):
+            raise ValueError("I/O operation on closed file")
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = mock_run_in_executor
+            lines = []
+            async for line in read_stdin_lines(mock_executor):
+                lines.append(line)
+            assert lines == []
+
+    @pytest.mark.asyncio
+    async def test_breaks_on_eof(self):
+        """When stdin returns empty string (EOF), should break."""
+        call_count = 0
+
+        async def mock_run_in_executor(executor, func):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return '{"method": "test"}\n'
+            return ""
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = mock_run_in_executor
+            lines = []
+            async for line in read_stdin_lines():
+                lines.append(line)
+            assert len(lines) == 1

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_http_transport.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_http_transport.py
@@ -272,3 +272,54 @@ class TestHTTPTransportErrorHandling:
         )
 
         assert response.status_code == 503
+
+
+class TestNonDictBodyReturns32600:
+    """Non-dict JSON body should return -32600 (Invalid Request), not -32603."""
+
+    @pytest.fixture
+    def mcp_app_simple(self, mock_mcp_handler):
+        """App with handler that returns OK (for testing body validation path)."""
+        mock_mcp_handler.handle_request = AsyncMock(
+            return_value={"jsonrpc": "2.0", "result": "ok", "id": 1}
+        )
+        app = FastAPI()
+        app.state.mcp_handler = mock_mcp_handler
+        app.include_router(mcp_router)
+        return app
+
+    @pytest.fixture
+    def simple_client(self, mcp_app_simple):
+        return TestClient(mcp_app_simple, raise_server_exceptions=False)
+
+    def test_array_body_returns_invalid_request(self, simple_client):
+        response = simple_client.post("/mcp", json=[1, 2, 3])
+        data = response.json()
+        assert data["error"]["code"] == -32600
+        assert data["id"] is None
+
+    def test_string_body_returns_invalid_request(self, simple_client):
+        response = simple_client.post("/mcp", json="ping")
+        assert response.json()["error"]["code"] == -32600
+
+    def test_number_body_returns_invalid_request(self, simple_client):
+        response = simple_client.post("/mcp", json=42)
+        assert response.json()["error"]["code"] == -32600
+
+    def test_null_body_returns_parse_error(self, simple_client):
+        """json=None sends empty body -> JSONDecodeError -> -32700."""
+        response = simple_client.post("/mcp", json=None)
+        assert response.json()["error"]["code"] == -32700
+
+    def test_dict_body_passes_through(self, simple_client):
+        response = simple_client.post(
+            "/mcp", json={"jsonrpc": "2.0", "method": "test", "id": 1}
+        )
+        data = response.json()
+        assert "error" not in data or data.get("result") == "ok"
+
+    def test_invalid_json_returns_parse_error(self, simple_client):
+        response = simple_client.post(
+            "/mcp", content=b"not json", headers={"content-type": "application/json"}
+        )
+        assert response.json()["error"]["code"] == -32700

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -1,5 +1,6 @@
 """Semantic analysis module for text processing."""
 
+import hashlib
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -97,7 +98,8 @@ class SemanticAnalyzer:
             SemanticAnalysisResult containing all analysis results
         """
         # Check cache
-        cache_key = (doc_id, include_enhanced) if doc_id else None
+        text_fingerprint = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+        cache_key = (doc_id, text_fingerprint, include_enhanced) if doc_id else None
         if cache_key and cache_key in self._doc_cache:
             cached = self._doc_cache[cache_key]
             if include_enhanced:

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -293,7 +293,7 @@ class TestSemanticAnalyzer:
             assert result1.entities == result2.entities
             assert result1.pos_tags == result2.pos_tags
             assert result1.topics == result2.topics
-            assert ("doc1", True) in analyzer._doc_cache
+            assert any(k[0] == "doc1" for k in analyzer._doc_cache)
 
     def test_analyze_text_without_enhanced_fields(self, mock_nlp, mock_doc):
         """Test text analysis short-circuits enhanced computations when disabled."""
@@ -321,7 +321,7 @@ class TestSemanticAnalyzer:
             mock_pos_tags.assert_not_called()
             mock_dependencies.assert_not_called()
             mock_similarity.assert_not_called()
-            assert ("doc2", False) in analyzer._doc_cache
+            assert any(k[0] == "doc2" for k in analyzer._doc_cache)
 
     def test_extract_entities(self, mock_nlp, mock_doc):
         """Test entity extraction."""
@@ -765,8 +765,8 @@ class TestSemanticAnalyzer:
             assert result_enhanced_false is not result_enhanced_true
 
             # Cache should have separate keys
-            assert ("same_doc", False) in analyzer._doc_cache
-            assert ("same_doc", True) in analyzer._doc_cache
+            assert any(k[0] == "same_doc" and k[-1] is False for k in analyzer._doc_cache)
+            assert any(k[0] == "same_doc" and k[-1] is True for k in analyzer._doc_cache)
 
             # Verify enhanced fields differ
             assert len(result_enhanced_false.pos_tags) == 0
@@ -982,4 +982,35 @@ class TestSemanticAnalyzer:
                 assert isinstance(result.document_similarity, dict)
 
                 # Verify caching
-                assert ("test_doc", True) in analyzer._doc_cache
+                assert any(k[0] == "test_doc" for k in analyzer._doc_cache)
+
+
+class TestCacheKeyFingerprint:
+    """Cache key must include text content hash to prevent stale results."""
+
+    def test_same_doc_id_different_text_different_cache_key(self):
+        import hashlib
+
+        doc_id = "chunk_0"
+        text_a = "Apple Inc was founded in 1976"
+        text_b = "Microsoft Corporation was founded in 1975"
+
+        fp_a = hashlib.sha256(text_a.encode("utf-8")).hexdigest()[:16]
+        fp_b = hashlib.sha256(text_b.encode("utf-8")).hexdigest()[:16]
+
+        key_a = (doc_id, fp_a, False)
+        key_b = (doc_id, fp_b, False)
+        assert key_a != key_b, "Different text should produce different cache keys"
+
+    def test_same_doc_id_same_text_same_cache_key(self):
+        import hashlib
+
+        doc_id = "chunk_0"
+        text = "Same content"
+
+        fp1 = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+        fp2 = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+        key1 = (doc_id, fp1, False)
+        key2 = (doc_id, fp2, False)
+        assert key1 == key2, "Same text should produce same cache key"


### PR DESCRIPTION
## Summary
- **routes.py**: Return JSON-RPC `-32600` (Invalid Request) for non-dict body instead of `-32603` (Internal Error)
- **search/orchestration**: Resolve adaptive weights before `ResultCombiner` construction so internal `_scorer` uses final values
- **search/engine**: Wrap all `_search_ops.search()` calls with `_search_semaphore` to enforce concurrency throttling consistently
- **cli.py**: Cancel `handle_stdio` task on SIGINT/SIGTERM and close stdin to unblock executor thread
- **semantic_analyzer**: Add SHA-256 text fingerprint to cache key to prevent stale results when same `doc_id` is reused

## Test plan
- [x] 13 new unit tests added (in correct scope files, not monolithic)
- [x] 4 existing semantic_analyzer tests fixed for new cache key format
- [x] Full test suite: 2763 tests pass (1752 qdrant-loader + 1011 mcp-server)
- [x] Ruff lint + format: clean
- [ ] Manual: send SIGINT to stdio mode, verify exit within 3s
- [ ] Manual: send `[]` body to `/mcp` endpoint, verify `-32600` response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown and stdin handling for more reliable server cleanup
  * Added early validation for malformed requests to prevent downstream errors

* **Performance**
  * Added concurrency limiting for search operations to reduce contention
  * Improved semantic-analysis caching to better key results by content
  * Refined search parameter resolution for more predictable result weighting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->