### PR TITLE
chore(docs): align config.template.yaml, .env.template and user document with Ollama and OpenAI setup

### DIFF
--- a/docs/users/configuration/config-file-reference.md
+++ b/docs/users/configuration/config-file-reference.md
@@ -61,11 +61,11 @@ global:
     base_url: ${LLM_BASE_URL} # e.g. https://api.openai.com/v1, http://localhost:11434/v1
     api_key: ${LLM_API_KEY} # optional for local providers like Ollama
     models:
-      embeddings: ${LLM_EMBEDDING_MODEL} # e.g. text-embedding-3-small | nomic-embed-text | bge-small-en-v1.5
+      embeddings: ${LLM_EMBEDDING_MODEL} # e.g. text-embedding-3-small | argus-ai/pplx-embed-v1-0.6b:fp32
       chat: ${LLM_CHAT_MODEL} # e.g. gpt-4o-mini | llama3.1:8b-instruct
     tokenizer: cl100k_base # cl100k_base | none
     embeddings:
-      vector_size: 1536 # set according to chosen embedding model
+      vector_size: ${VECTOR_SIZE}
 
 projects:
   my-project:
@@ -95,13 +95,13 @@ global:
   llm:
     provider: ${LLM_PROVIDER}
     base_url: ${LLM_BASE_URL}
-    api_key: ${LLM_API_KEY}
+    api_key: ${LLM_API_KEY} # {OPENAI_API_KEY} if LLM_ PROVIDER=openai
     api_version: ${LLM_API_VERSION}  # Required for azure_openai
     headers: {}
     models:
       embeddings: ${LLM_EMBEDDING_MODEL}
       chat: ${LLM_CHAT_MODEL}
-    tokenizer: cl100k_base
+    tokenizer: none | # OpenAI: cl100k_base
     request:
       timeout_s: 30
       max_retries: 3
@@ -313,18 +313,18 @@ global:
     # Required: Provider and endpoint
     provider: ${LLM_PROVIDER}
     base_url: ${LLM_BASE_URL}
-    api_key: ${LLM_API_KEY}
+    api_key: ${LLM_API_KEY} # {OPENAI_API_KEY} if LLM_ PROVIDER=openai
     # Required: Models
     models:
       embeddings: ${LLM_EMBEDDING_MODEL}
       chat: ${LLM_CHAT_MODEL}
     # Optional: Tokenizer and policies
-    tokenizer: cl100k_base
+    tokenizer: none | # OpenAI: cl100k_base
     request:
       timeout_s: 30
       max_retries: 3
     embeddings:
-      vector_size: 1536
+      vector_size: ${VECTOR_SIZE}
 
 > Deprecation: `global.embedding.*` is still honored but will be removed in a future release. Migrate to `global.llm.*`.
 ```

--- a/docs/users/configuration/config-file-reference.md
+++ b/docs/users/configuration/config-file-reference.md
@@ -319,7 +319,7 @@ global:
       embeddings: ${LLM_EMBEDDING_MODEL}
       chat: ${LLM_CHAT_MODEL}
     # Optional: Tokenizer and policies
-    tokenizer: none | # OpenAI: cl100k_base
+    tokenizer: none # OpenAI: cl100k_base
     request:
       timeout_s: 30
       max_retries: 3

--- a/docs/users/configuration/config-file-reference.md
+++ b/docs/users/configuration/config-file-reference.md
@@ -101,7 +101,7 @@ global:
     models:
       embeddings: ${LLM_EMBEDDING_MODEL}
       chat: ${LLM_CHAT_MODEL}
-    tokenizer: none | # OpenAI: cl100k_base
+    tokenizer: none # OpenAI: cl100k_base
     request:
       timeout_s: 30
       max_retries: 3

--- a/packages/qdrant-loader/README.md
+++ b/packages/qdrant-loader/README.md
@@ -90,6 +90,50 @@ curl -o .env https://raw.githubusercontent.com/martin-papy/qdrant-loader/main/pa
 ```
 
 ### 2. Environment Configuration
+#### 🧠 LLM Provider Support
+
+This system is designed to support **both local and cloud-based Large Language Model (LLM) providers**.
+
+Currently supported providers:
+
+- **Ollama** — local models (**default and preferred**)
+- **OpenAI** — cloud-based models
+
+The system uses a **unified configuration approach**, allowing you to switch providers without changing application code.
+
+---
+
+#### 🖥️ Ollama (Local Models – Recommended)
+
+Ollama is the **default and recommended provider**, especially for local development and privacy-sensitive environments.
+
+#### Prerequisites
+
+To use **local models with Ollama**, ensure the following:
+
+1. **Ollama is installed and running on your machine**
+
+   - Ollama must be accessible at the configured endpoint  
+     (default: `http://localhost:11434`).
+
+   - Installation guide:  
+     https://ollama.com/download
+
+2. **Required models must be pulled locally before running the system**
+
+   - For embedding generation, the following model is required:
+
+   ```bash
+   ollama pull argus-ai/pplx-embed-v1-0.6b:fp32
+
+🖥️ OpenAI (Cloud Models)
+The system also supports OpenAI as a cloud-based LLM provider.
+#### Requirements: 
+**To use OpenAI, you must:**
+- Set the provider: `LLM_PROVIDER=openai`
+- Configure the OpenAI endpoint: `LLM_BASE_URL=https://api.openai.com/v1`
+- Provide a valid API key: `OPENAI_API_KEY=your_openai_key`
+
 
 Edit `.env` file:
 
@@ -99,15 +143,44 @@ QDRANT_URL=http://localhost:6333
 QDRANT_COLLECTION_NAME=my_docs
 QDRANT_API_KEY=your_api_key  # Required for QDrant Cloud
 
-# LLM Configuration (new unified approach)
-LLM_PROVIDER=openai
-LLM_BASE_URL=https://api.openai.com/v1
-LLM_API_KEY=your_openai_key
-LLM_EMBEDDING_MODEL=text-embedding-3-small
-LLM_CHAT_MODEL=gpt-4o-mini
+
+# =========================
+# LLM Configuration (Unified, Ollama-first)
+# =========================
+
+LLM_PROVIDER=ollama #openai
+# Possible values:
+#   - ollama (default, local)
+#   - openai (cloud)
+
+LLM_BASE_URL=http://localhost:11434/v1
+# Ollama: Local OpenAI-compatible endpoint
+# OpenAI equivalent: https://api.openai.com/v1
+
+LLM_API_KEY=ollama
+# Ollama: Always use "ollama" (no authentication required)
+# OpenAI: Use your real API key (e.g. sk-xxxx)
+
+
+LLM_EMBEDDING_MODEL=argus-ai/pplx-embed-v1-0.6b:fp32
+# Ollama: Local embedding model
+# OpenAI equivalent:
+#   - text-embedding-3-small (1536 dims)
+
+
+LLM_CHAT_MODEL=llama3.1:8b
+# Ollama: Local chat / instruction model
+# OpenAI equivalent:
+#   - gpt-4o
+#   - gpt-4o-mini
+
+VECTOR_SIZE=1024
+# OpenAI: 1536
+
 
 # Legacy (still supported)
 OPENAI_API_KEY=your_openai_key
+# Only used when LLM_PROVIDER=openai
 
 # State Management
 STATE_DB_PATH=./state.db
@@ -125,16 +198,16 @@ global_config:
     chunk_overlap: 200
   
   llm:
-    provider: "openai"
-    base_url: "https://api.openai.com/v1"
-    api_key: "${LLM_API_KEY}"
+    provider: "${LLM_PROVIDER}"
+    base_url: "${LLM_BASE_URL}"
+    api_key: "${LLM_API_KEY}" # {OPENAI_API_KEY} if LLM_ PROVIDER=openai
     models:
-      embeddings: "text-embedding-3-small"
-      chat: "gpt-4o-mini"
+      embeddings: "${LLM_EMBEDDING_MODEL}"
+      chat: "${LLM_CHAT_MODEL}"
     request:
       batch_size: 100
     embeddings:
-      vector_size: 1536
+      vector_size: "${VECTOR_SIZE}"
   
   file_conversion:
     max_file_size: 52428800  # 50MB

--- a/packages/qdrant-loader/README.md
+++ b/packages/qdrant-loader/README.md
@@ -207,7 +207,7 @@ global_config:
     request:
       batch_size: 100
     embeddings:
-      vector_size: "${VECTOR_SIZE}"
+      vector_size: ${VECTOR_SIZE}
   
   file_conversion:
     max_file_size: 52428800  # 50MB

--- a/packages/qdrant-loader/README.md
+++ b/packages/qdrant-loader/README.md
@@ -125,8 +125,9 @@ To use **local models with Ollama**, ensure the following:
 
    ```bash
    ollama pull argus-ai/pplx-embed-v1-0.6b:fp32
+   ```
 
-🖥️ OpenAI (Cloud Models)
+#### 🖥️ OpenAI (Cloud Models)
 The system also supports OpenAI as a cloud-based LLM provider.
 #### Requirements: 
 **To use OpenAI, you must:**

--- a/packages/qdrant-loader/conf/.env.template
+++ b/packages/qdrant-loader/conf/.env.template
@@ -43,7 +43,8 @@ VECTOR_SIZE=1024
 
 # Legacy (still supported)
 OPENAI_API_KEY=your_openai_key
-# Only used when LLM_PROVIDER=openai
+# Used by OpenAI flows and as a fallback in some conversion paths
+# (e.g., MarkItDown LLM descriptions) when explicit llm_api_key is not set.
 
 # State Management
 STATE_DB_PATH=./state.db

--- a/packages/qdrant-loader/conf/.env.template
+++ b/packages/qdrant-loader/conf/.env.template
@@ -2,11 +2,51 @@
 # Never commit .env with real secrets to version control.
 # Ensure .env is listed in .gitignore (it is by default).
 
-# OpenAI Configuration
-OPENAI_API_KEY=your_openai_api_key_here
+# QDrant Configuration
+QDRANT_URL=http://localhost:6333
+QDRANT_COLLECTION_NAME=my_docs
+QDRANT_API_KEY=your_api_key  # Required for QDrant Cloud
 
-# Qdrant Configuration
-QDRANT_API_KEY=your_qdrant_api_key_here
+
+# =========================
+# LLM Configuration (Unified, Ollama-first)
+# =========================
+
+LLM_PROVIDER=ollama #openai
+# Possible values:
+#   - ollama (default, local)
+#   - openai (cloud)
+
+LLM_BASE_URL=http://localhost:11434/v1
+# Ollama: Local OpenAI-compatible endpoint
+# OpenAI equivalent: https://api.openai.com/v1
+
+LLM_API_KEY=ollama
+# Ollama: Always use "ollama" (no authentication required)
+# OpenAI: Use your real API key (e.g. sk-xxxx)
+
+
+LLM_EMBEDDING_MODEL=argus-ai/pplx-embed-v1-0.6b:fp32
+# Ollama: Local embedding model
+# OpenAI equivalent:
+#   - text-embedding-3-small (1536 dims)
+
+
+LLM_CHAT_MODEL=llama3.1:8b
+# Ollama: Local chat / instruction model
+# OpenAI equivalent:
+#   - gpt-4o
+#   - gpt-4o-mini
+
+VECTOR_SIZE=1024
+# OpenAI: 1536
+
+# Legacy (still supported)
+OPENAI_API_KEY=your_openai_key
+# Only used when LLM_PROVIDER=openai
+
+# State Management
+STATE_DB_PATH=./state.db
 
 # Git Authentication Configuration
 # GitHub Personal Access Token for repository access

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -100,12 +100,22 @@ global:
   # Default embedding configuration
   # Controls how text is converted to vectors
   embedding:
-    endpoint: "http://localhost:11434/v1"               # e.g. http://localhost:11434/v1 for Ollama
-    model: "argus-ai/pplx-embed-v1-0.6b:fp32"           # e.g. argus-ai/pplx-embed-v1-0.6b:fp32
-    api_key: "ollama"                                   # use "ollama" for local Ollama
+    endpoint: "http://localhost:11434/v1"
+    # Ollama: Local Ollama OpenAI-compatible endpoint
+    # OpenAI equivalent: https://api.openai.com/v1       
+    model: "argus-ai/pplx-embed-v1-0.6b:fp32" 
+    # Ollama: Local embedding model name
+    # OpenAI equivalent: text-embedding-3-small   (1536 dimensions, cheaper)
+    api_key: "ollama"
+    # Ollama: Use the fixed value "ollama" (no real auth)
+    # OpenAI: Your real API key (e.g. sk-xxxx)
     batch_size: 100
-    vector_size: 1024                                   # must match your model's output dimensions
+    vector_size: 1024
+    # MUST match model output dimension
+    # OpenAI: text-embedding-3-small → 1536                      
     tokenizer: "none"
+    # Ollama: "none"
+    # OpenAI: "cl100k_base"
     max_tokens_per_request: 8000
     max_tokens_per_chunk: 8000
 
@@ -113,14 +123,14 @@ global:
   # New preferred configuration block; legacy embedding/markitdown fields still work
   llm:
     provider: "ollama" # openai | ollama | azure_openai | custom
-    base_url: "http://localhost:11434/v1"
-    api_key: "ollama"
+    base_url: "http://localhost:11434/v1" # OpenAI: https://api.openai.com/v1
+    api_key: "ollama" # Ollama: Use the fixed value "ollama" (no real auth), OpenAI: Your real API key (e.g. sk-xxxx)
     api_version: null # Required for azure_openai (e.g., 2024-05-01-preview)
     headers: {}
     models:
-      embeddings: "argus-ai/pplx-embed-v1-0.6b:fp32"
-      chat: "llama3.2"
-    tokenizer: "none" # cl100k_base | none
+      embeddings: "argus-ai/pplx-embed-v1-0.6b:fp32" #OpenAI equivalent: text-embedding-3-small
+      chat: "llama3.2" #OpenAI equivalent: gpt-4o or gpt-3.5-turbo
+    tokenizer: "none" # OpenAI: "cl100k_base"
     request:
       timeout_s: 30
       max_retries: 3

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -35,9 +35,9 @@
 global:
   # Qdrant vector database configuration
   qdrant:
-    url: "http://localhost:6333"
-    api_key: null # Optional API key for Qdrant Cloud
-    collection_name: "default_collection" # Collection name used by all projects
+    url: "${QDRANT_URL}"
+    api_key: "${QDRANT_API_KEY}" # Optional API key for Qdrant Cloud
+    collection_name: "${QDRANT_COLLECTION_NAME}" # Collection name used by all projects
 
   # Default chunking configuration
   # Controls how documents are split into chunks for processing

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -100,17 +100,17 @@ global:
   # Default embedding configuration
   # Controls how text is converted to vectors
   embedding:
-    endpoint: "http://localhost:11434/v1"
+    endpoint: "${LLM_BASE_URL}"
     # Ollama: Local Ollama OpenAI-compatible endpoint
     # OpenAI equivalent: https://api.openai.com/v1       
-    model: "argus-ai/pplx-embed-v1-0.6b:fp32" 
+    model: "${LLM_EMBEDDING_MODEL}" 
     # Ollama: Local embedding model name
     # OpenAI equivalent: text-embedding-3-small   (1536 dimensions, cheaper)
-    api_key: "ollama"
+    api_key: "${LLM_API_KEY}"
     # Ollama: Use the fixed value "ollama" (no real auth)
     # OpenAI: Your real API key (e.g. sk-xxxx)
     batch_size: 100
-    vector_size: 1024
+    vector_size: ${VECTOR_SIZE}
     # MUST match model output dimension
     # OpenAI: text-embedding-3-small → 1536                      
     tokenizer: "none"
@@ -122,14 +122,14 @@ global:
   # Unified LLM configuration (provider-agnostic)
   # New preferred configuration block; legacy embedding/markitdown fields still work
   llm:
-    provider: "ollama" # openai | ollama | azure_openai | custom
-    base_url: "http://localhost:11434/v1" # OpenAI: https://api.openai.com/v1
-    api_key: "ollama" # Ollama: Use the fixed value "ollama" (no real auth), OpenAI: Your real API key (e.g. sk-xxxx)
+    provider: "${LLM_PROVIDER}" # openai | ollama | azure_openai | custom
+    base_url: "${LLM_BASE_URL}" # OpenAI: https://api.openai.com/v1
+    api_key: "${LLM_API_KEY}" # Ollama: Use "ollama", OpenAI: real API key
     api_version: null # Required for azure_openai (e.g., 2024-05-01-preview)
     headers: {}
     models:
-      embeddings: "argus-ai/pplx-embed-v1-0.6b:fp32" #OpenAI equivalent: text-embedding-3-small
-      chat: "llama3.2" #OpenAI equivalent: gpt-4o or gpt-3.5-turbo
+      embeddings: "${LLM_EMBEDDING_MODEL}" #OpenAI equivalent: text-embedding-3-small
+      chat: "${LLM_CHAT_MODEL}" #OpenAI equivalent: gpt-4o or gpt-3.5-turbo
     tokenizer: "none" # OpenAI: "cl100k_base"
     request:
       timeout_s: 30


### PR DESCRIPTION
# Pull Request

## Summary


This PR updates the configuration templates to better support both **local models (Ollama)** and **OpenAI** in a unified and consistent way.

Key changes include:
- Adjusted `.env.template` to reflect an Ollama-first setup while clearly documenting OpenAI equivalents.
- Updated `config.template.yaml` to align LLM provider, base URL, models, and embedding settings with the unified configuration approach.
- Added clear comments to explain how to switch between Ollama (local) and OpenAI (cloud) without code changes.
- Improved documentation clarity to help developers quickly set up local development or production environments.

No application logic is changed in this PR — configuration and documentation only.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages: 
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Doc impact

* docs/users/configuration/config-file-reference.md
* packages/qdrant-loader/README.md
* packages/qdrant-loader/conf/.env.template
* packages/qdrant-loader/conf/config.template.yaml

## Testing

All test is passed!

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [x] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configuration templates updated to support selectable LLM providers with Ollama-first defaults.
  * Embedding and LLM settings made configurable via environment variables (base URLs, API keys, embedding and chat models, vector size).
  * Qdrant connection and collection options added for easier vector store configuration.
  * Added configurable state database path and preserved the OpenAI key as a legacy fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->