### PR TITLE
fix: contextual embedding chunk content

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/chunking_service.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/chunking_service.py
@@ -207,7 +207,7 @@ class ChunkingService:
             prefix = document.build_contextual_content()
             for chunk in chunked_docs:
                 chunk.contextual_content = (
-                    f"{prefix}{chunk.content}" if prefix else chunk.content
+                    f"{prefix}" if prefix else ""
                 )
 
             # Optimized: Only calculate and log detailed metrics when debug logging is enabled

--- a/packages/qdrant-loader/src/qdrant_loader/core/document.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/document.py
@@ -366,7 +366,7 @@ class Document(BaseModel):
             return None
         parts = [
             f"Source: {self.source_type}",
-            f"Document: {self.title}",
+            f"Title: {self.title}",
         ]
         project = self.metadata.get("project_name")
         if project:


### PR DESCRIPTION
# Pull Request

## Summary

- Remove chunk content
- Replace a key of contextual content parts

## Type of change

- [ ] Feature
- [X] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate chunk text from appearing in per-chunk contextual metadata when a contextual prefix is present.
  * Clarified contextual content label by changing the title segment from "Document" to "Title" for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->