### PR TITLE
fix: total_chunk in metric file and duplicate document id causes miss…

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/async_ingestion_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/async_ingestion_pipeline.py
@@ -232,6 +232,12 @@ class AsyncIngestionPipeline:
 
             # Update metrics
             if documents:
+                pipeline_result = getattr(
+                    self.orchestrator, "last_pipeline_result", None
+                )
+                total_chunks = getattr(pipeline_result, "success_count", 0)
+                total_size_bytes = sum(len(doc.content or "") for doc in documents)
+
                 self.monitor.start_batch(
                     "document_batch",
                     batch_size=len(documents),
@@ -243,7 +249,14 @@ class AsyncIngestionPipeline:
                     },
                 )
                 # Note: Success/error counts are handled internally by the new architecture
-                self.monitor.end_batch("document_batch", len(documents), 0, [])
+                self.monitor.end_batch(
+                    "document_batch",
+                    len(documents),
+                    0,
+                    [],
+                    total_chunks=total_chunks,
+                    total_size_bytes=total_size_bytes,
+                )
 
             self.monitor.end_operation("ingestion_process")
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/async_ingestion_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/async_ingestion_pipeline.py
@@ -236,7 +236,14 @@ class AsyncIngestionPipeline:
                     self.orchestrator, "last_pipeline_result", None
                 )
                 total_chunks = getattr(pipeline_result, "success_count", 0)
-                total_size_bytes = sum(len(doc.content or "") for doc in documents)
+
+                def _safe_document_size(doc: Document) -> int:
+                    try:
+                        return int(doc.metadata.get("size", 0))
+                    except (TypeError, ValueError):
+                        return 0
+
+                total_size_bytes = sum(_safe_document_size(doc) for doc in documents)
 
                 self.monitor.start_batch(
                     "document_batch",

--- a/packages/qdrant-loader/src/qdrant_loader/core/attachment_downloader.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/attachment_downloader.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+import uuid
 from pathlib import Path
 
 import requests
@@ -365,7 +366,17 @@ class AttachmentDownloader:
                 )
 
             # Create attachment document
+            # Use an explicit attachment-specific ID so attachments under the same
+            # parent cannot collide if URL normalization strips fragments.
+            attachment_doc_id = str(
+                uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"{parent_document.id}:attachment:{attachment.id}",
+                )
+            )
+
             document = Document(
+                id=attachment_doc_id,
                 title=f"Attachment: {attachment.filename}",
                 content=content,
                 content_type=content_type,

--- a/packages/qdrant-loader/src/qdrant_loader/core/monitoring/ingestion_metrics.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/monitoring/ingestion_metrics.py
@@ -171,6 +171,8 @@ class IngestionMonitor:
         document_sizes: list[int] | None = None,
         chunk_sizes: list[int] | None = None,
         source: str | None = None,
+        total_chunks: int | None = None,
+        total_size_bytes: int | None = None,
     ) -> None:
         """End tracking a batch.
 
@@ -182,6 +184,8 @@ class IngestionMonitor:
             document_sizes: List of document sizes in bytes
             chunk_sizes: List of chunk sizes in bytes
             source: Source identifier for the batch
+            total_chunks: Explicit total chunk count for this batch
+            total_size_bytes: Explicit total document size for this batch
         """
         if batch_id not in self.batch_metrics:
             logger.warning(f"Attempted to end untracked batch {batch_id}")
@@ -195,22 +199,30 @@ class IngestionMonitor:
         metrics.errors = errors or []
         metrics.is_completed = True
 
-        # Calculate total chunks from document metadata
-        total_chunks = 0
+        # Calculate total chunks from explicit value first, fallback to tracked document metadata.
+        computed_total_chunks = 0
         for doc_id, doc_metrics in self.ingestion_metrics.items():
             if doc_id.startswith("doc_") and doc_metrics.metadata.get("num_chunks"):
-                total_chunks += doc_metrics.metadata["num_chunks"]
+                computed_total_chunks += doc_metrics.metadata["num_chunks"]
 
-        # Calculate total size from document metadata
-        total_size = 0
+        effective_total_chunks = (
+            total_chunks if total_chunks is not None else computed_total_chunks
+        )
+
+        # Calculate total size from explicit value first, fallback to tracked document metadata.
+        computed_total_size = 0
         for doc_id, doc_metrics in self.ingestion_metrics.items():
             if doc_id.startswith("doc_") and doc_metrics.metadata.get("size"):
-                total_size += doc_metrics.metadata["size"]
+                computed_total_size += doc_metrics.metadata["size"]
+
+        effective_total_size = (
+            total_size_bytes if total_size_bytes is not None else computed_total_size
+        )
 
         # Update processing stats
         self.processing_stats.update_rates(
             num_documents=metrics.batch_size,
-            num_chunks=total_chunks,
+            num_chunks=effective_total_chunks,
             processing_time=metrics.duration,
         )
 
@@ -226,8 +238,8 @@ class IngestionMonitor:
         if metrics.summary:
             metrics.summary.update_batch_stats(
                 num_documents=metrics.batch_size,
-                num_chunks=total_chunks,
-                total_size=total_size,
+                num_chunks=effective_total_chunks,
+                total_size=effective_total_size,
                 processing_time=metrics.duration,
                 success_count=success_count,
                 error_count=error_count,

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -11,6 +11,7 @@ from qdrant_loader.utils.logging import LoggingConfig
 from .document_pipeline import DocumentPipeline
 from .source_filter import SourceFilter
 from .source_processor import SourceProcessor
+from .workers.upsert_worker import PipelineResult
 
 logger = LoggingConfig.get_logger(__name__)
 
@@ -176,6 +177,7 @@ class PipelineOrchestrator:
             raise ValueError("Project manager not available")
 
         all_documents = []
+        aggregated_result = PipelineResult()
         project_ids = self.project_manager.list_project_ids()
 
         logger.info(f"Processing {len(project_ids)} projects")
@@ -189,7 +191,20 @@ class PipelineOrchestrator:
                     source=source,
                     force=force,
                 )
+                project_result = self.last_pipeline_result
                 all_documents.extend(project_documents)
+
+                if project_result is not None:
+                    aggregated_result.success_count += project_result.success_count
+                    aggregated_result.error_count += project_result.error_count
+                    aggregated_result.successfully_processed_documents.update(
+                        project_result.successfully_processed_documents
+                    )
+                    aggregated_result.failed_document_ids.update(
+                        project_result.failed_document_ids
+                    )
+                    aggregated_result.errors.extend(project_result.errors)
+
                 logger.debug(
                     f"Processed {len(project_documents)} documents from project: {project_id}"
                 )
@@ -199,6 +214,8 @@ class PipelineOrchestrator:
                 )
                 # Continue processing other projects
                 continue
+
+        self.last_pipeline_result = aggregated_result
 
         logger.info(
             f"Completed processing all projects: {len(all_documents)} total documents"

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -43,6 +43,7 @@ class PipelineOrchestrator:
         self.settings = settings
         self.components = components
         self.project_manager = project_manager
+        self.last_pipeline_result = None
 
     async def process_documents(
         self,
@@ -65,6 +66,7 @@ class PipelineOrchestrator:
             List of processed documents
         """
         logger.info("🚀 Starting document ingestion")
+        self.last_pipeline_result = None
 
         try:
             # Determine sources configuration to use
@@ -147,6 +149,7 @@ class PipelineOrchestrator:
             result = await self.components.document_pipeline.process_documents(
                 documents
             )
+            self.last_pipeline_result = result
 
             # Update document states for successfully processed documents
             await self._update_document_states(

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
@@ -1,6 +1,7 @@
 """Upsert worker for upserting embedded chunks to Qdrant."""
 
 import asyncio
+from collections import Counter
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -145,22 +146,43 @@ class UpsertWorker(BaseWorker):
 
                 # Process batch when it reaches the desired size
                 if len(batch) >= self.batch_size:
-                    batch_chunk_ids = {str(chunk.id) for chunk, _ in batch}
+                    batch_chunk_id_list = [str(chunk.id) for chunk, _ in batch]
+                    batch_chunk_ids = set(batch_chunk_id_list)
+                    batch_chunk_id_counts = Counter(batch_chunk_id_list)
                     success_count, error_count, successful_doc_ids, errors = (
                         await self.process(batch)
                     )
 
                     if success_count > 0:
-                        duplicate_chunk_ids = batch_chunk_ids & seen_chunk_ids
+                        same_batch_duplicates = {
+                            chunk_id
+                            for chunk_id, count in batch_chunk_id_counts.items()
+                            if count > 1
+                        }
+                        cross_batch_duplicates = batch_chunk_ids & seen_chunk_ids
+                        duplicate_chunk_ids = (
+                            cross_batch_duplicates | same_batch_duplicates
+                        )
                         new_chunk_ids = batch_chunk_ids - seen_chunk_ids
 
                         if duplicate_chunk_ids:
+                            same_batch_duplicate_occurrences = sum(
+                                count - 1
+                                for count in batch_chunk_id_counts.values()
+                                if count > 1
+                            )
                             logger.warning(
                                 "Detected chunk ID collisions during upsert; existing points will be overwritten",
                                 duplicate_count=len(duplicate_chunk_ids),
+                                same_batch_duplicate_count=len(same_batch_duplicates),
+                                same_batch_duplicate_occurrences=same_batch_duplicate_occurrences,
+                                cross_batch_duplicate_count=len(cross_batch_duplicates),
                             )
                             errors.append(
-                                f"Detected {len(duplicate_chunk_ids)} duplicate chunk IDs that overwrite existing points"
+                                "Detected duplicate chunk IDs during upsert: "
+                                f"{len(cross_batch_duplicates)} cross-batch IDs and "
+                                f"{same_batch_duplicate_occurrences} same-batch duplicate occurrences "
+                                f"across {len(same_batch_duplicates)} IDs"
                             )
 
                         seen_chunk_ids.update(batch_chunk_ids)
@@ -173,22 +195,41 @@ class UpsertWorker(BaseWorker):
 
             # Process any remaining chunks in the final batch
             if batch and not self.shutdown_event.is_set():
-                batch_chunk_ids = {str(chunk.id) for chunk, _ in batch}
+                batch_chunk_id_list = [str(chunk.id) for chunk, _ in batch]
+                batch_chunk_ids = set(batch_chunk_id_list)
+                batch_chunk_id_counts = Counter(batch_chunk_id_list)
                 success_count, error_count, successful_doc_ids, errors = (
                     await self.process(batch)
                 )
 
                 if success_count > 0:
-                    duplicate_chunk_ids = batch_chunk_ids & seen_chunk_ids
+                    same_batch_duplicates = {
+                        chunk_id
+                        for chunk_id, count in batch_chunk_id_counts.items()
+                        if count > 1
+                    }
+                    cross_batch_duplicates = batch_chunk_ids & seen_chunk_ids
+                    duplicate_chunk_ids = cross_batch_duplicates | same_batch_duplicates
                     new_chunk_ids = batch_chunk_ids - seen_chunk_ids
 
                     if duplicate_chunk_ids:
+                        same_batch_duplicate_occurrences = sum(
+                            count - 1
+                            for count in batch_chunk_id_counts.values()
+                            if count > 1
+                        )
                         logger.warning(
                             "Detected chunk ID collisions during upsert; existing points will be overwritten",
                             duplicate_count=len(duplicate_chunk_ids),
+                            same_batch_duplicate_count=len(same_batch_duplicates),
+                            same_batch_duplicate_occurrences=same_batch_duplicate_occurrences,
+                            cross_batch_duplicate_count=len(cross_batch_duplicates),
                         )
                         errors.append(
-                            f"Detected {len(duplicate_chunk_ids)} duplicate chunk IDs that overwrite existing points"
+                            "Detected duplicate chunk IDs during upsert: "
+                            f"{len(cross_batch_duplicates)} cross-batch IDs and "
+                            f"{same_batch_duplicate_occurrences} same-batch duplicate occurrences "
+                            f"across {len(same_batch_duplicates)} IDs"
                         )
 
                     seen_chunk_ids.update(batch_chunk_ids)

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
@@ -133,6 +133,7 @@ class UpsertWorker(BaseWorker):
         logger.debug("UpsertWorker started")
         result = PipelineResult()
         batch = []
+        seen_chunk_ids: set[str] = set()
 
         try:
             async for chunk_embedding in embedded_chunks:
@@ -144,10 +145,27 @@ class UpsertWorker(BaseWorker):
 
                 # Process batch when it reaches the desired size
                 if len(batch) >= self.batch_size:
+                    batch_chunk_ids = {str(chunk.id) for chunk, _ in batch}
                     success_count, error_count, successful_doc_ids, errors = (
                         await self.process(batch)
                     )
-                    result.success_count += success_count
+
+                    if success_count > 0:
+                        duplicate_chunk_ids = batch_chunk_ids & seen_chunk_ids
+                        new_chunk_ids = batch_chunk_ids - seen_chunk_ids
+
+                        if duplicate_chunk_ids:
+                            logger.warning(
+                                "Detected chunk ID collisions during upsert; existing points will be overwritten",
+                                duplicate_count=len(duplicate_chunk_ids),
+                            )
+                            errors.append(
+                                f"Detected {len(duplicate_chunk_ids)} duplicate chunk IDs that overwrite existing points"
+                            )
+
+                        seen_chunk_ids.update(batch_chunk_ids)
+                        result.success_count += len(new_chunk_ids)
+
                     result.error_count += error_count
                     result.successfully_processed_documents.update(successful_doc_ids)
                     result.errors.extend(errors)
@@ -155,10 +173,27 @@ class UpsertWorker(BaseWorker):
 
             # Process any remaining chunks in the final batch
             if batch and not self.shutdown_event.is_set():
+                batch_chunk_ids = {str(chunk.id) for chunk, _ in batch}
                 success_count, error_count, successful_doc_ids, errors = (
                     await self.process(batch)
                 )
-                result.success_count += success_count
+
+                if success_count > 0:
+                    duplicate_chunk_ids = batch_chunk_ids & seen_chunk_ids
+                    new_chunk_ids = batch_chunk_ids - seen_chunk_ids
+
+                    if duplicate_chunk_ids:
+                        logger.warning(
+                            "Detected chunk ID collisions during upsert; existing points will be overwritten",
+                            duplicate_count=len(duplicate_chunk_ids),
+                        )
+                        errors.append(
+                            f"Detected {len(duplicate_chunk_ids)} duplicate chunk IDs that overwrite existing points"
+                        )
+
+                    seen_chunk_ids.update(batch_chunk_ids)
+                    result.success_count += len(new_chunk_ids)
+
                 result.error_count += error_count
                 result.successfully_processed_documents.update(successful_doc_ids)
                 result.errors.extend(errors)

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_async_ingestion_pipeline.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_async_ingestion_pipeline.py
@@ -313,6 +313,7 @@ class TestAsyncIngestionPipeline:
             mock_orchestrator.process_documents = AsyncMock(
                 return_value=sample_documents
             )
+            mock_orchestrator.last_pipeline_result = Mock(success_count=5)
             mock_orchestrator_class.return_value = mock_orchestrator
 
             mock_monitor = Mock()
@@ -346,7 +347,14 @@ class TestAsyncIngestionPipeline:
                     "force": False,
                 },
             )
-            mock_monitor.end_batch.assert_called_once_with("document_batch", 2, 0, [])
+            mock_monitor.end_batch.assert_called_once_with(
+                "document_batch",
+                2,
+                0,
+                [],
+                total_chunks=5,
+                total_size_bytes=28,
+            )
 
             assert result == sample_documents
 

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_async_ingestion_pipeline.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_async_ingestion_pipeline.py
@@ -353,10 +353,94 @@ class TestAsyncIngestionPipeline:
                 0,
                 [],
                 total_chunks=5,
-                total_size_bytes=28,
+                total_size_bytes=0,
             )
 
             assert result == sample_documents
+
+    @pytest.mark.asyncio
+    async def test_process_documents_uses_metadata_size_for_total_size_bytes(
+        self, mock_settings, mock_qdrant_manager
+    ):
+        """total_size_bytes should be summed from document metadata['size']."""
+        documents_with_size = [
+            Document(
+                content="short",
+                url="http://example.com/doc1",
+                content_type="text/plain",
+                source_type="test",
+                source="test_source",
+                title="Test Document 1",
+                metadata={"source": "test", "size": 100},
+            ),
+            Document(
+                content="very long content that should not be used for size metrics",
+                url="http://example.com/doc2",
+                content_type="text/plain",
+                source_type="test",
+                source="test_source",
+                title="Test Document 2",
+                metadata={"source": "test", "size": "250"},
+            ),
+            Document(
+                content="content present but invalid metadata size",
+                url="http://example.com/doc3",
+                content_type="text/plain",
+                source_type="test",
+                source="test_source",
+                title="Test Document 3",
+                metadata={"source": "test", "size": "invalid"},
+            ),
+        ]
+
+        with (
+            patch(
+                "qdrant_loader.core.async_ingestion_pipeline.PipelineComponentsFactory"
+            ),
+            patch(
+                "qdrant_loader.core.async_ingestion_pipeline.PipelineOrchestrator"
+            ) as mock_orchestrator_class,
+            patch("qdrant_loader.core.async_ingestion_pipeline.ResourceManager"),
+            patch(
+                "qdrant_loader.core.async_ingestion_pipeline.IngestionMonitor"
+            ) as mock_monitor_class,
+            patch("qdrant_loader.core.async_ingestion_pipeline.prometheus_metrics"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.Path") as mock_path,
+        ):
+            self._setup_path_mocks(mock_path)
+
+            mock_orchestrator = Mock()
+            mock_orchestrator.process_documents = AsyncMock(
+                return_value=documents_with_size
+            )
+            mock_orchestrator.last_pipeline_result = Mock(success_count=7)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            mock_monitor = Mock()
+            mock_monitor.clear_metrics = Mock()
+            mock_monitor.start_operation = Mock()
+            mock_monitor.end_operation = Mock()
+            mock_monitor.start_batch = Mock()
+            mock_monitor.end_batch = Mock()
+            mock_monitor_class.return_value = mock_monitor
+
+            pipeline = AsyncIngestionPipeline(
+                settings=mock_settings, qdrant_manager=mock_qdrant_manager
+            )
+            pipeline.state_manager._initialized = True
+            pipeline.project_manager._initialized = True
+
+            result = await pipeline.process_documents(source_type="jira")
+
+            mock_monitor.end_batch.assert_called_once_with(
+                "document_batch",
+                3,
+                0,
+                [],
+                total_chunks=7,
+                total_size_bytes=350,
+            )
+            assert result == documents_with_size
 
     @pytest.mark.asyncio
     async def test_process_documents_error_handling(

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -581,3 +581,104 @@ class TestPipelineOrchestrator:
         # Verify no updates were attempted (but initialization was called)
         self.state_manager.update_document_state.assert_not_called()
         self.state_manager.initialize.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_all_projects_aggregates_pipeline_results(self):
+        """Multi-project runs should aggregate pipeline results across projects."""
+        project_manager = Mock()
+        project_manager.list_project_ids.return_value = ["p1", "p2"]
+        orchestrator = PipelineOrchestrator(
+            self.settings, self.components, project_manager=project_manager
+        )
+
+        docs_by_project = {
+            "p1": [Mock(spec=Document, id="doc1")],
+            "p2": [Mock(spec=Document, id="doc2")],
+        }
+        results_by_project = {
+            "p1": Mock(
+                success_count=3,
+                error_count=1,
+                successfully_processed_documents={"doc1"},
+                failed_document_ids={"doc1-failed"},
+                errors=["p1-error"],
+            ),
+            "p2": Mock(
+                success_count=5,
+                error_count=2,
+                successfully_processed_documents={"doc2"},
+                failed_document_ids={"doc2-failed"},
+                errors=["p2-error"],
+            ),
+        }
+
+        async def mock_process_documents(**kwargs):
+            project_id = kwargs["project_id"]
+            orchestrator.last_pipeline_result = results_by_project[project_id]
+            return docs_by_project[project_id]
+
+        with patch.object(
+            orchestrator, "process_documents", side_effect=mock_process_documents
+        ):
+            documents = await orchestrator._process_all_projects()
+
+        assert len(documents) == 2
+        assert {doc.id for doc in documents} == {"doc1", "doc2"}
+
+        assert orchestrator.last_pipeline_result is not None
+        assert orchestrator.last_pipeline_result.success_count == 8
+        assert orchestrator.last_pipeline_result.error_count == 3
+        assert orchestrator.last_pipeline_result.successfully_processed_documents == {
+            "doc1",
+            "doc2",
+        }
+        assert orchestrator.last_pipeline_result.failed_document_ids == {
+            "doc1-failed",
+            "doc2-failed",
+        }
+        assert orchestrator.last_pipeline_result.errors == ["p1-error", "p2-error"]
+
+    @pytest.mark.asyncio
+    async def test_process_all_projects_handles_missing_project_results(self):
+        """Projects with no pipeline result should not break aggregate result."""
+        project_manager = Mock()
+        project_manager.list_project_ids.return_value = ["p1", "p2"]
+        orchestrator = PipelineOrchestrator(
+            self.settings, self.components, project_manager=project_manager
+        )
+
+        docs_by_project = {
+            "p1": [Mock(spec=Document, id="doc1")],
+            "p2": [],
+        }
+
+        result_p1 = Mock(
+            success_count=2,
+            error_count=0,
+            successfully_processed_documents={"doc1"},
+            failed_document_ids=set(),
+            errors=[],
+        )
+
+        async def mock_process_documents(**kwargs):
+            project_id = kwargs["project_id"]
+            if project_id == "p1":
+                orchestrator.last_pipeline_result = result_p1
+            else:
+                orchestrator.last_pipeline_result = None
+            return docs_by_project[project_id]
+
+        with patch.object(
+            orchestrator, "process_documents", side_effect=mock_process_documents
+        ):
+            documents = await orchestrator._process_all_projects()
+
+        assert len(documents) == 1
+        assert documents[0].id == "doc1"
+
+        assert orchestrator.last_pipeline_result is not None
+        assert orchestrator.last_pipeline_result.success_count == 2
+        assert orchestrator.last_pipeline_result.error_count == 0
+        assert orchestrator.last_pipeline_result.successfully_processed_documents == {
+            "doc1"
+        }

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
@@ -586,3 +586,48 @@ class TestUpsertWorker:
 
         # Verify qdrant_manager.upsert_points was called twice (one full batch + one final batch)
         assert self.mock_qdrant_manager.upsert_points.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_counts_unique_ids_only(self):
+        """Duplicate chunk IDs should overwrite points and be counted once."""
+        # Two chunks intentionally share the same ID
+        mock_chunk1 = Mock()
+        mock_chunk1.id = "same-chunk-id"
+        mock_chunk1.content = "Version 1"
+        mock_chunk1.source = "test_source"
+        mock_chunk1.source_type = "test"
+        mock_chunk1.created_at = datetime(2023, 1, 1, 12, 0, 0)
+        mock_chunk1.metadata = {"parent_document": Mock(id="doc1")}
+
+        mock_chunk2 = Mock()
+        mock_chunk2.id = "same-chunk-id"
+        mock_chunk2.content = "Version 2"
+        mock_chunk2.source = "test_source"
+        mock_chunk2.source_type = "test"
+        mock_chunk2.created_at = datetime(2023, 1, 1, 12, 5, 0)
+        mock_chunk2.metadata = {"parent_document": Mock(id="doc2")}
+
+        async def embedded_chunks_iterator():
+            yield (mock_chunk1, [0.1, 0.2, 0.3])
+            yield (mock_chunk2, [0.4, 0.5, 0.6])
+
+        self.upsert_worker.batch_size = 1
+
+        with (
+            patch(
+                "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+            ),
+            patch(
+                "qdrant_loader.core.pipeline.workers.upsert_worker.logger"
+            ) as mock_logger,
+        ):
+            result = await self.upsert_worker.process_embedded_chunks(
+                embedded_chunks_iterator()
+            )
+
+        # Count unique IDs only: 2 processed attempts, 1 unique stored point ID
+        assert result.success_count == 1
+        assert result.error_count == 0
+        assert len(result.errors) == 1
+        assert "duplicate chunk IDs" in result.errors[0]
+        mock_logger.warning.assert_called()

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
@@ -631,3 +631,47 @@ class TestUpsertWorker:
         assert len(result.errors) == 1
         assert "duplicate chunk IDs" in result.errors[0]
         mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_detects_same_batch_duplicates(self):
+        """Duplicate IDs inside a single batch should be reported and counted once."""
+        mock_chunk1 = Mock()
+        mock_chunk1.id = "same-chunk-id"
+        mock_chunk1.content = "Version 1"
+        mock_chunk1.source = "test_source"
+        mock_chunk1.source_type = "test"
+        mock_chunk1.created_at = datetime(2023, 1, 1, 12, 0, 0)
+        mock_chunk1.metadata = {"parent_document": Mock(id="doc1")}
+
+        mock_chunk2 = Mock()
+        mock_chunk2.id = "same-chunk-id"
+        mock_chunk2.content = "Version 2"
+        mock_chunk2.source = "test_source"
+        mock_chunk2.source_type = "test"
+        mock_chunk2.created_at = datetime(2023, 1, 1, 12, 5, 0)
+        mock_chunk2.metadata = {"parent_document": Mock(id="doc2")}
+
+        async def embedded_chunks_iterator():
+            yield (mock_chunk1, [0.1, 0.2, 0.3])
+            yield (mock_chunk2, [0.4, 0.5, 0.6])
+
+        # Keep both chunks in the same batch
+        self.upsert_worker.batch_size = 2
+
+        with (
+            patch(
+                "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+            ),
+            patch(
+                "qdrant_loader.core.pipeline.workers.upsert_worker.logger"
+            ) as mock_logger,
+        ):
+            result = await self.upsert_worker.process_embedded_chunks(
+                embedded_chunks_iterator()
+            )
+
+        assert result.success_count == 1
+        assert result.error_count == 0
+        assert len(result.errors) == 1
+        assert "same-batch duplicate occurrences" in result.errors[0]
+        mock_logger.warning.assert_called()

--- a/packages/qdrant-loader/tests/unit/core/test_attachment_downloader.py
+++ b/packages/qdrant-loader/tests/unit/core/test_attachment_downloader.py
@@ -286,6 +286,50 @@ class TestAttachmentDownload:
 class TestProcessAttachment:
     """Test attachment processing functionality."""
 
+    def test_process_attachment_generates_unique_ids_per_attachment(self, mock_session):
+        """Attachments under the same parent must not collide on document ID."""
+        downloader = AttachmentDownloader(
+            session=mock_session, enable_file_conversion=False
+        )
+
+        parent_document = Document(
+            title="Parent Document",
+            content="Parent content",
+            content_type="html",
+            source_type="jira",
+            source="test_project",
+            url="https://example.com/browse/ABC-1",
+            metadata={},
+        )
+
+        metadata_1 = AttachmentMetadata(
+            id="att_001",
+            filename="document-a.pdf",
+            size=1024,
+            mime_type="application/pdf",
+            download_url="https://example.com/rest/api/attachment/content/att_001",
+            parent_document_id="ABC-1",
+        )
+        metadata_2 = AttachmentMetadata(
+            id="att_002",
+            filename="document-b.pdf",
+            size=2048,
+            mime_type="application/pdf",
+            download_url="https://example.com/rest/api/attachment/content/att_002",
+            parent_document_id="ABC-1",
+        )
+
+        doc_1 = downloader.process_attachment(
+            metadata_1, "/tmp/document-a.pdf", parent_document
+        )
+        doc_2 = downloader.process_attachment(
+            metadata_2, "/tmp/document-b.pdf", parent_document
+        )
+
+        assert doc_1 is not None
+        assert doc_2 is not None
+        assert doc_1.id != doc_2.id
+
     def test_process_attachment_with_conversion(self, attachment_downloader):
         """Test processing attachment with file conversion."""
         metadata = AttachmentMetadata(


### PR DESCRIPTION
# Pull Request

## Summary

Fix total_chunk in metric file and duplicate document id causes missing chunks. Create unique ID by uuid5 from parent.document_id + attachment.id.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate chunk detection now logs warnings and reports duplicate IDs during processing.
  * Attachment processing generates deterministic identifiers to prevent ID collisions.
  * Success counts now exclude duplicate chunk IDs so batch results reflect unique items.

* **Improvements**
  * Enhanced metrics and batch-level statistics with more accurate chunk counts and document size totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->