### PR TITLE
fix: add missing utility targets to .PHONY in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev test test-loader test-mcp test-core test-coverage lint format clean build publish-loader publish-mcp docs quality quality-all
+.PHONY: help install install-dev test test-loader test-mcp test-core test-coverage lint format clean clean-python clean-build build build-loader build-mcp publish-loader publish-mcp docs quality quality-all setup-dev check profile-pyspy profile-cprofile metrics
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'


### PR DESCRIPTION
# Pull Request

## Summary

Add missing utility targets to `.PHONY` declaration in Makefile. Addresses CodeRabbitAI review finding on PR #232 (`Makefile:55`).

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TODO", "TBD", "Coming soon")

## What's Changed

Added `clean-python`, `clean-build`, `build-loader`, `build-mcp`, `setup-dev`, `check`, `profile-pyspy`, `profile-cprofile`, and `metrics` to the `.PHONY` declaration. Without this, Make could skip these targets if a same-named file or directory exists in the repo root.

## Testing

- [x] `make help` — all targets listed correctly
- [x] `make -n clean` — dry-run works
- [x] `make -n check` — dry-run works

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)