### PR TITLE
chore(docs): clean up deprecated process_attachments in docs

### DIFF
--- a/docs/users/detailed-guides/data-sources/README.md
+++ b/docs/users/detailed-guides/data-sources/README.md
@@ -434,7 +434,7 @@ projects:
           project_key: "RESEARCH"
           token: "${JIRA_TOKEN}"
           email: "${JIRA_EMAIL}"
-          process_attachments: true
+          download_attachments: true
 ```
 
 ## 🧪 Configuration Management

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -102,8 +102,8 @@ global:
   embedding:
     endpoint: "${LLM_BASE_URL}"
     # Ollama: Local Ollama OpenAI-compatible endpoint
-    # OpenAI equivalent: https://api.openai.com/v1       
-    model: "${LLM_EMBEDDING_MODEL}" 
+    # OpenAI equivalent: https://api.openai.com/v1
+    model: "${LLM_EMBEDDING_MODEL}"
     # Ollama: Local embedding model name
     # OpenAI equivalent: text-embedding-3-small   (1536 dimensions, cheaper)
     api_key: "${LLM_API_KEY}"
@@ -112,7 +112,7 @@ global:
     batch_size: 100
     vector_size: ${VECTOR_SIZE}
     # MUST match model output dimension
-    # OpenAI: text-embedding-3-small → 1536                      
+    # OpenAI: text-embedding-3-small → 1536
     tokenizer: "none"
     # Ollama: "none"
     # OpenAI: "cl100k_base"
@@ -366,7 +366,6 @@ projects:
           project_key: "${JIRA_PROJECT_KEY}" # Project to process
           requests_per_minute: 60 # Rate limit for API calls
           page_size: 50 # Number of issues per API request
-          process_attachments: true # Whether to process issue attachments
           track_last_sync: true # Track last sync time for incremental updates
           token: "${JIRA_TOKEN}" # Jira API token (from id.atlassian.com)
           email: "${JIRA_EMAIL}" # Jira user email

--- a/packages/qdrant-loader/tests/config.test.template.yaml
+++ b/packages/qdrant-loader/tests/config.test.template.yaml
@@ -152,7 +152,6 @@ projects:
             - "Open"
             - "In Progress"
             - "Done"
-          process_attachments: true
           track_last_sync: true
           token: "${JIRA_TOKEN}"
           email: "${JIRA_EMAIL}"

--- a/packages/qdrant-loader/tests/config.test.yaml
+++ b/packages/qdrant-loader/tests/config.test.yaml
@@ -24,35 +24,36 @@ global:
   # Default chunking configuration
   # Controls how documents are split into chunks for processing
   chunking:
-    chunk_size: 2000       # Increased to better handle markdown sections
-    chunk_overlap: 200     # Increased overlap to maintain context between chunks
-    
+    chunk_size: 2000 # Increased to better handle markdown sections
+    chunk_overlap: 200 # Increased overlap to maintain context between chunks
+
   semantic_analysis:
-    num_topics: 3                    # Number of topics to extract using LDA
-    lda_passes: 10                   # Number of passes for LDA training
-    spacy_model: "en_core_web_md"    # spaCy model for text processing
-                                     # Options: en_core_web_sm (15MB, no vectors)
-                                     #          en_core_web_md (50MB, 20k vectors) - recommended
-                                     #          en_core_web_lg (750MB, 514k vectors)  
+    num_topics: 3 # Number of topics to extract using LDA
+    lda_passes: 10 # Number of passes for LDA training
+    spacy_model:
+      "en_core_web_md" # spaCy model for text processing
+      # Options: en_core_web_sm (15MB, no vectors)
+      #          en_core_web_md (50MB, 20k vectors) - recommended
+      #          en_core_web_lg (750MB, 514k vectors)
   # Default embedding configuration
   # Controls how text is converted to vectors
   embedding:
     endpoint: "https://api.openai.com/v1" # Optionnal. Defines the endpoint to use for embedding. Defaults to OpenAI endpoint.
-    model: "text-embedding-3-small"  # Embedding model to use. Could be BAAI/bge-small-en-v1.5 (exemple for local use) or text-embedding-3-small (for OpenAI use)
-    batch_size: 100                  # Number of chunks to process in one batch
-    vector_size: 1536                # Optionnal. Vector size for the embedding model (384 for BAAI/bge-small-en-v1.5, 1536 for OpenAI text-embedding-3-small)
-    tokenizer: "cl100k_base"         # Optionnal. Tokenizer to use for token counting. Use 'cl100k_base' for OpenAI models or 'none' for other models.
-    max_tokens_per_request: 8000     # Maximum total tokens per API request (leave buffer below model limit)
-    max_tokens_per_chunk: 8000       # Maximum tokens per individual chunk (should match model's context limit)
+    model: "text-embedding-3-small" # Embedding model to use. Could be BAAI/bge-small-en-v1.5 (exemple for local use) or text-embedding-3-small (for OpenAI use)
+    batch_size: 100 # Number of chunks to process in one batch
+    vector_size: 1536 # Optionnal. Vector size for the embedding model (384 for BAAI/bge-small-en-v1.5, 1536 for OpenAI text-embedding-3-small)
+    tokenizer: "cl100k_base" # Optionnal. Tokenizer to use for token counting. Use 'cl100k_base' for OpenAI models or 'none' for other models.
+    max_tokens_per_request: 8000 # Maximum total tokens per API request (leave buffer below model limit)
+    max_tokens_per_chunk: 8000 # Maximum tokens per individual chunk (should match model's context limit)
   # File conversion configuration
   # Controls how non-text files (PDF, Office docs, etc.) are converted to text
   file_conversion:
     # Maximum file size for conversion (in bytes)
-    max_file_size: 52428800  # 50MB
-    
+    max_file_size: 52428800 # 50MB
+
     # Timeout for conversion operations (in seconds)
-    conversion_timeout: 300  # 5 minutes
-    
+    conversion_timeout: 300 # 5 minutes
+
     # MarkItDown specific settings
     markitdown:
       # Enable LLM integration for image descriptions
@@ -61,15 +62,15 @@ global:
       llm_model: "gpt-4o"
       # LLM endpoint (when enabled)
       llm_endpoint: "https://api.openai.com/v1"
-      
+
   # State management configuration
   # Controls how document ingestion state is tracked
   state_management:
-    database_path: ":memory:"  # Path to SQLite database file
-    table_prefix: "qdrant_loader_"     # Prefix for database tables
-    connection_pool:                   # Connection pool settings
-      size: 5                         # Maximum number of connections
-      timeout: 30                  # Connection timeout in seconds
+    database_path: ":memory:" # Path to SQLite database file
+    table_prefix: "qdrant_loader_" # Prefix for database tables
+    connection_pool: # Connection pool settings
+      size: 5 # Maximum number of connections
+      timeout: 30 # Connection timeout in seconds
 
 projects:
   theorcs:
@@ -83,17 +84,17 @@ projects:
         thymeleaf:
           # Base URL of the documentation website
           base_url: "https://www.thymeleaf.org/doc/tutorials/3.1/usingthymeleaf.html"
-          
+
           # Specific version of the documentation to fetch
           version: "3.1"
 
           # Content type of the documentation
-          content_type: "html"  # Options: html, markdown, etc.
-          
+          content_type: "html" # Options: html, markdown, etc.
+
           # Optional: Specific path pattern to match documentation pages
           # Uses glob syntax: ** matches any directory, * matches any file
           path_pattern: "*"
-          
+
           # Optional: List of paths to exclude from processing
           exclude_paths:
             - "/downloads/**"
@@ -103,31 +104,31 @@ projects:
           selectors:
             # Main content container selector - this is correct
             content: ".content-wrapper"
-            
+
             # Elements to remove - these need to be updated
-            remove: 
-              - ".toc-wrapper"  # This is the table of contents
-              - ".toolbar-container"  # This is the top navigation
-              - "header"  # The header section
-              - "footer"  # The footer section
-              - "nav"  # Any navigation elements
-            
+            remove:
+              - ".toc-wrapper" # This is the table of contents
+              - ".toolbar-container" # This is the top navigation
+              - "header" # The header section
+              - "footer" # The footer section
+              - "nav" # Any navigation elements
+
             # Code blocks to preserve - this needs to be updated
-            code_blocks: "pre code, .code"  # The documentation uses both pre code and .code classes
+            code_blocks: "pre code, .code" # The documentation uses both pre code and .code classes
         thymeleaf-spring:
           # Base URL of the documentation website
           base_url: "https://www.thymeleaf.org/doc/tutorials/3.1/thymeleafspring.html"
-          
+
           # Specific version of the documentation to fetch
           version: "3.1"
-          
+
           # Content type of the documentation
-          content_type: "html"  # Options: html, markdown, etc.
-          
+          content_type: "html" # Options: html, markdown, etc.
+
           # Optional: Specific path pattern to match documentation pages
           # Uses glob syntax: ** matches any directory, * matches any file
           path_pattern: "*"
-          
+
           # Optional: List of paths to exclude from processing
           exclude_paths:
             - "/downloads/**"
@@ -137,30 +138,30 @@ projects:
           selectors:
             # Main content container selector - this is correct
             content: ".content-wrapper"
-            
+
             # Elements to remove - these need to be updated
-            remove: 
-              - ".toc-wrapper"  # This is the table of contents
-              - ".toolbar-container"  # This is the top navigation
-              - "header"  # The header section
-              - "footer"  # The footer section
-              - "nav"  # Any navigation elements
-            
+            remove:
+              - ".toc-wrapper" # This is the table of contents
+              - ".toolbar-container" # This is the top navigation
+              - "header" # The header section
+              - "footer" # The footer section
+              - "nav" # Any navigation elements
+
             # Code blocks to preserve - this needs to be updated
-            code_blocks: "pre code, .code"  # The documentation uses both pre code and .code classes
+            code_blocks: "pre code, .code" # The documentation uses both pre code and .code classes
       # Git repository sources
       git:
         # Example configuration for a public repository
         theorcs:
-          base_url: "https://github.com/martin-papy/theorcs-v5.git"  # Repository URL
-          branch: "main"                             # Branch to process
-          include_paths:                             # Paths to include (glob patterns)
+          base_url: "https://github.com/martin-papy/theorcs-v5.git" # Repository URL
+          branch: "main" # Branch to process
+          include_paths: # Paths to include (glob patterns)
             - "docs/**"
             - "README.md"
-          exclude_paths:                            # Paths to exclude (glob patterns)
+          exclude_paths: # Paths to exclude (glob patterns)
             - "docs/archive/**"
             - "src/**"
-          file_types:                                # File extensions to process
+          file_types: # File extensions to process
             - "*.md"
             - "*.java"
             - "*.css"
@@ -169,30 +170,30 @@ projects:
             - "*.html"
             - "*.yaml"
             - "*.properties"
-          max_file_size: 1048576                    # Maximum file size in bytes (1MB)
-          token: "${REPO_TOKEN}"                    #  GitHub Personal Access Token or none
+          max_file_size: 1048576 # Maximum file size in bytes (1MB)
+          token: "${REPO_TOKEN}" #  GitHub Personal Access Token or none
 
       # Confluence documentation sources
       confluence:
         theorcs:
-          base_url: "https://theorcs.atlassian.net/wiki"                  # Confluence instance URL
-          space_key: "THEORCS"      # Space to process
-          content_types:                            # Types of content to process
+          base_url: "https://theorcs.atlassian.net/wiki" # Confluence instance URL
+          space_key: "THEORCS" # Space to process
+          content_types: # Types of content to process
             - "page"
             - "blogpost"
-          include_labels: []                        # Only process content with these labels
-          exclude_labels: []                        # Skip content with these labels
-          token: "${CONFLUENCE_TOKEN}"              # Confluence API token
-          email: "${CONFLUENCE_EMAIL}"              # Confluence user email
+          include_labels: [] # Only process content with these labels
+          exclude_labels: [] # Skip content with these labels
+          token: "${CONFLUENCE_TOKEN}" # Confluence API token
+          email: "${CONFLUENCE_EMAIL}" # Confluence user email
 
       # JIRA issue tracking sources
       jira:
         theorcs:
-          base_url: "https://theorcs.atlassian.net"                   # JIRA instance URL
-          deployment_type: "cloud"                  # Deployment type: cloud, datacenter, or server
-          project_key: "THEORCS"        # Project to process
-          requests_per_minute: 60                   # Rate limit for API calls
-          page_size: 50                             # Number of issues per API request
-          process_attachments: true                 # Whether to process issue attachments
-          token: "${JIRA_TOKEN}"                    # JIRA API token
-          email: "${JIRA_EMAIL}"                    # JIRA user email
+          base_url: "https://theorcs.atlassian.net" # JIRA instance URL
+          deployment_type: "cloud" # Deployment type: cloud, datacenter, or server
+          project_key: "THEORCS" # Project to process
+          requests_per_minute: 60 # Rate limit for API calls
+          page_size: 50 # Number of issues per API request
+          download_attachments: true # Download and process issue attachments
+          token: "${JIRA_TOKEN}" # JIRA API token
+          email: "${JIRA_EMAIL}" # JIRA user email


### PR DESCRIPTION
# Pull Request

## Summary

standardize jira examples to download_attachments, remove process_attachments from templates
## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)
