### PR TITLE
test: isolate legacy embedding tests from LLM environment variables

### DIFF
--- a/packages/qdrant-loader-mcp-server/tests/unit/test_config_loader.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/test_config_loader.py
@@ -124,6 +124,9 @@ class TestSubstituteEnvVars:
 class TestLegacyEmbeddingMigration:
     def test_legacy_embedding_migrates_to_llm(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_EMBEDDING_MODEL", raising=False)
+        monkeypatch.delenv("LLM_CHAT_MODEL", raising=False)
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
         config_data = {
             "global": {
                 "embedding": {
@@ -140,6 +143,9 @@ class TestLegacyEmbeddingMigration:
 
     def test_legacy_does_not_override_explicit_llm(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("LLM_EMBEDDING_MODEL", raising=False)
+        monkeypatch.delenv("LLM_CHAT_MODEL", raising=False)
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
         config_data = {
             "global": {
                 "llm": {


### PR DESCRIPTION
# Pull Request

## Summary

fix unit test, isolate legacy embedding tests from LLM environment variables

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)
