### PR TITLE
feat: add enable_file_conversion=true to setup wizard generated config

### DIFF
--- a/packages/qdrant-loader/conf/config.simplified.template.yaml
+++ b/packages/qdrant-loader/conf/config.simplified.template.yaml
@@ -31,6 +31,7 @@ sources:
         - "*.txt"
         - "*.py"
       max_file_size: 1048576  # 1MB
+      enable_file_conversion: true
 
   # --- Git Repository (uncomment to enable) ---
   # git:
@@ -41,6 +42,7 @@ sources:
   #     file_types:
   #       - "*.md"
   #       - "*.py"
+  #     enable_file_conversion: true
 
   # --- Confluence (uncomment to enable) ---
   # confluence:
@@ -49,6 +51,7 @@ sources:
   #     space_key: "YOUR_SPACE"
   #     token: "${CONFLUENCE_TOKEN}"
   #     email: "${CONFLUENCE_EMAIL}"
+  #     enable_file_conversion: true
 
   # --- Jira (uncomment to enable) ---
   # jira:
@@ -57,6 +60,7 @@ sources:
   #     project_key: "YOUR_PROJECT"
   #     token: "${JIRA_TOKEN}"
   #     email: "${JIRA_EMAIL}"
+  #     enable_file_conversion: true
 
   # --- Public Documentation (uncomment to enable) ---
   # publicdocs:

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
@@ -198,6 +198,7 @@ def run_setup_default(output_dir: Path) -> None:
             "my-docs": {
                 "base_url": docs_path,
                 "file_types": ["*.md", "*.txt", "*.py"],
+                "enable_file_conversion": True,
             }
         }
     }
@@ -696,6 +697,7 @@ def _collect_git_config(source_name: str) -> _SourceResult:
         "base_url": url,
         "branch": branch,
         "file_types": file_types,
+        "enable_file_conversion": True,
     }
     extra_env: dict[str, str] = {}
 
@@ -730,6 +732,7 @@ def _collect_confluence_config(source_name: str) -> _SourceResult:
         "space_key": space_key,
         "token": f"${{{token_key}}}",
         "email": f"${{{email_key}}}",
+        "enable_file_conversion": True,
     }
     extra_env: dict[str, str] = {
         token_key: token,
@@ -758,6 +761,7 @@ def _collect_jira_config(source_name: str) -> _SourceResult:
         "project_key": project_key,
         "token": f"${{{token_key}}}",
         "email": f"${{{email_key}}}",
+        "enable_file_conversion": True,
     }
     extra_env: dict[str, str] = {
         token_key: token,
@@ -821,6 +825,7 @@ def _collect_localfile_config(
     config: dict[str, Any] = {
         "base_url": path,
         "file_types": file_types,
+        "enable_file_conversion": True,
     }
     return config, {}
 

--- a/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
+++ b/packages/qdrant-loader/tests/unit/cli/test_setup_cmd.py
@@ -188,6 +188,7 @@ class TestRunSetupWizardCreatesFiles:
         assert src["base_url"] == "https://docs.example.com/"
         assert src["version"] == "latest"
         assert src["content_type"] == "html"
+        assert "enable_file_conversion" not in src
 
     def test_run_setup_wizard_localfile_source(self, tmp_path: Path) -> None:
         """Test that localfile source gets the file:// prefix applied."""
@@ -444,6 +445,7 @@ class TestRunSetupDefault:
         # Should point to the docs subdirectory of the workspace
         assert src["base_url"].endswith("/docs")
         assert src["file_types"] == ["*.md", "*.txt", "*.py"]
+        assert src["enable_file_conversion"] is True
         # docs directory should be created
         assert (tmp_path / "docs").is_dir()
 
@@ -829,6 +831,7 @@ class TestCollectGitConfig:
         assert config["base_url"] == "https://github.com/org/repo.git"
         assert config["branch"] == "main"
         assert config["file_types"] == ["*.md", "*.txt"]
+        assert config["enable_file_conversion"] is True
 
     def test_collect_git_config_no_token(self) -> None:
         prompt_side_effects = [
@@ -843,6 +846,7 @@ class TestCollectGitConfig:
 
         assert "token" not in config
         assert extra_env == {}
+        assert config["enable_file_conversion"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -859,6 +863,7 @@ class TestCollectLocalfileConfig:
 
         assert config["base_url"].startswith("file:///")
         assert config["base_url"].endswith("/home/user/docs")
+        assert config["enable_file_conversion"] is True
         assert extra_env == {}
 
     def test_collect_localfile_preserves_existing_prefix(self) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

Add `enable_file_conversion: true` to all config files generated by the setup wizard and to the simplified config template, preventing silent failure when users load binary files (PDF, DOCX, XLSX).

## Problem

When users run `qdrant-loader setup`, the generated config YAML does not include `enable_file_conversion: true`. If users then ingest binary files, they get garbage text in chunks with no error or warning (silent failure).

## Changes

### `setup_cmd.py` — 5 locations:
- `run_setup_default()`: add to localfile source dict
- `_collect_localfile_config()`: add to config dict
- `_collect_git_config()`: add to config dict
- `_collect_confluence_config()`: add to config dict
- `_collect_jira_config()`: add to config dict
- **Not added** to `_collect_publicdocs_config()` (HTML crawler, no file conversion)

### `config.simplified.template.yaml`:
- Added `enable_file_conversion: true` for localfile, git, confluence, jira sections
- **Not added** for publicdocs

### `test_setup_cmd.py`:
- Added assertions to verify `enable_file_conversion` is present in generated config
- Added assertion to verify publicdocs does NOT include it

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Out of Scope
- Python default in `source_config.py` remains `False`
- `quick-start.md` not modified (manual config, not related to setup command)
- No runtime behavior changes

## Testing

```bash
cd packages/qdrant-loader && python -m pytest tests/unit/cli/test_setup_cmd.py -v
# 52 passed in 0.72s
```

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (`ruff check`)
- [ ] Documentation updated (if applicable)

Resolves: AIKH-1520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled automatic file conversion functionality across multiple data sources, including local files, Git repositories, Confluence, and Jira integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->