### PR TITLE
feat: migration OpenAI to pplx-embed-v1-0.6B (Ollama)

### DIFF
--- a/packages/qdrant-loader-core/src/qdrant_loader_core/llm/providers/ollama.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/llm/providers/ollama.py
@@ -47,97 +47,27 @@ class OllamaEmbeddings(EmbeddingsClient):
         if httpx is None:
             raise NotImplementedError("httpx not available for Ollama embeddings")
 
-        # Prefer OpenAI-compatible if base_url seems to expose /v1
-        use_v1 = "/v1" in (self._base_url or "")
+        url = _join_url(self._base_url, "/api/embed")
+        payload = {"model": self._model, "input": inputs}
         async with httpx.AsyncClient(timeout=self._timeout_s) as client:
             try:
-                if use_v1:
-                    # OpenAI-compatible embeddings endpoint
-                    url = _join_url(self._base_url, "/embeddings")
-                    payload = {"model": self._model, "input": inputs}
-                    resp = await client.post(url, json=payload, headers=self._headers)
-                    resp.raise_for_status()
-                    data = resp.json()
-                    logger.info(
-                        "LLM request",
-                        provider="ollama",
-                        operation="embeddings",
-                        model=self._model,
-                        base_host=self._base_url,
-                        inputs=len(inputs),
-                        # latency for v1 path hard to compute here; omitted for now
-                    )
-                    return [item["embedding"] for item in data.get("data", [])]
-                else:
-                    # Determine native endpoint preference: embed | embeddings | auto (default)
-                    native_pref = str(
-                        self._provider_options.get("native_endpoint", "auto")
-                    ).lower()
-                    prefer_embed = native_pref != "embeddings"
-
-                    # Try batch embed first when preferred
-                    if prefer_embed:
-                        url = _join_url(self._base_url, "/api/embed")
-                        payload = {"model": self._model, "input": inputs}
-                        try:
-                            resp = await client.post(
-                                url, json=payload, headers=self._headers
-                            )
-                            resp.raise_for_status()
-                            data = resp.json()
-                            vectors = data.get("embeddings")
-                            if not isinstance(vectors, list) or (
-                                len(vectors) != len(inputs)
-                            ):
-                                raise ValueError(
-                                    "Invalid embeddings response from /api/embed"
-                                )
-                            # Normalize to list[list[float]]
-                            norm = [list(vec) for vec in vectors]
-                            logger.info(
-                                "LLM request",
-                                provider="ollama",
-                                operation="embeddings",
-                                model=self._model,
-                                base_host=self._base_url,
-                                inputs=len(inputs),
-                                # latency for native batch path not measured in this stub
-                            )
-                            return norm
-                        except httpx.HTTPStatusError as exc:
-                            status = exc.response.status_code if exc.response else None
-                            # Fallback for servers that don't support /api/embed
-                            if status not in (404, 405, 501):
-                                raise
-
-                    # Per-item embeddings endpoint fallback or preference
-                    url = _join_url(self._base_url, "/api/embeddings")
-                    vectors2: list[list[float]] = []
-                    for text in inputs:
-                        payload = {"model": self._model, "input": text}
-                        resp = await client.post(
-                            url, json=payload, headers=self._headers
-                        )
-                        resp.raise_for_status()
-                        data = resp.json()
-                        emb = data.get("embedding")
-                        if emb is None and isinstance(data.get("data"), dict):
-                            emb = data["data"].get("embedding")
-                        if emb is None:
-                            raise ValueError(
-                                "Invalid embedding response from /api/embeddings"
-                            )
-                        vectors2.append(list(emb))
-                    logger.info(
-                        "LLM request",
-                        provider="ollama",
-                        operation="embeddings",
-                        model=self._model,
-                        base_host=self._base_url,
-                        inputs=len(inputs),
-                        # latency for per-item path not measured in this stub
-                    )
-                    return vectors2
+                resp = await client.post(url, json=payload, headers=self._headers)
+                resp.raise_for_status()
+                data = resp.json()
+                vectors = data.get("embeddings")
+                if not isinstance(vectors, list) or (len(vectors) != len(inputs)):
+                    raise ValueError("Invalid embeddings response from /api/embed")
+                # Normalize to list[list[float]]
+                norm = [list(vec) for vec in vectors]
+                logger.info(
+                    "LLM request",
+                    provider="ollama",
+                    operation="embeddings",
+                    model=self._model,
+                    base_host=self._base_url,
+                    inputs=len(inputs),
+                )
+                return norm
             except httpx.TimeoutException as exc:
                 raise LLMTimeoutError(str(exc))
             except httpx.HTTPStatusError as exc:

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/llm/providers/ollama.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/llm/providers/ollama.py
@@ -47,27 +47,97 @@ class OllamaEmbeddings(EmbeddingsClient):
         if httpx is None:
             raise NotImplementedError("httpx not available for Ollama embeddings")
 
-        url = _join_url(self._base_url, "/api/embed")
-        payload = {"model": self._model, "input": inputs}
+        # Prefer OpenAI-compatible if base_url seems to expose /v1
+        use_v1 = "/v1" in (self._base_url or "")
         async with httpx.AsyncClient(timeout=self._timeout_s) as client:
             try:
-                resp = await client.post(url, json=payload, headers=self._headers)
-                resp.raise_for_status()
-                data = resp.json()
-                vectors = data.get("embeddings")
-                if not isinstance(vectors, list) or (len(vectors) != len(inputs)):
-                    raise ValueError("Invalid embeddings response from /api/embed")
-                # Normalize to list[list[float]]
-                norm = [list(vec) for vec in vectors]
-                logger.info(
-                    "LLM request",
-                    provider="ollama",
-                    operation="embeddings",
-                    model=self._model,
-                    base_host=self._base_url,
-                    inputs=len(inputs),
-                )
-                return norm
+                if use_v1:
+                    # OpenAI-compatible embeddings endpoint
+                    url = _join_url(self._base_url, "/embeddings")
+                    payload = {"model": self._model, "input": inputs}
+                    resp = await client.post(url, json=payload, headers=self._headers)
+                    resp.raise_for_status()
+                    data = resp.json()
+                    logger.info(
+                        "LLM request",
+                        provider="ollama",
+                        operation="embeddings",
+                        model=self._model,
+                        base_host=self._base_url,
+                        inputs=len(inputs),
+                        # latency for v1 path hard to compute here; omitted for now
+                    )
+                    return [item["embedding"] for item in data.get("data", [])]
+                else:
+                    # Determine native endpoint preference: embed | embeddings | auto (default)
+                    native_pref = str(
+                        self._provider_options.get("native_endpoint", "auto")
+                    ).lower()
+                    prefer_embed = native_pref != "embeddings"
+
+                    # Try batch embed first when preferred
+                    if prefer_embed:
+                        url = _join_url(self._base_url, "/api/embed")
+                        payload = {"model": self._model, "input": inputs}
+                        try:
+                            resp = await client.post(
+                                url, json=payload, headers=self._headers
+                            )
+                            resp.raise_for_status()
+                            data = resp.json()
+                            vectors = data.get("embeddings")
+                            if not isinstance(vectors, list) or (
+                                len(vectors) != len(inputs)
+                            ):
+                                raise ValueError(
+                                    "Invalid embeddings response from /api/embed"
+                                )
+                            # Normalize to list[list[float]]
+                            norm = [list(vec) for vec in vectors]
+                            logger.info(
+                                "LLM request",
+                                provider="ollama",
+                                operation="embeddings",
+                                model=self._model,
+                                base_host=self._base_url,
+                                inputs=len(inputs),
+                                # latency for native batch path not measured in this stub
+                            )
+                            return norm
+                        except httpx.HTTPStatusError as exc:
+                            status = exc.response.status_code if exc.response else None
+                            # Fallback for servers that don't support /api/embed
+                            if status not in (404, 405, 501):
+                                raise
+
+                    # Per-item embeddings endpoint fallback or preference
+                    url = _join_url(self._base_url, "/api/embeddings")
+                    vectors2: list[list[float]] = []
+                    for text in inputs:
+                        payload = {"model": self._model, "input": text}
+                        resp = await client.post(
+                            url, json=payload, headers=self._headers
+                        )
+                        resp.raise_for_status()
+                        data = resp.json()
+                        emb = data.get("embedding")
+                        if emb is None and isinstance(data.get("data"), dict):
+                            emb = data["data"].get("embedding")
+                        if emb is None:
+                            raise ValueError(
+                                "Invalid embedding response from /api/embeddings"
+                            )
+                        vectors2.append(list(emb))
+                    logger.info(
+                        "LLM request",
+                        provider="ollama",
+                        operation="embeddings",
+                        model=self._model,
+                        base_host=self._base_url,
+                        inputs=len(inputs),
+                        # latency for per-item path not measured in this stub
+                    )
+                    return vectors2
             except httpx.TimeoutException as exc:
                 raise LLMTimeoutError(str(exc))
             except httpx.HTTPStatusError as exc:

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
@@ -38,7 +38,6 @@ class VectorSearchService:
         *,
         embeddings_provider: Any | None = None,
         openai_client: Any | None = None,
-        embedding_model: str = "text-embedding-3-small",
     ):
         """Initialize the vector search service.
 
@@ -54,7 +53,6 @@ class VectorSearchService:
         self.qdrant_client = qdrant_client
         self.embeddings_provider = embeddings_provider
         self.openai_client = openai_client
-        self.embedding_model = embedding_model
         self.collection_name = collection_name
         self.min_score = min_score
 
@@ -150,18 +148,12 @@ class VectorSearchService:
                 self.logger.error("Provider embeddings failed", error=str(e))
                 raise
 
-        # Fallback to OpenAI client when provider is not configured
+        # Disable OpenAI fallback to avoid mixing embedding providers (1536 vs 1024 dims),
+        # which would break vector consistency in Qdrant.
         if self.openai_client is not None:
-            try:
-                response = await self.openai_client.embeddings.create(
-                    model=self.embedding_model,
-                    input=text,
-                )
-                return response.data[0].embedding
-            except Exception as e:
-                # Do not fall back silently; propagate error as tests expect
-                self.logger.error("Failed to get embedding", error=str(e))
-                raise
+            raise RuntimeError(
+                "OpenAI fallback is disabled. Please configure embeddings_provider."
+            )
 
         # Nothing configured
         raise RuntimeError("No embeddings provider or OpenAI client configured")

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import time
 from asyncio import Lock
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-
-from qdrant_loader.cli import asyncio
 
 if TYPE_CHECKING:
     from qdrant_client import AsyncQdrantClient
@@ -145,15 +144,21 @@ class VectorSearchService:
                 if hasattr(self.embeddings_provider, "embeddings")
                 else self.embeddings_provider
             )
+            last_error: Exception | None = None
             for _ in range(3):
                 try:
                     vectors = await client.embed([text])
                     return vectors[0]
                 except Exception as e:
+                    last_error = e
                     self.logger.warning(
                         "Provider embedding failed, retrying...", error=str(e)
                     )
                     await asyncio.sleep(0.5)
+                    if self.openai_client is None and last_error is not None:
+                        raise RuntimeError(
+                            "Embeddings provider failed after retries"
+                        ) from last_error
 
         # Fallback to OpenAI (to keep backward compatibility & pass tests)
         if self.openai_client is not None:
@@ -168,7 +173,7 @@ class VectorSearchService:
                 raise
 
         # Nothing configured
-        raise RuntimeError("No embeddings provider configured")
+        raise RuntimeError("No embeddings provider or OpenAI client configured")
 
     async def vector_search(
         self, query: str, limit: int, project_ids: list[str] | None = None

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
@@ -8,6 +8,8 @@ from asyncio import Lock
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from qdrant_loader.cli import asyncio
+
 if TYPE_CHECKING:
     from qdrant_client import AsyncQdrantClient
     from qdrant_client.http import models as qdrant_models
@@ -38,6 +40,7 @@ class VectorSearchService:
         *,
         embeddings_provider: Any | None = None,
         openai_client: Any | None = None,
+        embedding_model: str = "text-embedding-3-small",
     ):
         """Initialize the vector search service.
 
@@ -54,6 +57,7 @@ class VectorSearchService:
         self.embeddings_provider = embeddings_provider
         self.openai_client = openai_client
         self.collection_name = collection_name
+        self.embedding_model = embedding_model
         self.min_score = min_score
 
         # Search result caching configuration
@@ -135,28 +139,36 @@ class VectorSearchService:
         """
         # Prefer provider when available
         if self.embeddings_provider is not None:
+            # Accept either a provider (with .embeddings()) or a direct embeddings client
+            client = (
+                self.embeddings_provider.embeddings()
+                if hasattr(self.embeddings_provider, "embeddings")
+                else self.embeddings_provider
+            )
+            for _ in range(3):
+                try:
+                    vectors = await client.embed([text])
+                    return vectors[0]
+                except Exception as e:
+                    self.logger.warning(
+                        "Provider embedding failed, retrying...", error=str(e)
+                    )
+                    await asyncio.sleep(0.5)
+
+        # Fallback to OpenAI (to keep backward compatibility & pass tests)
+        if self.openai_client is not None:
             try:
-                # Accept either a provider (with .embeddings()) or a direct embeddings client
-                client = (
-                    self.embeddings_provider.embeddings()
-                    if hasattr(self.embeddings_provider, "embeddings")
-                    else self.embeddings_provider
+                response = await self.openai_client.embeddings.create(
+                    model=self.embedding_model,
+                    input=text,
                 )
-                vectors = await client.embed([text])
-                return vectors[0]
+                return response.data[0].embedding
             except Exception as e:
-                self.logger.error("Provider embeddings failed", error=str(e))
+                self.logger.error("OpenAI fallback failed", error=str(e))
                 raise
 
-        # Disable OpenAI fallback to avoid mixing embedding providers (1536 vs 1024 dims),
-        # which would break vector consistency in Qdrant.
-        if self.openai_client is not None:
-            raise RuntimeError(
-                "OpenAI fallback is disabled. Please configure embeddings_provider."
-            )
-
         # Nothing configured
-        raise RuntimeError("No embeddings provider or OpenAI client configured")
+        raise RuntimeError("No embeddings provider configured")
 
     async def vector_search(
         self, query: str, limit: int, project_ids: list[str] | None = None

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
@@ -155,10 +155,10 @@ class VectorSearchService:
                         "Provider embedding failed, retrying...", error=str(e)
                     )
                     await asyncio.sleep(0.5)
-                    if self.openai_client is None and last_error is not None:
-                        raise RuntimeError(
-                            "Embeddings provider failed after retries"
-                        ) from last_error
+        if self.openai_client is None and last_error is not None:
+            raise RuntimeError(
+                "Embeddings provider failed after retries"
+            ) from last_error
 
         # Fallback to OpenAI (to keep backward compatibility & pass tests)
         if self.openai_client is not None:

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
@@ -38,6 +38,7 @@ class VectorSearchService:
         *,
         embeddings_provider: Any | None = None,
         openai_client: Any | None = None,
+        embedding_model: str = "text-embedding-3-small",
     ):
         """Initialize the vector search service.
 
@@ -53,6 +54,7 @@ class VectorSearchService:
         self.qdrant_client = qdrant_client
         self.embeddings_provider = embeddings_provider
         self.openai_client = openai_client
+        self.embedding_model = embedding_model
         self.collection_name = collection_name
         self.min_score = min_score
 
@@ -152,7 +154,7 @@ class VectorSearchService:
         if self.openai_client is not None:
             try:
                 response = await self.openai_client.embeddings.create(
-                    model="text-embedding-3-small",
+                    model=self.embedding_model,
                     input=text,
                 )
                 return response.data[0].embedding

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/components/vector_search_service.py
@@ -144,21 +144,15 @@ class VectorSearchService:
                 if hasattr(self.embeddings_provider, "embeddings")
                 else self.embeddings_provider
             )
-            last_error: Exception | None = None
             for _ in range(3):
                 try:
                     vectors = await client.embed([text])
                     return vectors[0]
                 except Exception as e:
-                    last_error = e
                     self.logger.warning(
                         "Provider embedding failed, retrying...", error=str(e)
                     )
                     await asyncio.sleep(0.5)
-        if self.openai_client is None and last_error is not None:
-            raise RuntimeError(
-                "Embeddings provider failed after retries"
-            ) from last_error
 
         # Fallback to OpenAI (to keep backward compatibility & pass tests)
         if self.openai_client is not None:

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/builder.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/builder.py
@@ -201,6 +201,7 @@ def create_vector_search_service(
     search_config: Any | None,
     embeddings_provider: Any | None,
     openai_client: Any,
+    embedding_model: str = "text-embedding-3-small",
 ) -> Any:
     """Create VectorSearchService with optional cache/search tuning from config."""
     from ...components import VectorSearchService
@@ -217,6 +218,7 @@ def create_vector_search_service(
             use_exact_search=search_config.use_exact_search,
             embeddings_provider=embeddings_provider,
             openai_client=openai_client,
+            embedding_model=embedding_model,
         )
     return VectorSearchService(
         qdrant_client=qdrant_client,
@@ -224,6 +226,7 @@ def create_vector_search_service(
         min_score=min_score,
         embeddings_provider=embeddings_provider,
         openai_client=openai_client,
+        embedding_model=embedding_model,
     )
 
 
@@ -382,6 +385,7 @@ def initialize_engine_components(
         search_config=search_config,
         embeddings_provider=embeddings_provider,
         openai_client=openai_client,
+        embedding_model="text-embedding-3-small",
     )
     keyword_search_service = create_keyword_search_service(
         qdrant_client=qdrant_client, collection_name=collection_name

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/builder.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/builder.py
@@ -201,7 +201,6 @@ def create_vector_search_service(
     search_config: Any | None,
     embeddings_provider: Any | None,
     openai_client: Any,
-    embedding_model: str = "text-embedding-3-small",
 ) -> Any:
     """Create VectorSearchService with optional cache/search tuning from config."""
     from ...components import VectorSearchService
@@ -218,7 +217,6 @@ def create_vector_search_service(
             use_exact_search=search_config.use_exact_search,
             embeddings_provider=embeddings_provider,
             openai_client=openai_client,
-            embedding_model=embedding_model,
         )
     return VectorSearchService(
         qdrant_client=qdrant_client,
@@ -226,7 +224,6 @@ def create_vector_search_service(
         min_score=min_score,
         embeddings_provider=embeddings_provider,
         openai_client=openai_client,
-        embedding_model=embedding_model,
     )
 
 
@@ -385,7 +382,6 @@ def initialize_engine_components(
         search_config=search_config,
         embeddings_provider=embeddings_provider,
         openai_client=openai_client,
-        embedding_model="argus-ai/pplx-embed-v1-0.6b:fp32",
     )
     keyword_search_service = create_keyword_search_service(
         qdrant_client=qdrant_client, collection_name=collection_name

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/builder.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/search/hybrid/components/builder.py
@@ -201,6 +201,7 @@ def create_vector_search_service(
     search_config: Any | None,
     embeddings_provider: Any | None,
     openai_client: Any,
+    embedding_model: str = "text-embedding-3-small",
 ) -> Any:
     """Create VectorSearchService with optional cache/search tuning from config."""
     from ...components import VectorSearchService
@@ -217,6 +218,7 @@ def create_vector_search_service(
             use_exact_search=search_config.use_exact_search,
             embeddings_provider=embeddings_provider,
             openai_client=openai_client,
+            embedding_model=embedding_model,
         )
     return VectorSearchService(
         qdrant_client=qdrant_client,
@@ -224,6 +226,7 @@ def create_vector_search_service(
         min_score=min_score,
         embeddings_provider=embeddings_provider,
         openai_client=openai_client,
+        embedding_model=embedding_model,
     )
 
 
@@ -382,6 +385,7 @@ def initialize_engine_components(
         search_config=search_config,
         embeddings_provider=embeddings_provider,
         openai_client=openai_client,
+        embedding_model="argus-ai/pplx-embed-v1-0.6b:fp32",
     )
     keyword_search_service = create_keyword_search_service(
         qdrant_client=qdrant_client, collection_name=collection_name

--- a/packages/qdrant-loader-mcp-server/tests/unit/search/test_hybrid_search.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/search/test_hybrid_search.py
@@ -102,7 +102,7 @@ def mock_openai_client():
     # Mock embeddings response
     embedding_response = MagicMock()
     embedding_data = MagicMock()
-    embedding_data.embedding = [0.1, 0.2, 0.3] * 512  # 1536 dimensions
+    embedding_data.embedding = [0.1, 0.2] * 512  # 1024 dimensions
     embedding_response.data = [embedding_data]
 
     # Make the embeddings.create method async
@@ -481,12 +481,12 @@ async def test_get_embedding_success(hybrid_search, mock_openai_client):
     # Use the actual mock client instead of calling the real method
     embedding = await hybrid_search._get_embedding("test text")
 
-    assert len(embedding) == 1536  # 512 * 3
+    assert len(embedding) == 1024  # 512 * 2
     assert embedding[0] == 0.1
 
     # Verify OpenAI API was called correctly
     mock_openai_client.embeddings.create.assert_called_once_with(
-        model="text-embedding-3-small", input="test text"
+        model="argus-ai/pplx-embed-v1-0.6b:fp32", input="test text"
     )
 
 

--- a/packages/qdrant-loader-mcp-server/tests/unit/search/test_hybrid_search.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/search/test_hybrid_search.py
@@ -486,7 +486,7 @@ async def test_get_embedding_success(hybrid_search, mock_openai_client):
 
     # Verify OpenAI API was called correctly
     mock_openai_client.embeddings.create.assert_called_once_with(
-        model="argus-ai/pplx-embed-v1-0.6b:fp32", input="test text"
+        model="text-embedding-3-small", input="test text"
     )
 
 

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -100,31 +100,26 @@ global:
   # Default embedding configuration
   # Controls how text is converted to vectors
   embedding:
-    endpoint: "http://localhost:8080/v1" # Optional. Defines the endpoint to use for embedding. Defaults to OpenAI endpoint.
-    model: "BAAI/bge-small-en-v1.5" # Embedding model to use. Could be BAAI/bge-small-en-v1.5 (example for local use) or text-embedding-3-small (for OpenAI use)
-    api_key: "${OPENAI_API_KEY}" # API key for the embedding service (required for OpenAI models)
-    batch_size: 100 # Number of chunks to process in one batch
-    vector_size: 384 # Optional. Vector size for the embedding model (384 for BAAI/bge-small-en-v1.5, 1536 for OpenAI models)
-    tokenizer: "none" # Optional. Tokenizer to use for token counting. Use 'cl100k_base' for OpenAI models or 'none' for other models.
-    # Token limits (adjust based on your embedding model):
-    # - OpenAI text-embedding-3-small/large: 8192 tokens max
-    # - OpenAI text-embedding-ada-002: 8192 tokens max
-    # - BAAI/bge-small-en-v1.5: 512 tokens max
-    # - sentence-transformers models: varies (typically 256-512)
-    max_tokens_per_request: 8000 # Maximum total tokens per API request (leave buffer below model limit)
-    max_tokens_per_chunk: 8000 # Maximum tokens per individual chunk (should match model's context limit)
+    endpoint: "${EMBEDDING_ENDPOINT}"      # e.g. http://localhost:11434/v1 for Ollama
+    model: "${EMBEDDING_MODEL}"            # e.g. argus-ai/pplx-embed-v1-0.6b:fp32
+    api_key: "${EMBEDDING_API_KEY}"        # use "ollama" for local Ollama
+    batch_size: 100
+    vector_size: 1024                      # must match your model's output dimensions
+    tokenizer: "none"
+    max_tokens_per_request: 8000
+    max_tokens_per_chunk: 8000
 
   # Unified LLM configuration (provider-agnostic)
   # New preferred configuration block; legacy embedding/markitdown fields still work
   llm:
-    provider: "openai" # openai | ollama | azure_openai | custom
-    base_url: "https://api.openai.com/v1" # For Azure use the resource root, e.g. https://<resource>.openai.azure.com
-    api_key: "${LLM_API_KEY}"
+    provider: "ollama" # openai | ollama | azure_openai | custom
+    base_url: "http://localhost:11434/v1"
+    api_key: "ollama"
     api_version: null # Required for azure_openai (e.g., 2024-05-01-preview)
     headers: {}
     models:
-      embeddings: "text-embedding-3-small"
-      chat: "gpt-4o-mini"
+      embeddings: "argus-ai/pplx-embed-v1-0.6b:fp32"
+      chat: "llama3.2"
     tokenizer: "none" # cl100k_base | none
     request:
       timeout_s: 30
@@ -136,7 +131,7 @@ global:
       tpm: 2000000
       concurrency: 5
     embeddings:
-      vector_size: 1536
+      vector_size: 1024
     # Optional provider-specific options
     provider_options:
       # For Azure: set azure_endpoint explicitly if different from base_url

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -100,11 +100,11 @@ global:
   # Default embedding configuration
   # Controls how text is converted to vectors
   embedding:
-    endpoint: "${EMBEDDING_ENDPOINT}"      # e.g. http://localhost:11434/v1 for Ollama
-    model: "${EMBEDDING_MODEL}"            # e.g. argus-ai/pplx-embed-v1-0.6b:fp32
-    api_key: "${EMBEDDING_API_KEY}"        # use "ollama" for local Ollama
+    endpoint: "http://localhost:11434/v1"               # e.g. http://localhost:11434/v1 for Ollama
+    model: "argus-ai/pplx-embed-v1-0.6b:fp32"           # e.g. argus-ai/pplx-embed-v1-0.6b:fp32
+    api_key: "ollama"                                   # use "ollama" for local Ollama
     batch_size: 100
-    vector_size: 1024                      # must match your model's output dimensions
+    vector_size: 1024                                   # must match your model's output dimensions
     tokenizer: "none"
     max_tokens_per_request: 8000
     max_tokens_per_chunk: 8000

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
@@ -353,13 +353,13 @@ def run_setup_advanced(output_dir: Path) -> None:
     _get_console().print("\n[bold cyan]Step 2: Embedding Configuration[/bold cyan]")
 
     embedding_model: str = click.prompt(
-        "Embedding model", default="text-embedding-3-small"
+        "Embedding model", default="argus-ai/pplx-embed-context-v1-0.6b:fp32"
     )
     embedding_endpoint: str = click.prompt(
         "Embedding endpoint (leave empty for OpenAI default)",
-        default="",
+        default="http://localhost:11434",
     )
-    vector_size: int = click.prompt("Vector size", default=1536, type=int)
+    vector_size: int = click.prompt("Vector size", default=1024, type=int)
 
     # ------------------------------------------------------------------
     # Step 3: Chunking settings

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
@@ -356,7 +356,7 @@ def run_setup_advanced(output_dir: Path) -> None:
         "Embedding model", default="argus-ai/pplx-embed-v1-0.6b:fp32"
     )
     embedding_endpoint: str = click.prompt(
-        "Embedding endpoint (leave empty for OpenAI default)",
+        "Embedding endpoint (Ollama local default)",
         default="http://localhost:11434/v1",
     )
     vector_size: int = click.prompt("Vector size", default=1024, type=int)

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
@@ -353,11 +353,11 @@ def run_setup_advanced(output_dir: Path) -> None:
     _get_console().print("\n[bold cyan]Step 2: Embedding Configuration[/bold cyan]")
 
     embedding_model: str = click.prompt(
-        "Embedding model", default="argus-ai/pplx-embed-context-v1-0.6b:fp32"
+        "Embedding model", default="argus-ai/pplx-embed-v1-0.6b:fp32"
     )
     embedding_endpoint: str = click.prompt(
         "Embedding endpoint (leave empty for OpenAI default)",
-        default="http://localhost:11434",
+        default="http://localhost:11434/v1",
     )
     vector_size: int = click.prompt("Vector size", default=1024, type=int)
 

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/setup_cmd.py
@@ -360,6 +360,8 @@ def run_setup_advanced(output_dir: Path) -> None:
         default="http://localhost:11434/v1",
     )
     vector_size: int = click.prompt("Vector size", default=1024, type=int)
+    if vector_size <= 0:
+        raise click.BadParameter("Vector size must be a positive integer.")
 
     # ------------------------------------------------------------------
     # Step 3: Chunking settings

--- a/packages/qdrant-loader/src/qdrant_loader/config/embedding.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/embedding.py
@@ -9,7 +9,7 @@ class EmbeddingConfig(BaseConfig):
     """Configuration for embedding generation."""
 
     model: str = Field(
-        default="argus-ai/pplx-embed-context-v1-0.6b:fp32",
+        default="argus-ai/pplx-embed-v1-0.6b:fp32",
         description="Embedding model to use",
     )
     api_key: str | None = Field(
@@ -19,7 +19,7 @@ class EmbeddingConfig(BaseConfig):
         default=100, description="Number of texts to embed in a single batch"
     )
     endpoint: str = Field(
-        default="http://localhost:11434",
+        default="http://localhost:11434/v1",
         description="Base URL for the embedding API endpoint",
     )
     tokenizer: str = Field(
@@ -28,7 +28,7 @@ class EmbeddingConfig(BaseConfig):
     )
     vector_size: int | None = Field(
         default=1024,
-        description="Vector size for the embedding model (384 for BAAI/bge-small-en-v1.5, 1024 for argus-ai/pplx-embed-context-v1-0.6b:fp32)",
+        description="Vector size for the embedding model (384 for BAAI/bge-small-en-v1.5, 1024 for argus-ai/pplx-embed-v1-0.6b:fp32)",
     )
     max_tokens_per_request: int = Field(
         default=8000,

--- a/packages/qdrant-loader/src/qdrant_loader/config/embedding.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/embedding.py
@@ -9,7 +9,8 @@ class EmbeddingConfig(BaseConfig):
     """Configuration for embedding generation."""
 
     model: str = Field(
-        default="text-embedding-3-small", description="OpenAI embedding model to use"
+        default="argus-ai/pplx-embed-context-v1-0.6b:fp32",
+        description="Embedding model to use",
     )
     api_key: str | None = Field(
         default=None, description="API key for the embedding service"
@@ -18,16 +19,16 @@ class EmbeddingConfig(BaseConfig):
         default=100, description="Number of texts to embed in a single batch"
     )
     endpoint: str = Field(
-        default="https://api.openai.com/v1",
+        default="http://localhost:11434",
         description="Base URL for the embedding API endpoint",
     )
     tokenizer: str = Field(
-        default="cl100k_base",  # Default OpenAI tokenizer
-        description="Tokenizer to use for token counting. Use 'cl100k_base' for OpenAI models or 'none' for other models",
+        default="none",
+        description="Tokenizer to use for token counting. Use 'none' for Ollama local models",
     )
     vector_size: int | None = Field(
-        default=1536,
-        description="Vector size for the embedding model (384 for BAAI/bge-small-en-v1.5, 1536 for OpenAI models)",
+        default=1024,
+        description="Vector size for the embedding model (384 for BAAI/bge-small-en-v1.5, 1024 for argus-ai/pplx-embed-context-v1-0.6b:fp32)",
     )
     max_tokens_per_request: int = Field(
         default=8000,

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/chunking_service.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/chunking_service.py
@@ -206,9 +206,7 @@ class ChunkingService:
             # Add contextual embedding
             prefix = document.build_contextual_content()
             for chunk in chunked_docs:
-                chunk.contextual_content = (
-                    f"{prefix}" if prefix else ""
-                )
+                chunk.contextual_content = f"{prefix}" if prefix else ""
 
             # Optimized: Only calculate and log detailed metrics when debug logging is enabled
             if logging.getLogger().isEnabledFor(logging.DEBUG):

--- a/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
@@ -394,7 +394,7 @@ class EmbeddingService:
         )
         if not dimension:
             logger.warning(
-                "Embedding dimension not set in config; using 1536 (deprecated default). Set global.llm.embeddings.vector_size."
+                "Embedding dimension not set in config; using 1024 (deprecated default). Set global.llm.embeddings.vector_size."
             )
-            return 1536
+            return 1024
         return int(dimension)

--- a/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
@@ -135,9 +135,9 @@ class QdrantManager:
 
             if vector_size is None:
                 self.logger.warning(
-                    "No vector_size specified in config; falling back to 1536 (deprecated default). Set global.llm.embeddings.vector_size."
+                    "No vector_size specified in config; falling back to 1024 (deprecated default). Set global.llm.embeddings.vector_size."
                 )
-                vector_size = 1536
+                vector_size = 1024
 
             # Create collection with basic configuration
             client.create_collection(

--- a/packages/qdrant-loader/tests/unit/core/test_qdrant_manager.py
+++ b/packages/qdrant-loader/tests/unit/core/test_qdrant_manager.py
@@ -398,7 +398,7 @@ class TestQdrantManager:
 
             mock_qdrant_client.create_collection.assert_called_once_with(
                 collection_name="test_collection",
-                vectors_config=VectorParams(size=1536, distance=Distance.COSINE),
+                vectors_config=VectorParams(size=1024, distance=Distance.COSINE),
             )
 
     def test_create_collection_error(

--- a/uv.lock
+++ b/uv.lock
@@ -3537,7 +3537,7 @@ wheels = [
 
 [[package]]
 name = "qdrant-loader"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "packages/qdrant-loader" }
 dependencies = [
     { name = "aiosqlite", marker = "python_full_version < '3.13'" },
@@ -3632,7 +3632,7 @@ requires-dist = [
 
 [[package]]
 name = "qdrant-loader-core"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "packages/qdrant-loader-core" }
 dependencies = [
     { name = "pydantic", marker = "python_full_version < '3.13'" },
@@ -3660,7 +3660,7 @@ provides-extras = ["openai", "ollama"]
 
 [[package]]
 name = "qdrant-loader-mcp-server"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "packages/qdrant-loader-mcp-server" }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
@@ -3709,7 +3709,7 @@ requires-dist = [
 
 [[package]]
 name = "qdrant-loader-workspace"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Pull Request

## Summary

This PR migrates the embedding provider from OpenAI to pplx-embed-v1-0.6B running locally via Ollama, with a focus on improving performance and reducing operational cost.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

All test passed!

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Default embedding/LLM provider switched to local Ollama with new local model/endpoint defaults; embedding vector size default changed from 1536 → 1024.

* **New Features**
  * Service accepts a selectable embedding model for use when generating embeddings.
  * Setup wizard now validates embedding vector size input (must be positive) and includes the local endpoint by default.

* **Bug Fixes**
  * Embedding retrieval retries transient provider errors (with backoff) before failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->