### PR TITLE
fix: cancel handle_stdio task on SIGINT/SIGTERM for clean shutdown

### DIFF
--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/cli.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/cli.py
@@ -6,6 +6,7 @@ import logging
 import os
 import signal
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import click
@@ -67,11 +68,14 @@ def _setup_logging(log_level: str, transport: str | None = None) -> None:
         print(f"Failed to setup logging: {e}", file=sys.stderr)
 
 
-async def read_stdin_lines():
+async def read_stdin_lines(executor=None):
     """Cross-platform async generator that yields lines from stdin."""
     loop = asyncio.get_event_loop()
     while True:
-        line = await loop.run_in_executor(None, sys.stdin.readline)
+        try:
+            line = await loop.run_in_executor(executor, sys.stdin.readline)
+        except (ValueError, OSError):
+            break  # stdin was closed during shutdown
         if not line:  # EOF
             break
         yield line
@@ -98,7 +102,7 @@ async def shutdown(
     logger.info("Shutdown signal dispatched")
 
 
-async def handle_stdio(config: Config, log_level: str):
+async def handle_stdio(config: Config, log_level: str, executor=None):
     """Handle stdio communication with Cursor."""
     logger = LoggingConfig.get_logger(__name__)
 
@@ -130,7 +134,7 @@ async def handle_stdio(config: Config, log_level: str):
         if not disable_console_logging:
             logger.info("Server ready to handle requests")
 
-        async for line in read_stdin_lines():
+        async for line in read_stdin_lines(executor):
             try:
                 raw_input = line.strip()
                 if not raw_input:
@@ -234,6 +238,12 @@ async def handle_stdio(config: Config, log_level: str):
         if not disable_console_logging:
             logger.error("Error in stdio handler", exc_info=True)
         raise
+    finally:
+        # Close stdin to unblock the executor thread waiting on readline()
+        try:
+            sys.stdin.close()
+        except Exception:
+            pass
 
 
 @click.command(name="mcp-qdrant-loader")
@@ -397,11 +407,15 @@ def cli(
 
             shutdown_event = asyncio.Event()
             shutdown_task = None
+            main_task = None
+            stdin_executor = None
 
             def signal_handler():
-                nonlocal shutdown_task
+                nonlocal shutdown_task, main_task
                 if shutdown_task is None:
                     shutdown_task = loop.create_task(shutdown(loop, shutdown_event))
+                if main_task is not None and not main_task.done():
+                    main_task.cancel()
 
             for sig in (signal.SIGTERM, signal.SIGINT):
                 try:
@@ -416,7 +430,15 @@ def cli(
                         pass
 
             try:
-                loop.run_until_complete(handle_stdio(config_obj, log_level))
+                stdin_executor = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="stdin-"
+                )
+                main_task = loop.create_task(
+                    handle_stdio(config_obj, log_level, stdin_executor)
+                )
+                loop.run_until_complete(main_task)
+            except asyncio.CancelledError:
+                pass  # Expected during signal-driven shutdown
             except Exception:
                 logger = LoggingConfig.get_logger(__name__)
                 logger.error("Error in main", exc_info=True)
@@ -461,6 +483,11 @@ def cli(
                     logger = LoggingConfig.get_logger(__name__)
                     logger.error("Error during final cleanup", exc_info=True)
                 finally:
+                    if stdin_executor is not None:
+                        try:
+                            stdin_executor.shutdown(wait=False)
+                        except Exception:
+                            pass
                     loop.close()
                     logger = LoggingConfig.get_logger(__name__)
                     logger.info("Server shutdown complete")

--- a/packages/qdrant-loader-mcp-server/tests/unit/test_cli.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_cli.py
@@ -606,3 +606,134 @@ class TestCLICommand:
 
         assert result.exit_code != 0
         assert "does not exist" in result.output
+
+
+class TestReadStdinLinesClosedStdin:
+    """read_stdin_lines should handle closed stdin gracefully."""
+
+    @pytest.mark.asyncio
+    async def test_breaks_on_value_error(self):
+        """When stdin is closed, readline raises ValueError -- should break."""
+        mock_executor = MagicMock()
+
+        async def mock_run_in_executor(executor, func):
+            raise ValueError("I/O operation on closed file")
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = mock_run_in_executor
+            lines = []
+            async for line in read_stdin_lines(mock_executor):
+                lines.append(line)
+            assert lines == []
+
+    @pytest.mark.asyncio
+    async def test_breaks_on_os_error(self):
+        """When stdin is closed, readline may raise OSError -- should break."""
+        mock_executor = MagicMock()
+
+        async def mock_run_in_executor(executor, func):
+            raise OSError("Bad file descriptor")
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = mock_run_in_executor
+            lines = []
+            async for line in read_stdin_lines(mock_executor):
+                lines.append(line)
+            assert lines == []
+
+    @pytest.mark.asyncio
+    async def test_breaks_on_eof(self):
+        """When stdin returns empty string (EOF), should break."""
+        call_count = 0
+
+        async def mock_run_in_executor(executor, func):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return '{"method": "test"}\n'
+            return ""
+
+        with patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.run_in_executor = mock_run_in_executor
+            lines = []
+            async for line in read_stdin_lines():
+                lines.append(line)
+            assert len(lines) == 1
+
+
+class TestSignalHandlerCancelsMainTask:
+    """Signal handler should cancel the main handle_stdio task."""
+
+    @patch("qdrant_loader_mcp_server.cli._setup_logging")
+    @patch("qdrant_loader_mcp_server.cli.load_config")
+    @patch("qdrant_loader_mcp_server.cli.handle_stdio")
+    @patch("asyncio.new_event_loop")
+    @patch("asyncio.set_event_loop")
+    @patch("signal.SIGTERM", 15)
+    @patch("signal.SIGINT", 2)
+    def test_signal_handler_creates_task_and_cancels(
+        self,
+        mock_set_event_loop,
+        mock_new_event_loop,
+        mock_handle_stdio,
+        mock_load_config,
+        mock_setup_logging,
+    ):
+        """Test that stdio transport wraps handle_stdio in a task (cancellable)."""
+        mock_loop = MagicMock()
+        mock_new_event_loop.return_value = mock_loop
+        mock_loop.run_until_complete.return_value = None
+
+        # Track create_task calls
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        mock_loop.create_task.return_value = mock_task
+
+        mock_config = MagicMock()
+        mock_load_config.return_value = (mock_config, {}, None)
+        mock_handle_stdio.return_value = AsyncMock()
+
+        runner = CliRunner()
+        runner.invoke(cli, ["--log-level", "DEBUG"])
+
+        # Verify create_task was called (handle_stdio wrapped as task)
+        assert mock_loop.create_task.called
+        # Verify run_until_complete receives the task, not raw coroutine
+        mock_loop.run_until_complete.assert_called()
+
+    @patch("qdrant_loader_mcp_server.cli._setup_logging")
+    @patch("qdrant_loader_mcp_server.cli.load_config")
+    @patch("qdrant_loader_mcp_server.cli.handle_stdio")
+    @patch("asyncio.new_event_loop")
+    @patch("asyncio.set_event_loop")
+    @patch("signal.SIGTERM", 15)
+    @patch("signal.SIGINT", 2)
+    def test_signal_handler_registered(
+        self,
+        mock_set_event_loop,
+        mock_new_event_loop,
+        mock_handle_stdio,
+        mock_load_config,
+        mock_setup_logging,
+    ):
+        """Test that signal handlers are registered for SIGINT and SIGTERM."""
+        mock_loop = MagicMock()
+        mock_new_event_loop.return_value = mock_loop
+        mock_loop.run_until_complete.return_value = None
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = True
+        mock_loop.create_task.return_value = mock_task
+
+        mock_config = MagicMock()
+        mock_load_config.return_value = (mock_config, {}, None)
+        mock_handle_stdio.return_value = AsyncMock()
+
+        runner = CliRunner()
+        runner.invoke(cli, ["--log-level", "INFO"])
+
+        # Verify add_signal_handler was called for both signals
+        signal_calls = list(mock_loop.add_signal_handler.call_args_list)
+        registered_signals = [call[0][0] for call in signal_calls]
+        assert 15 in registered_signals  # SIGTERM
+        assert 2 in registered_signals  # SIGINT


### PR DESCRIPTION
## Summary

   - Signal handler now cancels the `handle_stdio` task on SIGINT/SIGTERM instead of only setting `shutdown_event`
   - Use dedicated `ThreadPoolExecutor` for stdin reader to allow clean thread shutdown
   - Catch `ValueError`/`OSError` in `read_stdin_lines` when stdin is closed during shutdown
   - Close `sys.stdin` in `finally` block to unblock executor thread waiting on `readline()`
   - Add 5 new unit tests for signal handling and stdin shutdown scenarios

   ## Type of change

   - [ ] Feature
   - [x] Bug fix
   - [ ] Docs update
   - [ ] Chore

   ## Docs Impact (required for any code or docs changes)

   - [ ] Does this change require docs updates? If yes, list pages:
   - [ ] Have you updated or added pages under `docs/`?
   - [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
   - [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

   ## Testing

   ```
   python -m pytest packages/qdrant-loader-mcp-server/tests/unit/test_cli.py -v
   # 28/28 passed (23 existing + 5 new)

   ruff check packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/cli.py \
             packages/qdrant-loader-mcp-server/tests/unit/test_cli.py
   # All checks passed
   ```

   Manual testing:
   - Start server in stdio mode, press Ctrl+C → process exits within ~3s
   - Send SIGTERM to stdio process → clean exit

   ## Checklist

   - [x] Tests pass (`pytest -v`)
   - [x] Linting passes (make lint / make format)
   - [ ] Documentation updated (if applicable)

   Ref: PR #202 CodeRabbitAI review ([cli.py:419](https://github.com/martin-papy/qdrant-loader/pull/202#discussion_r2987605740))
   Jira: AIKH-1523