### PR TITLE
fix: add fingeerprint into key for fixing stale-hit

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -1,5 +1,6 @@
 """Semantic analysis module for text processing."""
 
+import hashlib
 import logging
 import threading
 from dataclasses import dataclass
@@ -81,6 +82,20 @@ class SemanticAnalyzer:
         self._doc_cache: dict = {}
         self._doc_cache_lock = threading.Lock()
 
+    def _build_cache_key(
+        self, text: str, doc_id: str | None, include_enhanced: bool
+    ) -> tuple[str, bool, str] | None:
+        """Build a cache key that includes a content fingerprint.
+
+        Including a fingerprint prevents stale cache hits when the same doc_id
+        is reused with different content.
+        """
+        if not doc_id:
+            return None
+
+        text_fingerprint = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        return (doc_id, include_enhanced, text_fingerprint)
+
     def analyze_text(
         self,
         text: str,
@@ -99,7 +114,7 @@ class SemanticAnalyzer:
             SemanticAnalysisResult containing all analysis results
         """
         # Check cache
-        cache_key = (doc_id, include_enhanced) if doc_id else None
+        cache_key = self._build_cache_key(text, doc_id, include_enhanced)
 
         # Protected read
         with self._doc_cache_lock:

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -877,6 +877,37 @@ class TestSemanticAnalyzer:
             assert len(result_enhanced_false.pos_tags) == 0
             assert len(result_enhanced_true.pos_tags) > 0
 
+    def test_analyze_text_same_doc_id_changed_text_recomputes(self, mock_nlp, mock_doc):
+        """Test that changed text with same doc_id does not hit stale cache."""
+        with (
+            patch("spacy.load", return_value=mock_nlp),
+            patch.object(SemanticAnalyzer, "_extract_topics", return_value=[]),
+            patch.object(
+                SemanticAnalyzer, "_calculate_document_similarity", return_value={}
+            ),
+            patch.object(
+                SemanticAnalyzer,
+                "_extract_entities",
+                side_effect=[
+                    [{"text": "Apple", "label": "ORG"}],
+                    [{"text": "Microsoft", "label": "ORG"}],
+                ],
+            ),
+        ):
+            mock_nlp.return_value = mock_doc
+            analyzer = SemanticAnalyzer()
+
+            result1 = analyzer.analyze_text(
+                "Apple is a company", doc_id="chunk_0", include_enhanced=False
+            )
+            result2 = analyzer.analyze_text(
+                "Microsoft is a company", doc_id="chunk_0", include_enhanced=False
+            )
+
+            assert result1.entities[0]["text"] == "Apple"
+            assert result2.entities[0]["text"] == "Microsoft"
+            assert len(analyzer._doc_cache) == 2
+
     def test_analyze_text_cache_hit_refreshes_similarity(self, mock_nlp, mock_doc):
         """Test that cache hit with include_enhanced=True refreshes similarity."""
         with (


### PR DESCRIPTION
# Pull Request

## Summary

 add fingeerprint into key for fixing stale hits

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache handling in semantic analysis to ensure accurate results when the same document ID is associated with different content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->