### PR TITLE
fix: Fix metrics, duplicate tracking, and error handling across codebase

### DIFF
--- a/packages/qdrant-loader-core/src/qdrant_loader_core/logging_processors.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/logging_processors.py
@@ -34,7 +34,7 @@ def redact_processor(
         "password",
     }
     sensitive_key_pattern = re.compile(
-        r"(?i)(?:^|[_-]|(?<=[a-z]))(token|secret|password|api[_-]?key|access[_-]?key|private[_-]?key|authorization)(?:$|[_-]|(?=[A-Z]))"
+        r"(?:^|[_-]|(?<=[a-z]))(?i:token|secret|password|api[_-]?key|access[_-]?key|private[_-]?key|authorization)(?:$|[_-]|(?=[A-Z]))"
     )
 
     def is_sensitive_key(key: Any) -> bool:

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/logging_processors.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/logging_processors.py
@@ -34,7 +34,7 @@ def redact_processor(
         "password",
     }
     sensitive_key_pattern = re.compile(
-        r"(?i)(?:^|[_-])(token|secret|password|api[_-]?key|access[_-]?key|private[_-]?key|authorization)(?:$|[_-])"
+        r"(?i)(?:^|[_-]|(?<=[a-z]))(token|secret|password|api[_-]?key|access[_-]?key|private[_-]?key|authorization)(?:$|[_-]|(?=[A-Z]))"
     )
 
     def is_sensitive_key(key: Any) -> bool:

--- a/packages/qdrant-loader-core/tests/test_logging_core.py
+++ b/packages/qdrant-loader-core/tests/test_logging_core.py
@@ -126,3 +126,30 @@ def test_redact_processor_masks_pattern_sensitive_keys():
     assert "***REDACTED***" in out["jira_token"]
     assert "***REDACTED***" in out["nested"]["client_secret"]
     assert out["ok"] == "safe"
+
+
+def test_redact_processor_camelcase_false_positives_not_redacted():
+    """Keys that contain a sensitive keyword as a substring but not at a word
+    boundary should NOT be redacted (camelCase boundary guards must be
+    case-sensitive)."""
+    logging_mod = import_module("qdrant_loader_core.logging")
+    redact = logging_mod.redact_processor
+
+    event = {
+        # "secret" is a prefix of "secretion" — no uppercase follows, so no match
+        "secretionRate": "safe-value",
+        # "apiKey" is a substring of "notapiKeyish" — no uppercase follows "ish"
+        "notapiKeyish": "safe-value",
+        # Sanity-check: genuine sensitive camelCase keys must still be redacted
+        "apiKey": "sk-ABCDEFGHIJKLMNOP",
+        "jiraApiKey": "ATATT-super-secret",
+    }
+
+    out = redact(None, "info", event)
+
+    # False-positives must pass through untouched
+    assert out["secretionRate"] == "safe-value", "secretionRate should not be redacted"
+    assert out["notapiKeyish"] == "safe-value", "notapiKeyish should not be redacted"
+    # True sensitive keys must still be masked
+    assert "***REDACTED***" in out["apiKey"], "apiKey should be redacted"
+    assert "***REDACTED***" in out["jiraApiKey"], "jiraApiKey should be redacted"

--- a/packages/qdrant-loader/src/qdrant_loader/cli/cli.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/cli.py
@@ -456,6 +456,8 @@ def config(
 
         output = _run_show_config(workspace, config, env, log_level)
         echo(output)
+    except ClickException:
+        raise
     except Exception as e:
         from qdrant_loader.utils.logging import LoggingConfig
 

--- a/packages/qdrant-loader/src/qdrant_loader/config/error_formatter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/error_formatter.py
@@ -90,11 +90,14 @@ def print_config_error(error: Exception) -> None:
         return
 
     if isinstance(error, ValueError):
+        safe_message = sanitize_exception_message(error)
+        raw_message = str(error)
+
         _stderr_console.print(
             Panel(
                 "[bold red]Configuration error[/bold red]\n\n"
-                f"[yellow]{sanitize_exception_message(error)}[/yellow]\n\n"
-                f"[green]Suggestion:[/green] {_suggest_fix('', sanitize_exception_message(error))}",
+                f"[yellow]{safe_message}[/yellow]\n\n"
+                f"[green]Suggestion:[/green] {_suggest_fix('', raw_message)}",
                 title="Validation Error",
                 style="red",
             )

--- a/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
+++ b/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
@@ -8,7 +8,6 @@ _SENSITIVE_FIELD_RE = re.compile(
     r"(?i)(?P<quote>['\"]?)(?P<key>[a-z0-9_\-]*(?:token|api[_-]?key|password|secret|access[_-]?key|private[_-]?key|authorization)[a-z0-9_\-]*)(?P=quote)\s*(?P<sep>[:=])\s*(?P<value>'[^']*'|\"[^\"]*\"|[^,\s}\]]+)"
 )
 _INPUT_VALUE_PREFIX_RE = re.compile(r"input_value\s*=\s*", re.IGNORECASE)
-_BEARER_RE = re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)([^\s,]+)")
 _AUTHORIZATION_RE = re.compile(
     r'(?i)(authorization\s*[:=]\s*)(?:(?:bearer|basic|token)\s+)?(?:"[^"]*"|\'[^\']*\'|[^\s,]+)'
 )
@@ -115,7 +114,6 @@ def redact_sensitive_data(text: str, mask: str = "**") -> str:
     redacted = _mask_input_value_segments(text, mask)
     redacted = _AUTHORIZATION_RE.sub(rf"\1{mask}", redacted)
     redacted = _SENSITIVE_FIELD_RE.sub(_replace_field, redacted)
-    redacted = _BEARER_RE.sub(rf"\1{mask}", redacted)
     redacted = _OPENAI_KEY_RE.sub(mask, redacted)
     return redacted
 

--- a/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
+++ b/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
@@ -122,4 +122,12 @@ def redact_sensitive_data(text: str, mask: str = "**") -> str:
 
 def sanitize_exception_message(error: Exception | str, mask: str = "**") -> str:
     """Convert an exception or message string to a safe, redacted message."""
-    return redact_sensitive_data(str(error), mask=mask)
+    redacted = redact_sensitive_data(str(error), mask=mask)
+
+    if redacted and redacted.strip():
+        return redacted
+
+    if isinstance(error, Exception):
+        return error.__class__.__name__
+
+    return "<redacted>"

--- a/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
+++ b/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
@@ -10,7 +10,7 @@ _SENSITIVE_FIELD_RE = re.compile(
 _INPUT_VALUE_PREFIX_RE = re.compile(r"input_value\s*=\s*", re.IGNORECASE)
 _BEARER_RE = re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)([^\s,]+)")
 _AUTHORIZATION_RE = re.compile(
-    r"(?i)(authorization\s*[:=]\s*)(?:(?:bearer|basic|token)\s+)?[^\s,]+"
+    r'(?i)(authorization\s*[:=]\s*)(?:(?:bearer|basic|token)\s+)?(?:"[^"]*"|\'[^\']*\'|[^\s,]+)'
 )
 _OPENAI_KEY_RE = re.compile(r"\bsk-[a-zA-Z0-9\-_]{12,}\b")
 

--- a/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
+++ b/packages/qdrant-loader/src/qdrant_loader/utils/sensitive.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import re
 
 _SENSITIVE_FIELD_RE = re.compile(
-    r"(?i)(?P<quote>['\"]?)(?P<key>[a-z0-9_\-]*(?:token|api[_-]?key|password|secret|access[_-]?key|private[_-]?key)[a-z0-9_\-]*)(?P=quote)\s*(?P<sep>[:=])\s*(?P<value>'[^']*'|\"[^\"]*\"|[^,\s}\]]+)"
+    r"(?i)(?P<quote>['\"]?)(?P<key>[a-z0-9_\-]*(?:token|api[_-]?key|password|secret|access[_-]?key|private[_-]?key|authorization)[a-z0-9_\-]*)(?P=quote)\s*(?P<sep>[:=])\s*(?P<value>'[^']*'|\"[^\"]*\"|[^,\s}\]]+)"
 )
 _INPUT_VALUE_PREFIX_RE = re.compile(r"input_value\s*=\s*", re.IGNORECASE)
 _BEARER_RE = re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)([^\s,]+)")
+_AUTHORIZATION_RE = re.compile(
+    r"(?i)(authorization\s*[:=]\s*)(?:(?:bearer|basic|token)\s+)?[^\s,]+"
+)
 _OPENAI_KEY_RE = re.compile(r"\bsk-[a-zA-Z0-9\-_]{12,}\b")
 
 
@@ -110,6 +113,7 @@ def redact_sensitive_data(text: str, mask: str = "**") -> str:
         return f"{quote}{key}{quote}{sep}{mask}"
 
     redacted = _mask_input_value_segments(text, mask)
+    redacted = _AUTHORIZATION_RE.sub(rf"\1{mask}", redacted)
     redacted = _SENSITIVE_FIELD_RE.sub(_replace_field, redacted)
     redacted = _BEARER_RE.sub(rf"\1{mask}", redacted)
     redacted = _OPENAI_KEY_RE.sub(mask, redacted)

--- a/packages/qdrant-loader/tests/unit/config/test_error_formatter.py
+++ b/packages/qdrant-loader/tests/unit/config/test_error_formatter.py
@@ -221,6 +221,20 @@ class TestPrintConfigErrorValueError:
         assert "JIRA_TOKEN=**" in output
         assert "OPENAI_API_KEY=**" in output
 
+    def test_print_config_error_value_error_uses_raw_message_for_suggestion(self):
+        """Suggestion matching should use raw error text, not the sanitized display text."""
+        error = ValueError("source is required")
+
+        with patch(
+            "qdrant_loader.config.error_formatter.sanitize_exception_message",
+            return_value="**",
+        ):
+            output = _capture_print_config_error(error)
+
+        assert "Suggestion:" in output
+        assert "Add at least one source under" in output
+        assert "sources:" in output
+
 
 # ---------------------------------------------------------------------------
 # print_config_error – generic / unknown exception type

--- a/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
+++ b/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
@@ -65,3 +65,19 @@ def test_sanitize_exception_message_masks_jira_config_repr() -> None:
 
     assert "ATATT-very-secret-token" not in safe
     assert "token=**" in safe
+
+
+def test_redact_sensitive_data_masks_non_bearer_authorization_colon() -> None:
+    raw = "Authorization: Basic dXNlcjpwYXNz"
+    redacted = redact_sensitive_data(raw)
+
+    assert "dXNlcjpwYXNz" not in redacted
+    assert "Authorization:**" in redacted
+
+
+def test_redact_sensitive_data_masks_non_bearer_authorization_equals() -> None:
+    raw = "authorization=plain-secret-value"
+    redacted = redact_sensitive_data(raw)
+
+    assert "plain-secret-value" not in redacted
+    assert "authorization=**" in redacted

--- a/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
+++ b/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
@@ -81,3 +81,17 @@ def test_redact_sensitive_data_masks_non_bearer_authorization_equals() -> None:
 
     assert "plain-secret-value" not in redacted
     assert "authorization=**" in redacted
+
+
+def test_sanitize_exception_message_falls_back_to_exception_type_on_empty() -> None:
+    safe = sanitize_exception_message(Exception())
+
+    assert safe == "Exception"
+
+
+def test_sanitize_exception_message_falls_back_to_placeholder_for_empty_string() -> (
+    None
+):
+    safe = sanitize_exception_message("")
+
+    assert safe == "<redacted>"

--- a/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
+++ b/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
@@ -67,6 +67,14 @@ def test_sanitize_exception_message_masks_jira_config_repr() -> None:
     assert "token=**" in safe
 
 
+def test_redact_sensitive_data_masks_bearer_authorization() -> None:
+    raw = "Authorization: Bearer sk-supersecrettoken"
+    redacted = redact_sensitive_data(raw)
+
+    assert "sk-supersecrettoken" not in redacted
+    assert "Authorization:**" in redacted
+
+
 def test_redact_sensitive_data_masks_non_bearer_authorization_colon() -> None:
     raw = "Authorization: Basic dXNlcjpwYXNz"
     redacted = redact_sensitive_data(raw)

--- a/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
+++ b/packages/qdrant-loader/tests/unit/utils/test_sensitive.py
@@ -83,6 +83,22 @@ def test_redact_sensitive_data_masks_non_bearer_authorization_equals() -> None:
     assert "authorization=**" in redacted
 
 
+def test_redact_sensitive_data_masks_quoted_authorization_with_space() -> None:
+    raw = 'Authorization: "Basic user:pass with space"'
+    redacted = redact_sensitive_data(raw)
+
+    assert "user:pass with space" not in redacted
+    assert "Authorization:**" in redacted
+
+
+def test_redact_sensitive_data_masks_single_quoted_authorization() -> None:
+    raw = "authorization: 'token my secret value'"
+    redacted = redact_sensitive_data(raw)
+
+    assert "my secret value" not in redacted
+    assert "authorization:**" in redacted
+
+
 def test_sanitize_exception_message_falls_back_to_exception_type_on_empty() -> None:
     safe = sanitize_exception_message(Exception())
 


### PR DESCRIPTION
Improve batch metrics calculation, duplicate deduplication, sensitive data redaction, and exception message formatting with proper fallback logic and test coverage.

# Pull Request

## Summary

fix CodeRabbit message in PR https://github.com/martin-papy/qdrant-loader/pull/232 relevant to sanitize error message
## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts sensitive-data redaction and CLI/config error surfacing; regex changes could introduce false negatives/positives that either leak secrets or over-redact logs, though covered by new tests.
> 
> **Overview**
> **Improves secret redaction in logs and error messages.** Updates the core structlog `redact_processor` key-matching regex to better handle camelCase boundaries (reducing substring false-positives) and extends text redaction to mask `authorization` values beyond Bearer tokens.
> 
> **Hardens error handling output.** `sanitize_exception_message` now falls back to the exception type/placeholder when redaction yields an empty message, `print_config_error` uses the *sanitized* message for display but the *raw* message for suggestion matching, and the CLI `config` command now rethrows `ClickException` unchanged. Tests are added/updated to lock in these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921e59ba4e24e21eb81a39615102ecd5d92da61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Broader detection and redaction of sensitive fields in logs (now covers authorization values and more key patterns); redaction ordering improved to reduce accidental leakage.

* **Bug Fixes**
  * CLI config command preserves explicit CLI errors instead of re-wrapping them.
  * Error UI shows a sanitized message while suggestion generation uses the raw message; empty sanitized results return a safe placeholder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->