### PR TITLE
fix:Respect enable_semantic_analysis across chunking strategies

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/base_strategy.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/base_strategy.py
@@ -63,8 +63,15 @@ class BaseChunkingStrategy(ABC):
         if self.chunk_overlap >= self.chunk_size:
             raise ValueError("Chunk overlap must be less than chunk size")
 
-        # Initialize text processor
-        self.text_processor = TextProcessor(settings)
+        # Master switch for NLP metadata extraction across all strategies.
+        self._semantic_analysis_enabled = bool(
+            getattr(settings.global_config.chunking, "enable_semantic_analysis", True)
+        )
+
+        # Initialize text processor only when NLP metadata extraction is enabled.
+        self.text_processor = (
+            TextProcessor(settings) if self._semantic_analysis_enabled else None
+        )
 
     def _count_tokens(self, text: str) -> int:
         """Count the number of tokens in a text string."""
@@ -82,6 +89,9 @@ class BaseChunkingStrategy(ABC):
         Returns:
             dict: Processed text features
         """
+        if self.text_processor is None:
+            return {"tokens": [], "entities": [], "pos_tags": [], "chunks": []}
+
         return self.text_processor.process_text(text)
 
     def _should_apply_nlp(
@@ -371,7 +381,8 @@ class BaseChunkingStrategy(ABC):
             content_type = "md"
 
         should_apply_nlp = (
-            not skip_nlp
+            self._semantic_analysis_enabled
+            and not skip_nlp
             and len(chunk_content) <= 10000  # Size limit
             and total_chunks <= 50  # Chunk count limit
             and self._should_apply_nlp(chunk_content, file_path, content_type)
@@ -380,7 +391,9 @@ class BaseChunkingStrategy(ABC):
         if not should_apply_nlp:
             # Skip NLP processing
             skip_reason = "performance_optimization"
-            if len(chunk_content) > 10000:
+            if not self._semantic_analysis_enabled:
+                skip_reason = "semantic_analysis_disabled"
+            elif len(chunk_content) > 10000:
                 skip_reason = "chunk_too_large"
             elif total_chunks > 50:
                 skip_reason = "too_many_chunks"

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/base_strategy.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/base_strategy.py
@@ -380,12 +380,14 @@ class BaseChunkingStrategy(ABC):
             file_path = "converted.md"  # Use .md extension for NLP decision
             content_type = "md"
 
+        nlp_applicable = self._should_apply_nlp(chunk_content, file_path, content_type)
+
         should_apply_nlp = (
             self._semantic_analysis_enabled
             and not skip_nlp
             and len(chunk_content) <= 10000  # Size limit
             and total_chunks <= 50  # Chunk count limit
-            and self._should_apply_nlp(chunk_content, file_path, content_type)
+            and nlp_applicable
         )
 
         if not should_apply_nlp:
@@ -397,7 +399,7 @@ class BaseChunkingStrategy(ABC):
                 skip_reason = "chunk_too_large"
             elif total_chunks > 50:
                 skip_reason = "too_many_chunks"
-            elif not self._should_apply_nlp(chunk_content, file_path, content_type):
+            elif not nlp_applicable:
                 skip_reason = "content_type_inappropriate"
 
             metadata.update(

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/default/text_chunk_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/default/text_chunk_processor.py
@@ -41,6 +41,17 @@ class TextChunkProcessor(BaseChunkProcessor):
         text_metadata = self._create_text_specific_metadata(chunk_content, original_doc)
         base_metadata.update(text_metadata)
 
+        # Always set NLP-state metadata so consumers can rely on these keys
+        if not self._semantic_analysis_enabled:
+            base_metadata.update(
+                {
+                    "entities": [],
+                    "pos_tags": [],
+                    "nlp_skipped": True,
+                    "skip_reason": "semantic_analysis_disabled",
+                }
+            )
+
         # Create chunk document
         chunk_doc = Document(
             id=chunk_id,

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/default/text_chunk_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/default/text_chunk_processor.py
@@ -51,6 +51,17 @@ class TextChunkProcessor(BaseChunkProcessor):
                     "skip_reason": "semantic_analysis_disabled",
                 }
             )
+        else:
+            # Initialize with defaults when semantic analysis is enabled
+            # These will be updated if actual NLP processing occurs
+            base_metadata.update(
+                {
+                    "entities": [],
+                    "pos_tags": [],
+                    "nlp_skipped": False,
+                    "skip_reason": None,
+                }
+            )
 
         # Create chunk document
         chunk_doc = Document(

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/metadata_extractor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/metadata_extractor.py
@@ -139,6 +139,13 @@ class MetadataExtractor:
             settings: Configuration settings containing markdown strategy config
         """
         self.settings = settings
+        self._semantic_analysis_enabled = bool(
+            getattr(
+                getattr(getattr(settings, "global_config", None), "chunking", None),
+                "enable_semantic_analysis",
+                True,
+            )
+        )
         self.cross_reference_extractor = CrossReferenceExtractor()
         self.entity_extractor = EntityExtractor()
         self.hierarchy_extractor = HierarchyExtractor()
@@ -163,16 +170,20 @@ class MetadataExtractor:
             self.cross_reference_extractor.extract_cross_references(chunk_content)
         )
 
-        # Extract entities
-        metadata["entities"] = self.entity_extractor.extract_entities(chunk_content)
+        # Respect global semantic-analysis master switch.
+        if self._semantic_analysis_enabled:
+            metadata["entities"] = self.entity_extractor.extract_entities(chunk_content)
+            metadata["topic_analysis"] = self.topic_analyzer.analyze_topic(
+                chunk_content
+            )
+        else:
+            metadata["entities"] = []
+            metadata["topic_analysis"] = {"topics": [], "coherence": 0.0}
 
         # Extract hierarchical relationships
         metadata["hierarchy"] = self.hierarchy_extractor.map_hierarchical_relationships(
             chunk_content
         )
-
-        # Analyze topics
-        metadata["topic_analysis"] = self.topic_analyzer.analyze_topic(chunk_content)
 
         return metadata
 

--- a/packages/qdrant-loader/tests/integration/core/test_chunking_consistency.py
+++ b/packages/qdrant-loader/tests/integration/core/test_chunking_consistency.py
@@ -314,3 +314,56 @@ This concludes the documentation with a summary of all the topics covered and re
                 assert (
                     len(chunk.content) <= max_size + 50
                 ), f"Chunk {i} too large: {len(chunk.content)} chars (max: {max_size} + boundary tolerance)"
+
+    def test_semantic_master_switch_disables_nlp_metadata_across_strategies(
+        self, mock_settings, test_document
+    ):
+        """Test that enable_semantic_analysis=False disables NLP metadata for all strategies."""
+        mock_settings.global_config.chunking.enable_semantic_analysis = False
+        mock_settings.global_config.chunking.enable_enhanced_semantic_analysis = False
+
+        with (
+            patch(
+                "qdrant_loader.core.chunking.strategy.base_strategy.tiktoken"
+            ) as mock_tiktoken,
+            patch(
+                "qdrant_loader.core.chunking.strategy.base_strategy.TextProcessor"
+            ) as mock_text_processor,
+            patch("spacy.load") as mock_spacy_load,
+        ):
+            # Keep tokenizer behavior deterministic for both strategies.
+            mock_encoding = Mock()
+            mock_encoding.encode.side_effect = lambda text: list(
+                range(len(text.split()))
+            )
+            mock_encoding.decode.side_effect = lambda tokens: "decoded_text"
+            mock_tiktoken.get_encoding.return_value = mock_encoding
+
+            # Avoid real spaCy load in this integration assertion.
+            mock_nlp = Mock()
+            mock_nlp.pipe_names = []
+            mock_spacy_load.return_value = mock_nlp
+
+            default_strategy = DefaultChunkingStrategy(mock_settings)
+            markdown_strategy = MarkdownChunkingStrategy(mock_settings)
+
+            default_chunks = default_strategy.chunk_document(test_document)
+            markdown_chunks = markdown_strategy.chunk_document(test_document)
+
+            assert len(default_chunks) > 0
+            assert len(markdown_chunks) > 0
+
+            # Base strategy should mark NLP as skipped when semantic master switch is off.
+            for chunk in default_chunks:
+                assert chunk.metadata.get("entities") == []
+                assert chunk.metadata.get("pos_tags") == []
+                assert chunk.metadata.get("nlp_skipped") is True
+                assert chunk.metadata.get("skip_reason") == "semantic_analysis_disabled"
+
+            # Markdown strategy should also produce no semantic entities/pos_tags.
+            for chunk in markdown_chunks:
+                assert chunk.metadata.get("entities") == []
+                assert chunk.metadata.get("pos_tags", []) == []
+
+            # No TextProcessor should be created when semantic analysis is disabled.
+            mock_text_processor.assert_not_called()

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_markdown_metadata_extractor.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_markdown_metadata_extractor.py
@@ -1,0 +1,45 @@
+"""Tests for markdown metadata extractor semantic toggle behavior."""
+
+from unittest.mock import Mock
+
+from qdrant_loader.core.chunking.strategy.markdown.metadata_extractor import (
+    MetadataExtractor,
+)
+
+
+def _build_settings(enable_semantic_analysis: bool):
+    settings = Mock()
+    settings.global_config = Mock()
+    settings.global_config.chunking = Mock()
+    settings.global_config.chunking.enable_semantic_analysis = enable_semantic_analysis
+    settings.global_config.chunking.strategies = Mock()
+    settings.global_config.chunking.strategies.markdown = Mock()
+    settings.global_config.chunking.strategies.markdown.words_per_minute_reading = 200
+    return settings
+
+
+def test_extract_all_metadata_semantic_disabled_returns_no_entities_or_topics():
+    settings = _build_settings(enable_semantic_analysis=False)
+    extractor = MetadataExtractor(settings)
+
+    metadata = extractor.extract_all_metadata(
+        "This is a sample text with Microsoft and Apple.",
+        {"title": "Section"},
+    )
+
+    assert metadata["entities"] == []
+    assert metadata["topic_analysis"] == {"topics": [], "coherence": 0.0}
+
+
+def test_extract_all_metadata_semantic_enabled_keeps_entity_extraction():
+    settings = _build_settings(enable_semantic_analysis=True)
+    extractor = MetadataExtractor(settings)
+
+    metadata = extractor.extract_all_metadata(
+        "This is a sample text with Microsoft and Apple.",
+        {"title": "Section"},
+    )
+
+    assert isinstance(metadata["entities"], list)
+    assert len(metadata["entities"]) > 0
+    assert metadata["topic_analysis"]["topics"] == ["general"]

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/test_base_strategy.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/test_base_strategy.py
@@ -32,6 +32,7 @@ class TestBaseChunkingStrategy:
         settings.global_config.chunking = Mock()
         settings.global_config.chunking.chunk_size = 1000
         settings.global_config.chunking.chunk_overlap = 200
+        settings.global_config.chunking.enable_semantic_analysis = True
         settings.global_config.embedding = Mock()
         settings.global_config.embedding.tokenizer = "cl100k_base"
         return settings
@@ -44,8 +45,22 @@ class TestBaseChunkingStrategy:
         settings.global_config.chunking = Mock()
         settings.global_config.chunking.chunk_size = 1000
         settings.global_config.chunking.chunk_overlap = 200
+        settings.global_config.chunking.enable_semantic_analysis = True
         settings.global_config.embedding = Mock()
         settings.global_config.embedding.tokenizer = "none"
+        return settings
+
+    @pytest.fixture
+    def mock_settings_semantic_disabled(self):
+        """Create mock settings with semantic analysis disabled."""
+        settings = Mock(spec=Settings)
+        settings.global_config = Mock()
+        settings.global_config.chunking = Mock()
+        settings.global_config.chunking.chunk_size = 1000
+        settings.global_config.chunking.chunk_overlap = 200
+        settings.global_config.chunking.enable_semantic_analysis = False
+        settings.global_config.embedding = Mock()
+        settings.global_config.embedding.tokenizer = "cl100k_base"
         return settings
 
     def test_initialization_with_tokenizer(self, mock_settings):
@@ -150,6 +165,35 @@ class TestBaseChunkingStrategy:
 
             assert result == {"entities": [], "pos_tags": []}
             mock_processor.process_text.assert_called_once_with("test text")
+
+    def test_initialization_semantic_disabled_skips_text_processor(
+        self, mock_settings_semantic_disabled
+    ):
+        """Test TextProcessor is not initialized when semantic analysis is disabled."""
+        with patch(
+            "qdrant_loader.core.chunking.strategy.base_strategy.TextProcessor"
+        ) as mock_processor_class:
+            strategy = ConcreteChunkingStrategy(mock_settings_semantic_disabled)
+
+            assert strategy._semantic_analysis_enabled is False
+            assert strategy.text_processor is None
+            mock_processor_class.assert_not_called()
+
+    def test_process_text_semantic_disabled_returns_empty(
+        self, mock_settings_semantic_disabled
+    ):
+        """Test _process_text returns empty NLP payload when semantic analysis is disabled."""
+        with patch("qdrant_loader.core.chunking.strategy.base_strategy.TextProcessor"):
+            strategy = ConcreteChunkingStrategy(mock_settings_semantic_disabled)
+
+            result = strategy._process_text("test text")
+
+            assert result == {
+                "tokens": [],
+                "entities": [],
+                "pos_tags": [],
+                "chunks": [],
+            }
 
     def test_should_apply_nlp_text_files(self, mock_settings):
         """Test NLP application decision for text files."""
@@ -599,3 +643,29 @@ def function():
             # Should skip NLP for non-converted binary files
             assert chunk_doc.metadata["nlp_skipped"] is True
             assert chunk_doc.metadata["skip_reason"] == "content_type_inappropriate"
+
+    def test_create_chunk_document_semantic_disabled_skips_all_nlp_metadata(
+        self, mock_settings_semantic_disabled
+    ):
+        """Test master semantic switch disables NLP metadata extraction in base strategy."""
+        with patch("qdrant_loader.core.chunking.strategy.base_strategy.TextProcessor"):
+            strategy = ConcreteChunkingStrategy(mock_settings_semantic_disabled)
+
+            original_doc = Document(
+                content="Original content",
+                metadata={"file_name": "test.txt"},
+                source="test_source",
+                source_type="test",
+                url="http://test.com",
+                title="Test Title",
+                content_type="text",
+            )
+
+            chunk_doc = strategy._create_chunk_document(
+                original_doc, "This is text content for NLP processing.", 0, 2
+            )
+
+            assert chunk_doc.metadata["nlp_skipped"] is True
+            assert chunk_doc.metadata["skip_reason"] == "semantic_analysis_disabled"
+            assert chunk_doc.metadata["entities"] == []
+            assert chunk_doc.metadata["pos_tags"] == []


### PR DESCRIPTION
# Pull Request

## Summary

- Gate BaseChunkingStrategy NLP path with master semantic flag
- Skip TextProcessor init when semantic analysis is disabled
- Add unit tests for disabled semantic-analysis behavior
- Add integration coverage across default/markdown strategies
- 
## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global setting to enable or disable semantic analysis.

* **Improvements**
  * NLP initialization and processing now respect the global semantic-analysis switch.
  * Chunk and metadata outputs always include consistent NLP fields and a clear skip reason when semantic analysis is disabled.
  * NLP is pre-gated to avoid unnecessary processing when not applicable.

* **Bug Fixes**
  * Topic analysis is performed only when semantic analysis is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->