### PR TITLE
docs: add setup command to CLI reference and quick-start guide

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -25,9 +25,23 @@ Before starting, ensure you have:
 
 ## 🚀 Step 1: Initial Configuration
 
-### Set Up Workspace Directory
+### Option A: Use the Setup Wizard (Recommended)
 
-Create a workspace directory for your QDrant Loader project:
+The fastest way to get started is with the built-in setup wizard:
+
+```bash
+# Create and configure a workspace in one step
+qdrant-loader setup --output-dir my-qdrant-workspace --mode default
+cd my-qdrant-workspace
+```
+
+This generates `config.yaml`, `.env`, and a `docs/` directory ready for your documents. Edit the `.env` file to add your actual API keys, then skip to [Step 2](#-step-2-initialize-and-ingest).
+
+For more control over sources (Git, Confluence, Jira), use `--mode normal` instead. See the [CLI Reference](../users/cli-reference/commands.md#qdrant-loader-setup) for all options.
+
+### Option B: Manual Configuration
+
+Create a workspace directory for your QDrant Loader project manually:
 
 ```bash
 # Create workspace directory

--- a/docs/users/cli-reference/commands.md
+++ b/docs/users/cli-reference/commands.md
@@ -9,8 +9,74 @@ QDrant Loader provides a focused command-line interface for data ingestion and m
 ### Available Commands
 
 ```text
+🚀 Setup          - setup (interactive config generation)
 📊 Data Management - init, ingest
-🔧 Configuration - config (includes project information)
+🔧 Configuration  - config (includes project information)
+```
+
+## 🚀 Setup Command
+
+### `qdrant-loader setup`
+
+Interactive setup wizard that generates `config.yaml` and `.env` files for your workspace. This is the fastest way to get started with QDrant Loader.
+
+#### Basic Usage
+
+```bash
+# Interactive mode — prompts for workspace folder and setup mode
+qdrant-loader setup
+
+# Quick start with defaults (localfile source pointing to ./docs)
+qdrant-loader setup --output-dir ./my-workspace --mode default
+
+# Interactive wizard with source selection
+qdrant-loader setup --output-dir ./my-workspace --mode normal
+
+# Full control over global settings and multi-project config
+qdrant-loader setup --output-dir ./my-workspace --mode advanced
+```
+
+#### Options
+
+- `--output-dir PATH` - Directory to write `config.yaml` and `.env` files to. If omitted, you are prompted interactively.
+- `--mode [default|normal|advanced]` - Setup mode. If omitted, a TUI selector is shown.
+
+#### Setup Modes
+
+| Mode | Description | Best For |
+|------|-------------|----------|
+| **default** | Creates a localfile source pointing to `<workspace>/docs/` with no prompts | Quick start, testing |
+| **normal** | Interactive wizard — prompts for Qdrant URL, API keys, and data sources (git, confluence, jira, publicdocs, localfile) | Most users |
+| **advanced** | Full control — configure embedding model, vector size, chunking, reranking, and multi-project setup | Production deployments |
+
+#### What Gets Generated
+
+```text
+<output-dir>/
+├── config.yaml    # Configuration with your selected sources
+├── .env           # Environment variables (API keys, credentials)
+└── docs/          # (default mode only) Directory for local documents
+```
+
+All source configurations include `enable_file_conversion: true` by default, enabling automatic conversion of PDF, DOCX, XLSX, and other binary formats.
+
+#### Examples
+
+```bash
+# Set up a workspace for ingesting local documentation
+qdrant-loader setup --output-dir ./docs-workspace --mode default
+cd docs-workspace
+# Place your documents in the docs/ folder, then:
+qdrant-loader init --workspace .
+qdrant-loader ingest --workspace .
+
+# Set up with Confluence and Git sources
+qdrant-loader setup --output-dir ./team-kb --mode normal
+# Follow the prompts to configure each source
+
+# Advanced multi-project setup
+qdrant-loader setup --output-dir ./production --mode advanced
+# Configure embedding model, chunking strategy, and multiple projects
 ```
 
 ## 📊 Data Management Commands


### PR DESCRIPTION
# Pull Request

## Summary

Add documentation for the `qdrant-loader setup` command, which currently has zero docs coverage. The setup wizard is the fastest way for new users to get started but was completely undocumented.

## Changes

### `docs/users/cli-reference/commands.md`
- Add `## 🚀 Setup Command` section with usage, options, 3 modes (default/normal/advanced), generated output structure, and examples
- Update "Available Commands" list to include setup

### `docs/getting-started/quick-start.md`
- Add "Option A: Use the Setup Wizard (Recommended)" before manual config path
- Existing manual config renamed to "Option B: Manual Configuration"
- Link to CLI reference for detailed setup options

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Docs update
- [ ] Chore

## Docs Impact

- [x] Does this change require docs updates? Yes — this IS the docs update
- [x] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker?
- [x] Did you avoid banned placeholders?

## Testing

Verified markdown renders correctly. No code changes.

## Checklist

- [x] Linting passes
- [x] Documentation updated
- [x] Follows style-guide.md conventions
- [x] Content in English (matching repo convention)

Resolves: AIKH-1521