### PR TITLE
feat: add support for Jira Data Center custom fields via config

### DIFF
--- a/docs/users/configuration/config-file-reference.md
+++ b/docs/users/configuration/config-file-reference.md
@@ -590,6 +590,15 @@ sources:
       email: "${JIRA_EMAIL}"
       requests_per_minute: 60
       page_size: 100
+      extra_fields:
+        - param_name: customfield_12000
+          name: version
+          field_type: simple
+
+        - param_name: customfield_12001
+          name: affected_versions   # Metadata key under which the extracted value will be stored in Qdrant
+          field_type: array_object  # Use for fields that return a list of JIRA objects, e.g. [<JIRA Version: name='1.0.2', id='3900'>]
+          attr_name: name           # Attribute to extract from each object in the list
       issue_types:
         - "Bug"
         - "Story"

--- a/docs/users/detailed-guides/data-sources/jira.md
+++ b/docs/users/detailed-guides/data-sources/jira.md
@@ -105,7 +105,18 @@ projects:
           project_key: "PROJ"
           token: "${JIRA_TOKEN}"
           email: "${JIRA_EMAIL}"
-          
+          extra_fields:
+            - param_name: customfield_12000
+              name: version
+              field_type: simple
+
+            - param_name: customfield_12001
+              # name: Metadata key under which the extracted value will be stored in Qdrant
+              name: affected_versions   
+              # field_type: Use for fields that return a list of JIRA objects, e.g. [<JIRA Version: name='1.0.2', id='3900'>]
+              field_type: array_object  
+              # Attribute to extract from each object in the list
+              attr_name: name                     
           # Rate limiting
           requests_per_minute: 60
           page_size: 50

--- a/docs/users/detailed-guides/data-sources/jira.md
+++ b/docs/users/detailed-guides/data-sources/jira.md
@@ -106,17 +106,28 @@ projects:
           token: "${JIRA_TOKEN}"
           email: "${JIRA_EMAIL}"
           extra_fields:
+            # simple: store a scalar field directly
             - param_name: customfield_12000
-              name: version
+              name: external_id
               field_type: simple
 
+            # object: store a nested object as metadata
             - param_name: customfield_12001
-              # name: Metadata key under which the extracted value will be stored in Qdrant
-              name: affected_versions   
-              # field_type: Use for fields that return a list of JIRA objects, e.g. [<JIRA Version: name='1.0.2', id='3900'>]
-              field_type: array_object  
-              # Attribute to extract from each object in the list
-              attr_name: name                     
+              name: resolution_details
+              field_type: object
+              attr_name: value
+
+            # array: store a list of scalar values
+            - param_name: customfield_12002
+              name: labels_list
+              field_type: array
+
+            # array_object: extract a named attribute from each object in a list
+            - param_name: customfield_12003
+              name: affected_versions
+              field_type: array_object
+              attr_name: name
+
           # Rate limiting
           requests_per_minute: 60
           page_size: 50
@@ -204,6 +215,16 @@ projects:
 | `page_size` | int | Number of issues per API request | `100` |
 | `download_attachments` | bool | Download and process issue attachments | `false` |
 | `enable_file_conversion` | bool | Enable file conversion for attachments | `false` |
+| `extra_fields` | list | Add custom JIRA fields to extract as metadata | `[]` |
+
+#### `extra_fields` options
+
+| Option | Type | Description | Required |
+|--------|------|-------------|----------|
+| `param_name` | string | JIRA field key or custom field ID | yes |
+| `name` | string | Metadata key used in Qdrant | yes |
+| `field_type` | string | One of `simple`, `object`, `array`, `array_object` | yes |
+| `attr_name` | string | Attribute to extract for `array_object` fields | required for `array_object` or `object` |
 
 ### Issue Filtering
 

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/cloud_connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/cloud_connector.py
@@ -105,7 +105,7 @@ class JiraCloudConnector(BaseJiraConnector):
 
             for issue in issues:
                 try:
-                    parsed_issue = self._parse_issue(issue)
+                    parsed_issue = self._parse_issue(issue, self.config.extra_fields)
                     yield parsed_issue
                     processed_count += 1
 

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
@@ -95,6 +95,10 @@ class JiraExtraField(BaseModel):
                 raise ValueError(
                     f"'attr_name' is required for field_type='{self.field_type}'"
                 )
+        elif self.attr_name is not None:
+            raise ValueError(
+                "'attr_name' is only allowed for field_type='object' or 'array_object'"
+            )
         return self
 
     @model_validator(mode="after")

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
@@ -4,7 +4,14 @@ import os
 from enum import StrEnum
 from typing import Self
 
-from pydantic import ConfigDict, Field, HttpUrl, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    field_validator,
+    model_validator,
+)
 
 from qdrant_loader.config.source_config import SourceConfig
 
@@ -14,6 +21,47 @@ class JiraDeploymentType(StrEnum):
 
     CLOUD = "cloud"
     DATACENTER = "datacenter"
+
+
+class JiraFieldType(StrEnum):
+    SIMPLE = "simple"
+    OBJECT = "object"  # extract attribute from single object
+    ARRAY = "array"  # plain list
+    ARRAY_OBJECT = "array_object"  # extract attribute from list of objects
+
+
+class JiraExtraField(BaseModel):
+    param_name: str = Field(
+        ...,
+        description="The Jira API parameter name (e.g., 'customfield_11406', 'priority')",
+    )
+    name: str = Field(
+        ...,
+        description="Target attribute name on JiraIssue (e.g., 'sah_project')",
+    )
+    field_type: JiraFieldType = Field(
+        default=JiraFieldType.SIMPLE,
+        description=(
+            "Extraction strategy: "
+            "'simple' = direct value, "
+            "'object' = extract attribute from object (requires attr_name), "
+            "'array' = plain list, "
+            "'array_object' = extract attribute from list of objects (requires attr_name)"
+        ),
+    )
+    attr_name: str | None = Field(
+        default=None,
+        description="Attribute to extract from object(s) (e.g., 'name', 'value')",
+    )
+
+    @model_validator(mode="after")
+    def validate_attr_requirement(self) -> "JiraExtraField":
+        if self.field_type in {JiraFieldType.OBJECT, JiraFieldType.ARRAY_OBJECT}:
+            if not self.attr_name:
+                raise ValueError(
+                    f"'attr_name' is required for field_type='{self.field_type}'"
+                )
+        return self
 
 
 class JiraProjectConfig(SourceConfig):
@@ -68,6 +116,10 @@ class JiraProjectConfig(SourceConfig):
     include_statuses: list[str] = Field(
         default=[],
         description="Optional list of statuses to include (e.g., ['Open', 'In Progress']). If empty, all statuses are included.",
+    )
+    extra_fields: list[JiraExtraField] | None = Field(
+        default=None,
+        description="Optional list of extra Jira fields to retrieve with their extraction type.",
     )
 
     model_config = ConfigDict(validate_default=True, arbitrary_types_allowed=True)
@@ -149,3 +201,19 @@ class JiraProjectConfig(SourceConfig):
         if any(not item.strip() for item in v):
             raise ValueError("List items cannot be empty strings")
         return [item.strip() for item in v]
+
+    @field_validator("extra_fields")
+    @classmethod
+    def validate_extra_fields_unique(
+        cls, v: list[JiraExtraField] | None
+    ) -> list[JiraExtraField] | None:
+        """Validate that extra field param_names and names are unique."""
+        if v is None:
+            return v
+        param_names = [f.param_name for f in v if f.param_name is not None]
+        if len(param_names) != len(set(param_names)):
+            raise ValueError("Extra field 'param_name' values must be unique")
+        names = [f.name for f in v if f.name is not None]
+        if len(names) != len(set(names)):
+            raise ValueError("Extra field 'name' values must be unique")
+        return v

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
@@ -55,10 +55,12 @@ RESERVED_NAMES = {
 class JiraExtraField(BaseModel):
     param_name: str = Field(
         ...,
+        min_length=1,
         description="The Jira API parameter name (e.g., 'customfield_11406', 'priority')",
     )
     name: str = Field(
         ...,
+        min_length=1,
         description="Target attribute name on JiraIssue (e.g., 'sah_project')",
     )
     field_type: JiraFieldType = Field(
@@ -75,6 +77,16 @@ class JiraExtraField(BaseModel):
         default=None,
         description="Attribute to extract from object(s) (e.g., 'name', 'value')",
     )
+
+    @field_validator("param_name", "name", "attr_name", mode="before")
+    @classmethod
+    def normalize_strings(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        s = v.strip()
+        if s == "":
+            raise ValueError("Field value cannot be empty or whitespace")
+        return s
 
     @model_validator(mode="after")
     def validate_attr_requirement(self) -> "JiraExtraField":

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/config.py
@@ -30,6 +30,28 @@ class JiraFieldType(StrEnum):
     ARRAY_OBJECT = "array_object"  # extract attribute from list of objects
 
 
+RESERVED_NAMES = {
+    "id",
+    "key",
+    "summary",
+    "description",
+    "issue_type",
+    "status",
+    "priority",
+    "project_key",
+    "created",
+    "updated",
+    "reporter",
+    "assignee",
+    "labels",
+    "attachments",
+    "comments",
+    "parent_key",
+    "subtasks",
+    "linked_issues",
+}
+
+
 class JiraExtraField(BaseModel):
     param_name: str = Field(
         ...,
@@ -61,6 +83,14 @@ class JiraExtraField(BaseModel):
                 raise ValueError(
                     f"'attr_name' is required for field_type='{self.field_type}'"
                 )
+        return self
+
+    @model_validator(mode="after")
+    def validate_reserved_name(self) -> "JiraExtraField":
+        if self.name in RESERVED_NAMES:
+            raise ValueError(
+                f"'name' cannot be one of reserved attributes: {sorted(RESERVED_NAMES)}"
+            )
         return self
 
 

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
@@ -15,7 +15,11 @@ from qdrant_loader.connectors.jira.auth import (
     auto_detect_deployment_type as _auto_detect_type,
 )
 from qdrant_loader.connectors.jira.auth import setup_authentication as _setup_auth
-from qdrant_loader.connectors.jira.config import JiraDeploymentType, JiraProjectConfig
+from qdrant_loader.connectors.jira.config import (
+    JiraDeploymentType,
+    JiraExtraField,
+    JiraProjectConfig,
+)
 from qdrant_loader.connectors.jira.mappers import (
     parse_attachment as _parse_attachment_helper,
 )
@@ -403,9 +407,11 @@ class BaseJiraConnector(BaseConnector):
         """Get all issues from Jira."""
         ...
 
-    def _parse_issue(self, raw_issue: dict) -> JiraIssue:
+    def _parse_issue(
+        self, raw_issue: dict, extra_fields: list[JiraExtraField] | None = None
+    ) -> JiraIssue:
         """Parse a raw issue from the Jira response into a JiraIssue object."""
-        return _parse_issue_helper(raw_issue)
+        return _parse_issue_helper(raw_issue, extra_fields)
 
     def _parse_user(
         self, raw_user: dict | None, required: bool = False
@@ -468,7 +474,53 @@ class BaseJiraConnector(BaseConnector):
                 content_parts.append(comment.body)
 
             content = "\n\n".join(content_parts)
-
+            metadata = {
+                "project": self.config.project_key,
+                "issue_type": issue.issue_type,
+                "status": issue.status,
+                "key": issue.key,
+                "priority": issue.priority,
+                "labels": issue.labels,
+                "reporter": issue.reporter.display_name if issue.reporter else None,
+                "assignee": issue.assignee.display_name if issue.assignee else None,
+                "created": issue.created.isoformat(),
+                "updated": issue.updated.isoformat(),
+                "parent_key": issue.parent_key,
+                "subtasks": issue.subtasks,
+                "linked_issues": issue.linked_issues,
+                "comments": [
+                    {
+                        "id": comment.id,
+                        "body": comment.body,
+                        "created": comment.created.isoformat(),
+                        "updated": (
+                            comment.updated.isoformat() if comment.updated else None
+                        ),
+                        "author": (
+                            comment.author.display_name if comment.author else None
+                        ),
+                    }
+                    for comment in issue.comments
+                ],
+                "attachments": (
+                    [
+                        {
+                            "id": att.id,
+                            "filename": att.filename,
+                            "size": att.size,
+                            "mime_type": att.mime_type,
+                            "created": att.created.isoformat(),
+                            "author": (att.author.display_name if att.author else None),
+                        }
+                        for att in issue.attachments
+                    ]
+                    if issue.attachments
+                    else []
+                ),
+            }
+            if self.config.extra_fields:
+                for field in self.config.extra_fields:
+                    metadata[field.name] = getattr(issue, field.name)
             base_url = str(self.config.base_url).rstrip("/")
             document = Document(
                 id=issue.id,
@@ -481,52 +533,7 @@ class BaseJiraConnector(BaseConnector):
                 title=issue.summary,
                 updated_at=issue.updated,
                 is_deleted=False,
-                metadata={
-                    "project": self.config.project_key,
-                    "issue_type": issue.issue_type,
-                    "status": issue.status,
-                    "key": issue.key,
-                    "priority": issue.priority,
-                    "labels": issue.labels,
-                    "reporter": issue.reporter.display_name if issue.reporter else None,
-                    "assignee": issue.assignee.display_name if issue.assignee else None,
-                    "created": issue.created.isoformat(),
-                    "updated": issue.updated.isoformat(),
-                    "parent_key": issue.parent_key,
-                    "subtasks": issue.subtasks,
-                    "linked_issues": issue.linked_issues,
-                    "comments": [
-                        {
-                            "id": comment.id,
-                            "body": comment.body,
-                            "created": comment.created.isoformat(),
-                            "updated": (
-                                comment.updated.isoformat() if comment.updated else None
-                            ),
-                            "author": (
-                                comment.author.display_name if comment.author else None
-                            ),
-                        }
-                        for comment in issue.comments
-                    ],
-                    "attachments": (
-                        [
-                            {
-                                "id": att.id,
-                                "filename": att.filename,
-                                "size": att.size,
-                                "mime_type": att.mime_type,
-                                "created": att.created.isoformat(),
-                                "author": (
-                                    att.author.display_name if att.author else None
-                                ),
-                            }
-                            for att in issue.attachments
-                        ]
-                        if issue.attachments
-                        else []
-                    ),
-                },
+                metadata=metadata,
             )
             documents.append(document)
             logger.debug(

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/data_center_connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/data_center_connector.py
@@ -108,7 +108,7 @@ class JiraDataCenterConnector(BaseJiraConnector):
 
             for i, issue in enumerate(issues):
                 try:
-                    parsed_issue = self._parse_issue(issue)
+                    parsed_issue = self._parse_issue(issue,self.config.extra_fields)
                     yield parsed_issue
                     processed_count += 1
 

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/data_center_connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/data_center_connector.py
@@ -108,7 +108,7 @@ class JiraDataCenterConnector(BaseJiraConnector):
 
             for i, issue in enumerate(issues):
                 try:
-                    parsed_issue = self._parse_issue(issue,self.config.extra_fields)
+                    parsed_issue = self._parse_issue(issue, self.config.extra_fields)
                     yield parsed_issue
                     processed_count += 1
 

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/mappers.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/mappers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
+from .config import JiraExtraField, JiraFieldType
 from .models import JiraAttachment, JiraComment, JiraIssue, JiraUser
 
 
@@ -100,7 +101,34 @@ def parse_comment(raw_comment: dict[str, Any]) -> JiraComment:
     )
 
 
-def parse_issue(raw_issue: dict[str, Any]) -> JiraIssue:
+def _extract_extra_field_value(
+    container: dict[str, Any],
+    param_name: str,
+    field_type: JiraFieldType,
+    attr_name: str | None,
+) -> Any:
+    """Extract a single extra field value from the issue fields dict."""
+    raw = container.get(param_name)
+
+    if field_type in (JiraFieldType.SIMPLE, JiraFieldType.ARRAY):
+        return raw
+
+    if field_type == JiraFieldType.OBJECT:
+        if not isinstance(raw, dict):
+            return None
+        return raw.get(attr_name)
+
+    if field_type == JiraFieldType.ARRAY_OBJECT:
+        if not isinstance(raw, list):
+            return []
+        return [item.get(attr_name) for item in raw if isinstance(item, dict)]
+
+    return None
+
+
+def parse_issue(
+    raw_issue: dict[str, Any], extra_fields: list[JiraExtraField] | None = None
+) -> JiraIssue:
     """Parse a raw issue from the Jira response into a JiraIssue object."""
     # Gather identifiers early for clearer error messages
     issue_id = raw_issue.get("id")
@@ -227,7 +255,6 @@ def parse_issue(raw_issue: dict[str, Any]) -> JiraIssue:
         raise ValueError(
             f"Jira issue missing required top-level identifier(s): id={issue_id!r}, key={issue_key!r}"
         )
-
     description = fields.get("description", "")
     if description is not None and not isinstance(description, str):
         if not isinstance(description, dict):
@@ -236,7 +263,7 @@ def parse_issue(raw_issue: dict[str, Any]) -> JiraIssue:
             )
         description = adf_to_oneline_fulltext(description)
 
-    return JiraIssue(
+    jira_issue = JiraIssue(
         id=issue_id,
         key=issue_key,
         summary=str(fields.get("summary")),
@@ -264,6 +291,16 @@ def parse_issue(raw_issue: dict[str, Any]) -> JiraIssue:
         subtasks=subtasks_keys,
         linked_issues=[key for key in linked_outward if key],
     )
+    if extra_fields:
+        for field in extra_fields:
+            value = _extract_extra_field_value(
+                fields,
+                field.param_name,
+                field.field_type,
+                field.attr_name,
+            )
+            setattr(jira_issue, field.name, value)
+    return jira_issue
 
 
 def adf_to_oneline_fulltext(node: dict) -> str:

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/models.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 
 class JiraUser(BaseModel):
@@ -38,6 +38,7 @@ class JiraAttachment(BaseModel):
 class JiraIssue(BaseModel):
     """Jira issue model."""
 
+    model_config = ConfigDict(extra="allow")
     id: str = Field(..., description="Issue ID")
     key: str = Field(..., description="Issue key")
     summary: str = Field(..., description="Issue summary")

--- a/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
@@ -278,7 +278,7 @@ class EmbeddingService:
         # Invalid entries (filtered out above) get an empty list as placeholder so
         # callers can zip safely without index shift.
         full_result: list[list[float]] = [[] for _ in contents]
-        for idx, embedding in zip(valid_indices, embeddings):
+        for idx, embedding in zip(valid_indices, embeddings, strict=False):
             full_result[idx] = embedding
         return full_result
 

--- a/packages/qdrant-loader/tests/unit/connectors/jira/test_extra_fields.py
+++ b/packages/qdrant-loader/tests/unit/connectors/jira/test_extra_fields.py
@@ -1,0 +1,569 @@
+"""Unit tests for Jira extra_fields configuration and extraction."""
+
+import pytest
+from pydantic import HttpUrl, ValidationError
+from qdrant_loader.config.types import SourceType
+from qdrant_loader.connectors.jira.config import (
+    RESERVED_NAMES,
+    JiraExtraField,
+    JiraFieldType,
+    JiraProjectConfig,
+)
+from qdrant_loader.connectors.jira.mappers import _extract_extra_field_value
+
+
+# ─── JiraExtraField Validation Tests ───────────────────────────────────────
+class TestJiraExtraFieldValidation:
+    """Test JiraExtraField model validation."""
+
+    def test_valid_simple_field(self):
+        """Simple field type should not require attr_name."""
+        field = JiraExtraField(
+            param_name="customfield_10000",
+            name="my_custom_field",
+            field_type="simple",
+        )
+        assert field.param_name == "customfield_10000"
+        assert field.name == "my_custom_field"
+        assert field.field_type == "simple"
+        assert field.attr_name is None
+
+    def test_valid_array_field(self):
+        """Array field type should not require attr_name."""
+        field = JiraExtraField(
+            param_name="customfield_10001",
+            name="my_array_field",
+            field_type="array",
+        )
+        assert field.field_type == JiraFieldType.ARRAY
+        assert field.attr_name is None
+
+    def test_valid_object_field_with_attr_name(self):
+        """Object field type requires attr_name."""
+        field = JiraExtraField(
+            param_name="customfield_10002",
+            name="my_object_field",
+            field_type="object",
+            attr_name="name",
+        )
+        assert field.field_type == JiraFieldType.OBJECT
+        assert field.attr_name == "name"
+
+    def test_valid_array_object_field_with_attr_name(self):
+        """Array_object field type requires attr_name."""
+        field = JiraExtraField(
+            param_name="customfield_10003",
+            name="my_array_object_field",
+            field_type="array_object",
+            attr_name="value",
+        )
+        assert field.field_type == JiraFieldType.ARRAY_OBJECT
+        assert field.attr_name == "value"
+
+    def test_object_field_missing_attr_name_raises(self):
+        """Object field type without attr_name should raise ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            JiraExtraField(
+                param_name="customfield_10002",
+                name="my_object_field",
+                field_type="object",
+                # missing attr_name
+            )
+        assert "attr_name" in str(exc_info.value)
+        assert "required" in str(exc_info.value).lower()
+
+    def test_array_object_field_missing_attr_name_raises(self):
+        """Array_object field type without attr_name should raise ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            JiraExtraField(
+                param_name="customfield_10003",
+                name="my_array_object_field",
+                field_type="array_object",
+                # missing attr_name
+            )
+        assert "attr_name" in str(exc_info.value)
+        assert "required" in str(exc_info.value).lower()
+
+    def test_simple_field_with_attr_name_raises(self):
+        """Simple field type with attr_name should raise ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            JiraExtraField(
+                param_name="customfield_10000",
+                name="my_custom_field",
+                field_type="simple",
+                attr_name="value",  # not allowed for simple
+            )
+        assert "attr_name" in str(exc_info.value)
+
+    def test_array_field_with_attr_name_raises(self):
+        """Array field type with attr_name should raise ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            JiraExtraField(
+                param_name="customfield_10001",
+                name="my_array_field",
+                field_type="array",
+                attr_name="value",  # not allowed for array
+            )
+        assert "attr_name" in str(exc_info.value)
+
+    def test_all_reserved_names_rejected(self):
+        """Verify all RESERVED_NAMES are properly rejected."""
+        for reserved_name in RESERVED_NAMES:
+            with pytest.raises(ValidationError, match="reserved"):
+                JiraExtraField(
+                    param_name=f"cf_{reserved_name}",
+                    name=reserved_name,
+                    field_type="simple",
+                )
+
+    def test_whitespace_normalization_in_param_name(self):
+        """Whitespace in param_name should be stripped."""
+        field = JiraExtraField(
+            param_name="  customfield_10000  ",
+            name="my_field",
+            field_type="simple",
+        )
+        assert field.param_name == "customfield_10000"
+
+    def test_whitespace_normalization_in_name(self):
+        """Whitespace in name should be stripped."""
+        field = JiraExtraField(
+            param_name="customfield_10000",
+            name="  my_field  ",
+            field_type="simple",
+        )
+        assert field.name == "my_field"
+
+    def test_whitespace_normalization_in_attr_name(self):
+        """Whitespace in attr_name should be stripped."""
+        field = JiraExtraField(
+            param_name="customfield_10000",
+            name="my_field",
+            field_type="object",
+            attr_name="  attr_name  ",
+        )
+        assert field.attr_name == "attr_name"
+
+    def test_empty_param_name_raises(self):
+        """Empty param_name should raise ValueError."""
+        with pytest.raises(ValidationError):
+            JiraExtraField(
+                param_name="",
+                name="my_field",
+                field_type="simple",
+            )
+
+    def test_empty_name_raises(self):
+        """Empty name should raise ValueError."""
+        with pytest.raises(ValidationError):
+            JiraExtraField(
+                param_name="customfield_10000",
+                name="",
+                field_type="simple",
+            )
+
+
+# ─── validate_extra_fields_unique Tests ───────────────────────────────────
+
+
+class TestValidateExtraFieldsUnique:
+    """Test validation of uniqueness in extra_fields list."""
+
+    def test_unique_param_names_and_names_accepted(self):
+        """Extra fields with unique param_names and names should be accepted."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            extra_fields=[
+                JiraExtraField(
+                    param_name="customfield_10000",
+                    name="field_a",
+                    field_type="simple",
+                ),
+                JiraExtraField(
+                    param_name="customfield_10001",
+                    name="field_b",
+                    field_type="array",
+                ),
+            ],
+        )
+        assert len(config.extra_fields) == 2
+
+    def test_duplicate_param_name_raises(self):
+        """Duplicate param_name values should raise ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            JiraProjectConfig(
+                base_url=HttpUrl("https://test.atlassian.net"),
+                project_key="TEST",
+                source="test-jira",
+                source_type=SourceType.JIRA,
+                token="test-token",
+                email="test@example.com",
+                extra_fields=[
+                    JiraExtraField(
+                        param_name="customfield_10000",
+                        name="field_a",
+                        field_type="simple",
+                    ),
+                    JiraExtraField(
+                        param_name="customfield_10000",  # duplicate!
+                        name="field_b",
+                        field_type="simple",
+                    ),
+                ],
+            )
+        assert "param_name" in str(exc_info.value)
+        assert "unique" in str(exc_info.value).lower()
+
+    def test_duplicate_name_raises(self):
+        """Duplicate name values should raise ValueError."""
+        with pytest.raises(ValidationError) as exc_info:
+            JiraProjectConfig(
+                base_url=HttpUrl("https://test.atlassian.net"),
+                project_key="TEST",
+                source="test-jira",
+                source_type=SourceType.JIRA,
+                token="test-token",
+                email="test@example.com",
+                extra_fields=[
+                    JiraExtraField(
+                        param_name="customfield_10000",
+                        name="my_field",
+                        field_type="simple",
+                    ),
+                    JiraExtraField(
+                        param_name="customfield_10001",
+                        name="my_field",  # duplicate!
+                        field_type="simple",
+                    ),
+                ],
+            )
+        assert "name" in str(exc_info.value)
+        assert "unique" in str(exc_info.value).lower()
+
+    def test_three_fields_one_duplicate_param_raises(self):
+        """Duplicate param_name among multiple fields should raise."""
+        with pytest.raises(ValidationError, match="param_name"):
+            JiraProjectConfig(
+                base_url=HttpUrl("https://test.atlassian.net"),
+                project_key="TEST",
+                source="test-jira",
+                source_type=SourceType.JIRA,
+                token="test-token",
+                email="test@example.com",
+                extra_fields=[
+                    JiraExtraField(
+                        param_name="customfield_10000",
+                        name="field_a",
+                        field_type="simple",
+                    ),
+                    JiraExtraField(
+                        param_name="customfield_10001",
+                        name="field_b",
+                        field_type="simple",
+                    ),
+                    JiraExtraField(
+                        param_name="customfield_10000",  # duplicate of first
+                        name="field_c",
+                        field_type="simple",
+                    ),
+                ],
+            )
+
+    def test_empty_extra_fields_accepted(self):
+        """Empty extra_fields list should be accepted."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            extra_fields=[],
+        )
+        assert config.extra_fields == []
+
+    def test_none_extra_fields_accepted(self):
+        """None extra_fields should be accepted."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+        )
+        assert config.extra_fields is None
+
+
+# ─── _extract_extra_field_value Tests ──────────────────────────────────────
+
+
+class TestExtractExtraFieldValue:
+    """Test the _extract_extra_field_value function."""
+
+    def test_simple_field_with_scalar_value(self):
+        """Simple field should return the raw scalar value."""
+        fields = {"customfield_10000": "test_value"}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10000",
+            "simple",
+            None,
+        )
+        assert value == "test_value"
+
+    def test_simple_field_with_number(self):
+        """Simple field should preserve numeric values."""
+        fields = {"customfield_10000": 42}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10000",
+            "simple",
+            None,
+        )
+        assert value == 42
+
+    def test_simple_field_with_boolean(self):
+        """Simple field should preserve boolean values."""
+        fields = {"customfield_10000": True}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10000",
+            "simple",
+            None,
+        )
+        assert value is True
+
+    def test_simple_field_missing_param_returns_none(self):
+        """Simple field with missing param_name should return None."""
+        fields = {"other_field": "value"}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10000",
+            "simple",
+            None,
+        )
+        assert value is None
+
+    def test_simple_field_with_none_value(self):
+        """Simple field with None value should return None."""
+        fields = {"customfield_10000": None}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10000",
+            "simple",
+            None,
+        )
+        assert value is None
+
+    def test_array_field_with_list(self):
+        """Array field should return the raw list."""
+        fields = {"customfield_10001": ["a", "b", "c"]}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10001",
+            JiraFieldType.ARRAY,
+            None,
+        )
+        assert value == ["a", "b", "c"]
+
+    def test_array_field_with_empty_list(self):
+        """Array field with empty list should return empty list."""
+        fields = {"customfield_10001": []}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10001",
+            JiraFieldType.ARRAY,
+            None,
+        )
+        assert value == []
+
+    def test_array_field_missing_param_returns_none(self):
+        """Array field with missing param_name should return None."""
+        fields = {"other_field": ["value"]}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10001",
+            JiraFieldType.ARRAY,
+            None,
+        )
+        assert value is None
+
+    def test_object_field_with_dict_extracts_attr(self):
+        """Object field should extract the specified attribute from dict."""
+        fields = {
+            "customfield_10002": {
+                "name": "Project Version",
+                "id": "12345",
+                "released": True,
+            }
+        }
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10002",
+            JiraFieldType.OBJECT,
+            "name",
+        )
+        assert value == "Project Version"
+
+    def test_object_field_extracts_different_attr(self):
+        """Object field should extract the correct attribute when specified."""
+        fields = {
+            "customfield_10002": {
+                "name": "Project Version",
+                "id": "12345",
+                "released": True,
+            }
+        }
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10002",
+            JiraFieldType.OBJECT,
+            "id",
+        )
+        assert value == "12345"
+
+    def test_object_field_missing_attr_returns_none(self):
+        """Object field with missing attribute returns None."""
+        fields = {
+            "customfield_10002": {
+                "name": "Project Version",
+                "released": True,
+            }
+        }
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10002",
+            JiraFieldType.OBJECT,
+            "missing_attr",
+        )
+        assert value is None
+
+    def test_object_field_not_dict_returns_none(self):
+        """Object field with non-dict value should return None."""
+        fields = {"customfield_10002": "not a dict"}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10002",
+            JiraFieldType.OBJECT,
+            "name",
+        )
+        assert value is None
+
+    def test_object_field_missing_param_returns_none(self):
+        """Object field with missing param_name should return None."""
+        fields = {"other_field": {"name": "value"}}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10002",
+            JiraFieldType.OBJECT,
+            "name",
+        )
+        assert value is None
+
+    def test_array_object_field_with_list_of_dicts(self):
+        """Array_object field should extract attribute from each dict in list."""
+        fields = {
+            "customfield_10003": [
+                {"name": "v1.0", "id": "100"},
+                {"name": "v2.0", "id": "200"},
+                {"name": "v3.0", "id": "300"},
+            ]
+        }
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10003",
+            JiraFieldType.ARRAY_OBJECT,
+            "name",
+        )
+        assert value == ["v1.0", "v2.0", "v3.0"]
+
+    def test_array_object_field_extracts_different_attr(self):
+        """Array_object field should extract the correct attribute."""
+        fields = {
+            "customfield_10003": [
+                {"name": "v1.0", "id": "100"},
+                {"name": "v2.0", "id": "200"},
+            ]
+        }
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10003",
+            JiraFieldType.ARRAY_OBJECT,
+            "id",
+        )
+        assert value == ["100", "200"]
+
+    def test_array_object_field_with_empty_list(self):
+        """Array_object field with empty list should return empty list."""
+        fields = {"customfield_10003": []}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10003",
+            JiraFieldType.ARRAY_OBJECT,
+            "name",
+        )
+        assert value == []
+
+    def test_array_object_field_skips_non_dict_items(self):
+        """Array_object field should skip non-dict items in list."""
+        fields = {
+            "customfield_10003": [
+                {"name": "v1.0", "id": "100"},
+                "not a dict",
+                {"name": "v2.0", "id": "200"},
+                None,
+                {"name": "v3.0", "id": "300"},
+            ]
+        }
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10003",
+            JiraFieldType.ARRAY_OBJECT,
+            "name",
+        )
+        assert value == ["v1.0", "v2.0", "v3.0"]
+
+    def test_array_object_field_not_list_returns_empty_list(self):
+        """Array_object field with non-list value should return empty list."""
+        fields = {"customfield_10003": "not a list"}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10003",
+            JiraFieldType.ARRAY_OBJECT,
+            "name",
+        )
+        assert value == []
+
+    def test_array_object_field_missing_param_returns_empty_list(self):
+        """Array_object field with missing param_name should return empty list."""
+        fields = {"other_field": [{"name": "value"}]}
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10003",
+            JiraFieldType.ARRAY_OBJECT,
+            "name",
+        )
+        assert value == []
+
+    def test_array_object_field_with_missing_attrs(self):
+        """Array_object field returns None for missing attributes in items."""
+        fields = {
+            "customfield_10003": [
+                {"name": "v1.0", "id": "100"},
+                {"id": "200"},  # missing 'name'
+                {"name": "v3.0", "id": "300"},
+            ]
+        }
+        value = _extract_extra_field_value(
+            fields,
+            "customfield_10003",
+            JiraFieldType.ARRAY_OBJECT,
+            "name",
+        )
+        assert value == ["v1.0", None, "v3.0"]

--- a/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
+++ b/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
@@ -7,7 +7,12 @@ import pytest
 from pydantic import HttpUrl
 from qdrant_loader.config.types import SourceType
 from qdrant_loader.connectors.jira.cloud_connector import JiraCloudConnector
-from qdrant_loader.connectors.jira.config import JiraDeploymentType, JiraProjectConfig
+from qdrant_loader.connectors.jira.config import (
+    JiraDeploymentType,
+    JiraExtraField,
+    JiraFieldType,
+    JiraProjectConfig,
+)
 from qdrant_loader.connectors.jira.data_center_connector import JiraDataCenterConnector
 from qdrant_loader.connectors.jira.models import (
     JiraIssue,
@@ -107,6 +112,14 @@ def mock_data_center_issue_data():
             "parent": {"key": "TEST-0"},
             "subtasks": [{"key": "TEST-2"}],
             "issuelinks": [{"outwardIssue": {"key": "TEST-3"}}],
+            # Extra fields for testing
+            "customfield_10000": "EXT-12345",
+            "customfield_10001": {"name": "Fixed", "id": "1"},
+            "customfield_10002": ["tag1", "tag2", "tag3"],
+            "customfield_10003": [
+                {"name": "v1.0", "id": "100"},
+                {"name": "v2.0", "id": "200"},
+            ],
         },
     }
 
@@ -190,6 +203,14 @@ def mock_cloud_issue_data():
             "parent": {"key": "TEST-0"},
             "subtasks": [{"key": "TEST-2"}],
             "issuelinks": [{"outwardIssue": {"key": "TEST-3"}}],
+            # Extra fields for testing
+            "customfield_10000": "EXT-12345",
+            "customfield_10001": {"name": "Fixed", "id": "1"},
+            "customfield_10002": ["tag1", "tag2", "tag3"],
+            "customfield_10003": [
+                {"name": "v1.0", "id": "100"},
+                {"name": "v2.0", "id": "200"},
+            ],
         },
     }
 
@@ -773,6 +794,174 @@ class TestJiraConnector:
         assert '"Task"' in captured_jql
         assert "status IN " in captured_jql
         assert '"Done"' in captured_jql
+
+    # ─── extra_fields end-to-end tests ───────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_get_cloud_documents_with_extra_fields(self, mock_cloud_issue_data):
+        """Test that extra_fields appear in Document.metadata (end-to-end)."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            deployment_type=JiraDeploymentType.CLOUD,
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            extra_fields=[
+                JiraExtraField(
+                    param_name="customfield_10000",
+                    name="external_id",
+                    field_type=JiraFieldType.SIMPLE,
+                ),
+                JiraExtraField(
+                    param_name="customfield_10001",
+                    name="resolution",
+                    field_type=JiraFieldType.OBJECT,
+                    attr_name="name",
+                ),
+                JiraExtraField(
+                    param_name="customfield_10002",
+                    name="tags",
+                    field_type=JiraFieldType.ARRAY,
+                ),
+                JiraExtraField(
+                    param_name="customfield_10003",
+                    name="versions",
+                    field_type=JiraFieldType.ARRAY_OBJECT,
+                    attr_name="name",
+                ),
+            ],
+        )
+        connector = JiraCloudConnector(config)
+
+        with patch.object(
+            connector,
+            "_make_request",
+            return_value={"issues": [mock_cloud_issue_data]},
+        ):
+            async with connector:
+                documents = await connector.get_documents()
+
+                assert len(documents) == 1
+                document = documents[0]
+
+                # Verify extra fields are in metadata
+                assert document.metadata["external_id"] == "EXT-12345"
+                assert document.metadata["resolution"] == "Fixed"
+                assert document.metadata["tags"] == ["tag1", "tag2", "tag3"]
+                assert document.metadata["versions"] == ["v1.0", "v2.0"]
+
+    @pytest.mark.asyncio
+    async def test_get_datacenter_documents_with_extra_fields(
+        self, mock_data_center_issue_data
+    ):
+        """Test that extra_fields work with Data Center connector."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://jira.company.com"),
+            deployment_type=JiraDeploymentType.DATACENTER,
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-pat-token",
+            extra_fields=[
+                JiraExtraField(
+                    param_name="customfield_10000",
+                    name="external_id",
+                    field_type=JiraFieldType.SIMPLE,
+                ),
+            ],
+        )
+        connector = JiraDataCenterConnector(config)
+
+        with patch.object(
+            connector,
+            "_make_request",
+            return_value={"issues": [mock_data_center_issue_data], "total": 1},
+        ):
+            async with connector:
+                documents = await connector.get_documents()
+
+                assert len(documents) == 1
+                assert documents[0].metadata["external_id"] == "EXT-12345"
+
+    @pytest.mark.asyncio
+    async def test_extra_fields_with_missing_param(self, mock_cloud_issue_data):
+        """Test extra_fields handling when param_name is missing from response."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            deployment_type=JiraDeploymentType.CLOUD,
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            extra_fields=[
+                JiraExtraField(
+                    param_name="customfield_99999",  # doesn't exist in response
+                    name="missing_field",
+                    field_type=JiraFieldType.SIMPLE,
+                ),
+            ],
+        )
+        connector = JiraCloudConnector(config)
+
+        with patch.object(
+            connector,
+            "_make_request",
+            return_value={"issues": [mock_cloud_issue_data]},
+        ):
+            async with connector:
+                documents = await connector.get_documents()
+
+                assert len(documents) == 1
+                # Should be None for missing field
+                assert documents[0].metadata["missing_field"] is None
+
+    @pytest.mark.asyncio
+    async def test_extra_fields_array_object_with_non_dict_items(
+        self, mock_cloud_issue_data
+    ):
+        """Test array_object field_type gracefully skips non-dict items."""
+        config = JiraProjectConfig(
+            base_url=HttpUrl("https://test.atlassian.net"),
+            deployment_type=JiraDeploymentType.CLOUD,
+            project_key="TEST",
+            source="test-jira",
+            source_type=SourceType.JIRA,
+            token="test-token",
+            email="test@example.com",
+            extra_fields=[
+                JiraExtraField(
+                    param_name="customfield_10000",
+                    name="items",
+                    field_type=JiraFieldType.ARRAY_OBJECT,
+                    attr_name="name",
+                ),
+            ],
+        )
+        connector = JiraCloudConnector(config)
+
+        issue_data = mock_cloud_issue_data.copy()
+        issue_data["fields"]["customfield_10000"] = [
+            {"name": "item1", "id": "1"},
+            "not a dict",  # should be skipped
+            {"name": "item2", "id": "2"},
+            None,  # should be skipped
+            {"name": "item3", "id": "3"},
+        ]
+
+        with patch.object(
+            connector,
+            "_make_request",
+            return_value={"issues": [issue_data]},
+        ):
+            async with connector:
+                documents = await connector.get_documents()
+
+                assert len(documents) == 1
+                # Should extract only from dict items
+                assert documents[0].metadata["items"] == ["item1", "item2", "item3"]
 
 
 class TestJiraValidateConnection:

--- a/release.py
+++ b/release.py
@@ -341,6 +341,7 @@ def extract_changelog_for_version(version: str) -> str:
 
     # Find version section (format: ## [X.Y.Z] - Date)
     import re
+
     version_pattern = rf"## \[{re.escape(version)}\].*?\n(.*?)(?=\n## |\Z)"
     match = re.search(version_pattern, content, re.DOTALL)
 
@@ -381,7 +382,9 @@ def create_github_release(
     if not release_notes:
         logger.warning("No changelog found, falling back to git log for release notes")
         stdout, _ = run_command("git log --pretty=format:'%h %s' -n 10")
-        release_notes = f"## Changes for {package_name} v{version}\n\n```\n{stdout}\n```"
+        release_notes = (
+            f"## Changes for {package_name} v{version}\n\n```\n{stdout}\n```"
+        )
 
     # Create release
     headers = {
@@ -458,9 +461,7 @@ def check_changelog_updated(new_version: str, dry_run: bool = False) -> bool:
         bool: `True` if a changelog section for `new_version` is found, `False` otherwise.
     """
     logger = logging.getLogger(__name__)
-    logger.debug(
-        f"Checking if CHANGELOG.md has been updated for version {new_version}"
-    )
+    logger.debug(f"Checking if CHANGELOG.md has been updated for version {new_version}")
 
     changelog_path = Path("CHANGELOG.md")
 
@@ -483,35 +484,25 @@ def check_changelog_updated(new_version: str, dry_run: bool = False) -> bool:
 
         found_version = None
         for line in lines:
-            if re.match(r'^## \[Unreleased\]', line):
+            if re.match(r"^## \[Unreleased\]", line):
                 continue  # Skip Unreleased section
 
             match = re.match(version_pattern, line)
             if match:
                 found_version = match.group(1)
-                logger.debug(
-                    f"Found version section in CHANGELOG.md: {found_version}"
-                )
+                logger.debug(f"Found version section in CHANGELOG.md: {found_version}")
                 break
 
         if found_version == new_version:
-            logger.debug(
-                "CHANGELOG.md is up to date with the new version"
-            )
+            logger.debug("CHANGELOG.md is up to date with the new version")
             return True
         elif found_version:
-            logger.error(
-                f"CHANGELOG.md has not been updated for version {new_version}"
-            )
-            logger.error(
-                f"Found version {found_version} but expected {new_version}"
-            )
+            logger.error(f"CHANGELOG.md has not been updated for version {new_version}")
+            logger.error(f"Found version {found_version} but expected {new_version}")
             logger.error(
                 f"Please add a changelog section for the new version at the top of {changelog_path}"
             )
-            logger.error(
-                f"Expected format: ## [{new_version}] - <Date>"
-            )
+            logger.error(f"Expected format: ## [{new_version}] - <Date>")
             if not dry_run:
                 sys.exit(1)
             return False
@@ -1164,9 +1155,7 @@ def release(dry_run: bool = False, verbose: bool = False, sync_versions: bool = 
         status = "✅" if changelog_check else "❌"
         print(f"{status} Changelog Updated")
         if not changelog_check:
-            print(
-                f"   ⚠️  CHANGELOG.md needs to be updated for version {new_version}"
-            )
+            print(f"   ⚠️  CHANGELOG.md needs to be updated for version {new_version}")
         print()
 
     if dry_run:
@@ -1283,9 +1272,7 @@ def release(dry_run: bool = False, verbose: bool = False, sync_versions: bool = 
     # Create GitHub releases with NEW version
     token = get_github_token(dry_run)
     for package_name in get_packages_for_release():
-        create_github_release(
-            package_name, new_version, token, dry_run
-        )
+        create_github_release(package_name, new_version, token, dry_run)
 
     if not dry_run:
         print("\n🎉 RELEASE COMPLETED SUCCESSFULLY!")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,7 @@ def temp_workspace():
     yield workspace
     # Improved cleanup for Windows - retry with delays
     import time
+
     for attempt in range(3):
         try:
             shutil.rmtree(temp_dir)
@@ -386,8 +387,7 @@ Sitemap: https://qdrant-loader.net/sitemap.xml"""
     (templates_dir / "robots.txt").write_text(robots_template)
 
     # Create sample documentation files
-    (temp_workspace / "README.md").write_text(
-        """# QDrant Loader
+    (temp_workspace / "README.md").write_text("""# QDrant Loader
 
 Enterprise-ready vector database toolkit for building searchable knowledge bases.
 
@@ -396,19 +396,16 @@ Enterprise-ready vector database toolkit for building searchable knowledge bases
 - Multi-source data loading
 - Vector embeddings
 - Search capabilities
-"""
-    )
+""")
 
-    (temp_workspace / "docs" / "installation.md").write_text(
-        """# Installation
+    (temp_workspace / "docs" / "installation.md").write_text("""# Installation
 
 Install QDrant Loader using pip:
 
 ```bash
 pip install qdrant-loader
 ```
-"""
-    )
+""")
 
     # Create sample assets
     assets_dir = temp_workspace / "website" / "assets"

--- a/tests/test_website_build.py
+++ b/tests/test_website_build.py
@@ -271,7 +271,9 @@ class TestWebsiteBuildIntegration:
                     ).exists(), "Robots.txt should be created"
 
                     # Check that files have content
-                    index_content = (site_dir / "index.html").read_text(encoding="utf-8")
+                    index_content = (site_dir / "index.html").read_text(
+                        encoding="utf-8"
+                    )
                     assert (
                         len(index_content) > 100
                     ), "Index page should have substantial content"

--- a/tests/test_website_build_comprehensive.py
+++ b/tests/test_website_build_comprehensive.py
@@ -133,8 +133,8 @@ class TestWebsiteBuilderMarkdown:
         html = builder.basic_markdown_to_html(markdown)
         # The output varies depending on whether the markdown library is available
         # Just verify it contains code-related elements
-        assert '<code' in html
-        assert "print('hello')" in html or 'print(&#39;hello&#39;)' in html
+        assert "<code" in html
+        assert "print('hello')" in html or "print(&#39;hello&#39;)" in html
 
         # Test inline code
         markdown = "Use `pip install` to install"
@@ -233,9 +233,9 @@ class TestWebsiteBuilderMarkdown:
         result = builder.markdown_to_html(markdown)
 
         assert 'type="checkbox"' in result
-        assert 'disabled' in result
-        assert 'task-list-item' in result
-        assert 'checked' in result
+        assert "disabled" in result
+        assert "task-list-item" in result
+        assert "checked" in result
         assert "Pending item" in result
         assert "Done item" in result
 
@@ -935,8 +935,7 @@ class TestGitHubActionsWorkflow:
         favicon_script.parent.mkdir(parents=True, exist_ok=True)
 
         # Create a mock favicon generation script
-        favicon_script.write_text(
-            """
+        favicon_script.write_text("""
 import sys
 from pathlib import Path
 
@@ -981,8 +980,7 @@ def main():
 if __name__ == "__main__":
     success = main()
     sys.exit(0 if success else 1)
-"""
-        )
+""")
 
         # Test favicon generation step
         result = subprocess.run(

--- a/tests/test_website_build_coverage_boost.py
+++ b/tests/test_website_build_coverage_boost.py
@@ -205,10 +205,12 @@ Regular paragraph text.
         result = processor.render_task_list_checkboxes(html)
 
         assert result.count('type="checkbox"') == 2
-        assert result.count('disabled') == 2
-        assert 'task-list-item' in result
-        assert 'checked' in result
-        assert 'existing task-list-item' in result or 'task-list-item existing' in result
+        assert result.count("disabled") == 2
+        assert "task-list-item" in result
+        assert "checked" in result
+        assert (
+            "existing task-list-item" in result or "task-list-item existing" in result
+        )
 
     def test_convert_markdown_links_edge_cases(self):
         """Test markdown link conversion edge cases."""

--- a/tests/test_website_build_edge_cases.py
+++ b/tests/test_website_build_edge_cases.py
@@ -282,7 +282,9 @@ class TestWebsiteBuilderEdgeCases:
         # Create files with Unicode names
         unicode_dir = mock_project_structure / "docs" / "ünïcödé"
         unicode_dir.mkdir(parents=True)
-        (unicode_dir / "tëst.md").write_text("# Unicode Test\n\nContent with émojis 🚀", encoding="utf-8")
+        (unicode_dir / "tëst.md").write_text(
+            "# Unicode Test\n\nContent with émojis 🚀", encoding="utf-8"
+        )
 
         builder = WebsiteBuilder("website/templates", "site")
         builder.build_site()

--- a/website/builder/core.py
+++ b/website/builder/core.py
@@ -8,6 +8,7 @@ all build operations and manages the overall build lifecycle.
 import json
 import re
 import subprocess
+from datetime import UTC
 from pathlib import Path
 
 from .assets import AssetManager
@@ -376,12 +377,16 @@ class WebsiteBuilder:
                 if privacy_last_updated:
                     privacy_last_updated = privacy_last_updated.split("T", 1)[0]
                 else:
-                    from datetime import datetime, timezone
+                    from datetime import datetime
 
                     # Use stable template mtime fallback instead of build date.
-                    privacy_last_updated = datetime.fromtimestamp(
-                        privacy_template_path.stat().st_mtime, tz=timezone.utc
-                    ).date().isoformat()
+                    privacy_last_updated = (
+                        datetime.fromtimestamp(
+                            privacy_template_path.stat().st_mtime, tz=UTC
+                        )
+                        .date()
+                        .isoformat()
+                    )
 
                 self.build_page(
                     "base.html",

--- a/website/builder/markdown.py
+++ b/website/builder/markdown.py
@@ -408,9 +408,7 @@ class MarkdownProcessor:
                 classes = class_match.group(1).split()
                 if class_name not in classes:
                     classes.append(class_name)
-                return re.sub(
-                    r'class="([^"]*)"', f'class="{" ".join(classes)}"', attrs
-                )
+                return re.sub(r'class="([^"]*)"', f'class="{" ".join(classes)}"', attrs)
             return f'{attrs} class="{class_name}"'
 
         def replace_task_item(match: re.Match) -> str:
@@ -420,7 +418,7 @@ class MarkdownProcessor:
             checked_attr = " checked" if marker.lower() == "x" else ""
             attrs = add_class(attrs, "task-list-item")
             return (
-                f'<li{attrs}>'
+                f"<li{attrs}>"
                 f'<input class="form-check-input me-2" type="checkbox"{checked_attr} disabled>'
                 f"{body}</li>"
             )
@@ -695,7 +693,7 @@ class MarkdownProcessor:
             '<svg class="toc-icon" style="width:1rem;height:1rem;object-fit:contain;vertical-align:middle;margin-right:0.35rem;" '
             'width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">'
             '<path d="M10 7.5C9.50555 7.5 9.0222 7.64662 8.61108 7.92133C8.19995 8.19603 7.87952 8.58648 7.6903 9.04329C7.50108 9.50011 7.45157 10.0028 7.54804 10.4877C7.6445 10.9727 7.8826 11.4181 8.23223 11.7678C8.58187 12.1174 9.02732 12.3555 9.51228 12.452C9.99723 12.5484 10.4999 12.4989 10.9567 12.3097C11.4135 12.1205 11.804 11.8 12.0787 11.3889C12.3534 10.9778 12.5 10.4945 12.5 10C12.5 9.33696 12.2366 8.70107 11.7678 8.23223C11.2989 7.76339 10.663 7.5 10 7.5ZM10 11.25C9.75277 11.25 9.5111 11.1767 9.30554 11.0393C9.09998 10.902 8.93976 10.7068 8.84515 10.4784C8.75054 10.2499 8.72579 9.99861 8.77402 9.75614C8.82225 9.51366 8.9413 9.29093 9.11612 9.11612C9.29093 8.9413 9.51366 8.82225 9.75614 8.77402C9.99861 8.72579 10.2499 8.75054 10.4784 8.84515C10.7068 8.93976 10.902 9.09998 11.0393 9.30554C11.1767 9.5111 11.25 9.75277 11.25 10C11.25 10.3315 11.1183 10.6495 10.8839 10.8839C10.6495 11.1183 10.3315 11.25 10 11.25Z" fill="#343330" />'
-            '</svg>'
+            "</svg>"
         )
 
         for idx, (tag, heading_id, text) in enumerate(headings):
@@ -703,7 +701,7 @@ class MarkdownProcessor:
 
             # Determine if this heading has child headings (deeper level) before next sibling
             has_child = False
-            for next_tag, _next_id, _next_text in headings[idx + 1:]:
+            for next_tag, _next_id, _next_text in headings[idx + 1 :]:
                 next_level = int(next_tag[1])
                 if next_level > level:
                     has_child = True
@@ -730,24 +728,41 @@ class MarkdownProcessor:
 
             # Extract first <img> if present and sanitize it for TOC display
             icon_html = ""
-            img_match = re.search(r'(<img[^>]*>)', text, flags=re.DOTALL)
+            img_match = re.search(r"(<img[^>]*>)", text, flags=re.DOTALL)
             if img_match:
                 icon_html = img_match.group(1)
                 # Remove any on* handlers and javascript: hrefs for safety
-                icon_html = re.sub(r"\s(on\w+)\s*=\s*(\"[^\"]*\"|'[^']*')", "", icon_html)
-                icon_html = re.sub(r"javascript:\s*", "", icon_html, flags=re.IGNORECASE)
+                icon_html = re.sub(
+                    r"\s(on\w+)\s*=\s*(\"[^\"]*\"|'[^']*')", "", icon_html
+                )
+                icon_html = re.sub(
+                    r"javascript:\s*", "", icon_html, flags=re.IGNORECASE
+                )
                 # Remove any existing size/style attributes so we can normalize appearance
-                icon_html = re.sub(r"\s(width|height)=\s*(\"[^\"]*\"|'[^']*')", "", icon_html)
+                icon_html = re.sub(
+                    r"\s(width|height)=\s*(\"[^\"]*\"|'[^']*')", "", icon_html
+                )
                 icon_html = re.sub(r"\sstyle=\s*(\"[^\"]*\"|'[^']*')", "", icon_html)
                 # Ensure a small consistent size and spacing for TOC icons
                 # Add class toc-icon (append if class exists)
                 if re.search(r"\sclass=\s*\"[^\"]+\"", icon_html):
-                    icon_html = re.sub(r"\sclass=\s*\"([^\"]+)\"", lambda m: f' class="{m.group(1)} toc-icon"', icon_html)
+                    icon_html = re.sub(
+                        r"\sclass=\s*\"([^\"]+)\"",
+                        lambda m: f' class="{m.group(1)} toc-icon"',
+                        icon_html,
+                    )
                 elif re.search(r"\sclass=\s*'[^']+'", icon_html):
-                    icon_html = re.sub(r"\sclass=\s*'([^']+)'", lambda m: f" class='{m.group(1)} toc-icon'", icon_html)
+                    icon_html = re.sub(
+                        r"\sclass=\s*'([^']+)'",
+                        lambda m: f" class='{m.group(1)} toc-icon'",
+                        icon_html,
+                    )
                 else:
                     # inject class and inline style before the closing >
-                    icon_html = icon_html.rstrip('>') + ' class="toc-icon" style="width:1rem;height:1rem;object-fit:contain;vertical-align:middle;margin-right:0.35rem;">'
+                    icon_html = (
+                        icon_html.rstrip(">")
+                        + ' class="toc-icon" style="width:1rem;height:1rem;object-fit:contain;vertical-align:middle;margin-right:0.35rem;">'
+                    )
 
             # Derive display text: strip HTML, or use img alt, or fallback to id
             display_text = re.sub(r"<[^>]+>", "", text).strip()
@@ -757,12 +772,17 @@ class MarkdownProcessor:
                     display_text = m.group(1).strip()
                 else:
                     display_text = heading_id
-                    
+
             display_text = _html.escape(_html.unescape(display_text))
 
             # If no icon and this is a level-3 leaf heading (and not already a numbered item), use the default SVG
-            starts_with_number = bool(re.match(r'^\d+\.', display_text))
-            if not icon_html and not has_child and level == 3 and not starts_with_number:
+            starts_with_number = bool(re.match(r"^\d+\.", display_text))
+            if (
+                not icon_html
+                and not has_child
+                and level == 3
+                and not starts_with_number
+            ):
                 icon_html = default_svg
 
             toc_html += f'<li class="list-group-item"><a href="#{heading_id}">{icon_html}{display_text}</a></li>\n'


### PR DESCRIPTION
# Pull Request

## Summary

add a feature where user can add custom fields to the metadata. 

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages:
  - docs\users\detailed-guides\data-sources\jira.md
  - docs\users\configuration\config-file-reference.md
- [x] Have you updated or added pages under `docs/`?
- [x] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

This is the configuration file:
projects:
  my-project:
    sources:
      jira:
        projectkey:
          base_url: https://jira.softathome.com/
          project_key: projectkey
          deployment_type: "datacenter"
          token: ${JIRA_TOKEN}
          enable_file_conversion: true
          extra_fields:
          - param_name: customfield_12000
            name: detected_in_version
            field_type: simple
          - param_name: versions
            name: affected_versions
            field_type: array_object
            attr_name: name
Then I executed the following command: uv run qdrant-loader ingest --workspace . --log-level debug 
Using debug mode, I verified that the fields exist in the logs. The fields are also successfully added to Qdrant.
 Output:
<img width="179" height="101" alt="image" src="https://github.com/user-attachments/assets/2f09031e-8905-4358-ab23-4a991fb987ca" />


## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [x] Documentation updated (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds dynamic field extraction and injects values into `JiraIssue`/document metadata; misconfiguration or missing propagation (e.g., connectors not passing `extra_fields`) could cause runtime errors or unexpected metadata shapes.
> 
> **Overview**
> Adds configurable `extra_fields` support for the Jira connector, letting users specify additional Jira field parameters and how to extract them (simple/object/array/array-of-objects) via new `JiraExtraField`/`JiraFieldType` config models with validation.
> 
> Issue parsing now optionally extracts these fields and attaches them onto `JiraIssue` (model now allows extra attributes), and document generation appends the extracted values into `Document.metadata`. The Data Center connector is updated to pass configured `extra_fields` into issue parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b39c705139c5cc76d6a655affaa1fb502d6c1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure and extract additional Jira fields into document metadata (simple, nested object, and array-of-object types).

* **Improvements**
  * Issue parsing now includes configured extra fields so their values appear in produced documents.
  * Embedding responses are aligned to original inputs; empty embeddings are skipped and logged.

* **Validation**
  * Extra-field definitions are trimmed, non-empty, enforce attribute mapping for nested types, and disallow duplicate names.

* **Bug Fixes**
  * Clearer error handling when project state update conflicts occur.

* **Style**
  * Minor footer and layout HTML tweaks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/251)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->