### PR TITLE
fix: add optional figuration issue_types and include_statuses for jir…

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/cloud_connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/cloud_connector.py
@@ -59,9 +59,7 @@ class JiraCloudConnector(BaseJiraConnector):
         )
 
         while True:
-            jql = f'project = "{self.config.project_key}"'
-            if updated_after:
-                jql += f" AND updated >= '{updated_after.strftime('%Y-%m-%d %H:%M')}'"
+            jql = self._build_jql_filter(updated_after)
 
             params = {
                 "jql": jql,

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
@@ -161,6 +161,25 @@ class BaseJiraConnector(BaseConnector):
                     ),
                 )
 
+    @staticmethod
+    def _escape_jql_literal(value: str) -> str:
+        """Escape special characters in JQL string literals.
+
+        Escapes backslashes and double quotes to prevent JQL injection
+        and query breaking when config values contain these characters.
+
+        Args:
+            value: The string value to escape
+
+        Returns:
+            str: The escaped string safe for inclusion in JQL quoted literals
+        """
+        # Replace backslash first to avoid double-escaping
+        value = value.replace("\\", "\\\\")
+        # Then escape double quotes
+        value = value.replace('"', '\\"')
+        return value
+
     def _build_jql_filter(self, updated_after: datetime | None = None) -> str:
         """Build JQL filter query with project key, issue types, and statuses.
 
@@ -170,17 +189,24 @@ class BaseJiraConnector(BaseConnector):
         Returns:
             str: JQL filter query
         """
-        jql = f'project = "{self.config.project_key}"'
+        escaped_project_key = self._escape_jql_literal(self.config.project_key)
+        jql = f'project = "{escaped_project_key}"'
 
         # Add issue type filter if configured
         if self.config.issue_types:
-            types_str = ", ".join(f'"{t}"' for t in self.config.issue_types)
+            escaped_types = [
+                self._escape_jql_literal(t) for t in self.config.issue_types
+            ]
+            types_str = ", ".join(f'"{t}"' for t in escaped_types)
             jql += f" AND type IN ({types_str})"
             logger.debug(f"Applied JIRA issue type filter: {self.config.issue_types}")
 
         # Add status filter if configured
         if self.config.include_statuses:
-            statuses_str = ", ".join(f'"{s}"' for s in self.config.include_statuses)
+            escaped_statuses = [
+                self._escape_jql_literal(s) for s in self.config.include_statuses
+            ]
+            statuses_str = ", ".join(f'"{s}"' for s in escaped_statuses)
             jql += f" AND status IN ({statuses_str})"
             logger.debug(f"Applied JIRA status filter: {self.config.include_statuses}")
 

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
@@ -161,6 +161,35 @@ class BaseJiraConnector(BaseConnector):
                     ),
                 )
 
+    def _build_jql_filter(self, updated_after: datetime | None = None) -> str:
+        """Build JQL filter query with project key, issue types, and statuses.
+
+        Args:
+            updated_after: Optional datetime to filter issues updated after this time
+
+        Returns:
+            str: JQL filter query
+        """
+        jql = f'project = "{self.config.project_key}"'
+
+        # Add issue type filter if configured
+        if self.config.issue_types:
+            types_str = ", ".join(f'"{t}"' for t in self.config.issue_types)
+            jql += f" AND type IN ({types_str})"
+            logger.debug(f"Applied JIRA issue type filter: {self.config.issue_types}")
+
+        # Add status filter if configured
+        if self.config.include_statuses:
+            statuses_str = ", ".join(f'"{s}"' for s in self.config.include_statuses)
+            jql += f" AND status IN ({statuses_str})"
+            logger.debug(f"Applied JIRA status filter: {self.config.include_statuses}")
+
+        # Add updated_after filter if provided
+        if updated_after:
+            jql += f" AND updated >= '{updated_after.strftime('%Y-%m-%d %H:%M')}'"
+
+        return jql
+
     async def __aenter__(self):
         """Async context manager entry."""
         if not self._initialized:

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/data_center_connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/data_center_connector.py
@@ -55,9 +55,7 @@ class JiraDataCenterConnector(BaseJiraConnector):
         )
 
         while True:
-            jql = f'project = "{self.config.project_key}"'
-            if updated_after:
-                jql += f" AND updated >= '{updated_after.strftime('%Y-%m-%d %H:%M')}'"
+            jql = self._build_jql_filter(updated_after)
 
             params = {
                 "jql": jql,

--- a/packages/qdrant-loader/tests/config.test.template.yaml
+++ b/packages/qdrant-loader/tests/config.test.template.yaml
@@ -20,40 +20,41 @@ global:
     url: "${QDRANT_URL}"
     api_key: "${QDRANT_API_KEY}"
     collection_name: "${QDRANT_COLLECTION_NAME}"
-  
+
   # Chunking configuration for tests
   chunking:
     chunk_size: 500
     chunk_overlap: 50
-  
+
   embedding:
     model: text-embedding-3-small
-    api_key: "${OPENAI_API_KEY}"     # API key for the embedding service (required for OpenAI models)
-    batch_size: 10  # Smaller batch size for tests
-    
+    api_key: "${OPENAI_API_KEY}" # API key for the embedding service (required for OpenAI models)
+    batch_size: 10 # Smaller batch size for tests
+
   semantic_analysis:
-    num_topics: 3                    # Number of topics to extract using LDA
-    lda_passes: 10                   # Number of passes for LDA training
-    spacy_model: "en_core_web_md"    # spaCy model for text processing
-                                     # Options: en_core_web_sm (15MB, no vectors)
-                                     #          en_core_web_md (50MB, 20k vectors) - recommended
-                                     #          en_core_web_lg (750MB, 514k vectors)  
+    num_topics: 3 # Number of topics to extract using LDA
+    lda_passes: 10 # Number of passes for LDA training
+    spacy_model:
+      "en_core_web_md" # spaCy model for text processing
+      # Options: en_core_web_sm (15MB, no vectors)
+      #          en_core_web_md (50MB, 20k vectors) - recommended
+      #          en_core_web_lg (750MB, 514k vectors)
   state_management:
-    database_path: ":memory:"  # Use in-memory SQLite for tests
+    database_path: ":memory:" # Use in-memory SQLite for tests
     table_prefix: "test_qdrant_loader_"
     connection_pool:
-      size: 1  # Single connection for tests
-      timeout: 5  # Shorter timeout for tests
-  
+      size: 1 # Single connection for tests
+      timeout: 5 # Shorter timeout for tests
+
   # File conversion configuration for tests
   # Using smaller limits for faster test execution
   file_conversion:
     # Maximum file size for conversion (in bytes) - 10MB for tests
-    max_file_size: 10485760  # 10MB (smaller than production default)
-    
+    max_file_size: 10485760 # 10MB (smaller than production default)
+
     # Timeout for conversion operations (in seconds) - shorter for tests
-    conversion_timeout: 60  # 1 minute (shorter than production default)
-    
+    conversion_timeout: 60 # 1 minute (shorter than production default)
+
     # MarkItDown specific settings
     markitdown:
       # Disable LLM integration for tests to avoid API calls
@@ -71,14 +72,14 @@ projects:
     project_id: "default"
     display_name: "Test Project"
     description: "Default test project for unit tests"
-    
+
     # Source-specific configurations
     sources:
       publicdocs:
         test-docs:
           source_type: "publicdocs"
           source: "test-docs"
-          base_url: https://docs.python.org/3/tutorial/  # Using Python docs as test site
+          base_url: https://docs.python.org/3/tutorial/ # Using Python docs as test site
           version: "3.12"
           content_type: html
           exclude_paths:
@@ -106,7 +107,7 @@ projects:
           token: "${REPO_TOKEN}"
           include_paths: ["/", "docs/**/*", "src/main/**/*", "README.md"]
           exclude_paths: ["src/test/**/*"]
-          file_types: ["*.md","*.java"]
+          file_types: ["*.md", "*.java"]
           max_file_size: 1048576
           depth: 1
 
@@ -143,6 +144,14 @@ projects:
           project_key: "${JIRA_PROJECT_KEY}"
           requests_per_minute: 60
           page_size: 50
+          issue_types:
+            - "Bug"
+            - "Story"
+            - "Task"
+          include_statuses:
+            - "Open"
+            - "In Progress"
+            - "Done"
           process_attachments: true
           track_last_sync: true
           token: "${JIRA_TOKEN}"
@@ -159,7 +168,7 @@ projects:
         test-files:
           source_type: "localfile"
           source: "test-files"
-          base_url: "file:///tmp/test-files"  # Test directory
+          base_url: "file:///tmp/test-files" # Test directory
           include_paths:
             - "docs/**"
             - "*.md"
@@ -175,7 +184,7 @@ projects:
             - "*.docx"
             - "*.xlsx"
             - "*.pptx"
-          max_file_size: 5242880  # 5MB for tests
+          max_file_size: 5242880 # 5MB for tests
 
           # File conversion settings for this source
           # Enable file conversion for testing

--- a/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
+++ b/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
@@ -637,6 +637,33 @@ class TestJiraConnector:
 
         assert jql == 'project = "TEST"'
 
+    def test_escape_jql_literal_handles_quotes_and_backslashes(self):
+        """Test JQL literal escaping for unsafe characters."""
+        assert JiraCloudConnector._escape_jql_literal('MY"PROJECT') == 'MY\\"PROJECT'
+        assert JiraCloudConnector._escape_jql_literal(r"ABC\DEF") == r"ABC\\DEF"
+        assert JiraCloudConnector._escape_jql_literal('A"B\\C') == 'A\\"B\\\\C'
+
+    def test_jql_filter_build_escapes_all_config_literals(self):
+        """Test JQL filter builder escapes project, issue type and status values."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key='MY"PROJECT\\KEY',
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            issue_types=['Bug"Type', r"Feature\Request"],
+            include_statuses=['Open"Status', r"In\Progress"],
+        )
+        connector = JiraCloudConnector(config)
+        jql = connector._build_jql_filter()
+
+        assert 'project = "MY\\"PROJECT\\\\KEY"' in jql
+        assert '"Bug\\"Type"' in jql
+        assert '"Feature\\\\Request"' in jql
+        assert '"Open\\"Status"' in jql
+        assert '"In\\\\Progress"' in jql
+
     @pytest.mark.asyncio
     async def test_cloud_issue_filtering(
         self, jira_cloud_config, mock_cloud_issue_data

--- a/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
+++ b/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
@@ -563,3 +563,159 @@ class TestJiraConnector:
         )
         connector = JiraDataCenterConnector(datacenter_config)
         assert connector._auto_detect_deployment_type() == JiraDeploymentType.DATACENTER
+
+    def test_jql_filter_build_with_issue_types(self, jira_cloud_config):
+        """Test JQL filter builder with issue_types."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            issue_types=["Bug", "Story"],
+        )
+        connector = JiraCloudConnector(config)
+        jql = connector._build_jql_filter()
+
+        assert 'project = "TEST"' in jql
+        assert "type IN " in jql
+        assert '"Bug"' in jql
+        assert '"Story"' in jql
+
+    def test_jql_filter_build_with_statuses(self, jira_cloud_config):
+        """Test JQL filter builder with include_statuses."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            include_statuses=["Open", "In Progress"],
+        )
+        connector = JiraCloudConnector(config)
+        jql = connector._build_jql_filter()
+
+        assert 'project = "TEST"' in jql
+        assert "status IN " in jql
+        assert '"Open"' in jql
+        assert '"In Progress"' in jql
+
+    def test_jql_filter_build_with_all_filters(self, jira_cloud_config):
+        """Test JQL filter builder with all filters combined."""
+        from datetime import datetime
+
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            issue_types=["Bug", "Story"],
+            include_statuses=["Open", "In Progress"],
+        )
+        connector = JiraCloudConnector(config)
+        updated_after = datetime(2024, 1, 1, 12, 0)
+        jql = connector._build_jql_filter(updated_after=updated_after)
+
+        assert 'project = "TEST"' in jql
+        assert "type IN " in jql
+        assert '"Bug"' in jql
+        assert '"Story"' in jql
+        assert "status IN " in jql
+        assert '"Open"' in jql
+        assert '"In Progress"' in jql
+        assert "updated >= " in jql
+        assert "2024-01-01" in jql
+
+    def test_jql_filter_build_no_filters(self, jira_cloud_config):
+        """Test JQL filter builder without any optional filters."""
+        connector = JiraCloudConnector(jira_cloud_config)
+        jql = connector._build_jql_filter()
+
+        assert jql == 'project = "TEST"'
+
+    @pytest.mark.asyncio
+    async def test_cloud_issue_filtering(
+        self, jira_cloud_config, mock_cloud_issue_data
+    ):
+        """Test that issue filtering is applied in Cloud connector."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            issue_types=["Bug"],
+            include_statuses=["Open"],
+        )
+        connector = JiraCloudConnector(config)
+
+        # Track the JQL query used
+        captured_jql = None
+
+        async def mock_make_request(method, endpoint, **kwargs):
+            nonlocal captured_jql
+            if "params" in kwargs:
+                captured_jql = kwargs["params"].get("jql")
+            return {"issues": [mock_cloud_issue_data]}
+
+        with patch.object(connector, "_make_request", side_effect=mock_make_request):
+            async with connector:
+                issues = []
+                async for issue in connector.get_issues():
+                    issues.append(issue)
+                    break  # Just get the first one
+
+        # Verify filtering was applied in the JQL query
+        assert captured_jql is not None
+        assert 'project = "TEST"' in captured_jql
+        assert "type IN " in captured_jql
+        assert '"Bug"' in captured_jql
+        assert "status IN " in captured_jql
+        assert '"Open"' in captured_jql
+
+    @pytest.mark.asyncio
+    async def test_datacenter_issue_filtering(
+        self, jira_data_center_config, mock_data_center_issue_data
+    ):
+        """Test that issue filtering is applied in Data Center connector."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://jira.company.com"),
+            deployment_type=JiraDeploymentType.DATACENTER,
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-pat-token",
+            issue_types=["Bug", "Task"],
+            include_statuses=["Done"],
+        )
+        connector = JiraDataCenterConnector(config)
+
+        # Track the JQL query used
+        captured_jql = None
+
+        async def mock_make_request(method, endpoint, **kwargs):
+            nonlocal captured_jql
+            if "params" in kwargs:
+                captured_jql = kwargs["params"].get("jql")
+            return {"issues": [mock_data_center_issue_data], "total": 1}
+
+        with patch.object(connector, "_make_request", side_effect=mock_make_request):
+            async with connector:
+                issues = []
+                async for issue in connector.get_issues():
+                    issues.append(issue)
+                    break  # Just get the first one
+
+        # Verify filtering was applied in the JQL query
+        assert captured_jql is not None
+        assert 'project = "TEST"' in captured_jql
+        assert "type IN " in captured_jql
+        assert '"Bug"' in captured_jql
+        assert '"Task"' in captured_jql
+        assert "status IN " in captured_jql
+        assert '"Done"' in captured_jql


### PR DESCRIPTION


# Pull Request

## Summary

add optional figuration issue_types and include_statuses for jira connector
## Type of change

- [ ] Feature
- [x] Bug fix
- [x] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages: config.test.template.yaml
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and cleaned up Jira query construction used by cloud and data center connectors.
  * Introduced safer handling of query literals and unified assembly of project, issue-type, status and optional updated-after filters.
  * Added debug logging around applied filters for improved observability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->