### PR TITLE
fix: remove unused f-string prefix in markdown TOC builder

### DIFF
--- a/website/builder/markdown.py
+++ b/website/builder/markdown.py
@@ -717,7 +717,7 @@ class MarkdownProcessor:
                 icon_html = default_svg
 
             # Add the current heading with icon (if any)
-            toc_html += f'<li><a href="#' + heading_id + f'">{icon_html}{display_text}</a></li>\n'
+            toc_html += '<li><a href="#' + heading_id + f'">{icon_html}{display_text}</a></li>\n'
 
         # Close all remaining open lists
         while open_lists > 0:


### PR DESCRIPTION
# Pull Request

## Summary

Remove unnecessary f-string prefix detected by ruff linter in `website/builder/markdown.py`.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

- `make lint` passes with 0 errors after this fix.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal string assembly in markdown table of contents generation with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->