### PR TITLE
fix: correct embedding worker totals when empty chunks are skipped

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
@@ -266,7 +266,14 @@ class EmbeddingService:
         logger.info(
             f"🔗 Generated embeddings: {len(embeddings)} items in {batch_count} batches"
         )
-        return embeddings
+
+        # Reconstruct full-length result aligned with original input indices.
+        # Invalid entries (filtered out above) get an empty list as placeholder so
+        # callers can zip safely without index shift.
+        full_result: list[list[float]] = [[] for _ in contents]
+        for idx, embedding in zip(valid_indices, embeddings):
+            full_result[idx] = embedding
+        return full_result
 
     async def _process_batch(self, batch: list[str]) -> list[list[float]]:
         """Process a single batch of content for embeddings.

--- a/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
@@ -267,6 +267,13 @@ class EmbeddingService:
             f"🔗 Generated embeddings: {len(embeddings)} items in {batch_count} batches"
         )
 
+        if len(valid_indices) != len(embeddings):
+            raise ValueError(
+                "Embedding count mismatch: "
+                f"expected {len(valid_indices)} embeddings for valid contents, "
+                f"got {len(embeddings)}"
+            )
+
         # Reconstruct full-length result aligned with original input indices.
         # Invalid entries (filtered out above) get an empty list as placeholder so
         # callers can zip safely without index shift.

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/embedding_worker.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/embedding_worker.py
@@ -65,7 +65,18 @@ class EmbeddingWorker(BaseWorker):
                     logger.debug("EmbeddingWorker skipping result due to shutdown")
                     return []
 
-                result = list(zip(chunks, embeddings, strict=False))
+                # Filter out chunks whose embedding is empty (invalid content was
+                # skipped in get_embeddings and replaced with [] placeholder).
+                result = [
+                    (chunk, emb)
+                    for chunk, emb in zip(chunks, embeddings, strict=False)
+                    if emb
+                ]
+                skipped = len(chunks) - len(result)
+                if skipped:
+                    logger.warning(
+                        f"Skipped {skipped} chunk(s) with empty embeddings, they will not be upserted"
+                    )
                 logger.debug(f"EmbeddingWorker completed batch of {len(chunks)} items")
 
                 # Cleanup after large batches
@@ -115,9 +126,9 @@ class EmbeddingWorker(BaseWorker):
                             f"🔄 Processing embedding batch of {len(batch)} chunks..."
                         )
                         results = await self.process(batch)
-                        total_processed += len(batch)
+                        total_processed += len(results)
                         logger.info(
-                            f"🔗 Generated embeddings: {len(batch)} items in batch, {total_processed} total processed"
+                            f"🔗 Generated embeddings: {len(results)} items in batch, {total_processed} total processed"
                         )
 
                         for result in results:
@@ -137,9 +148,9 @@ class EmbeddingWorker(BaseWorker):
                         f"🔄 Processing final embedding batch of {len(batch)} chunks..."
                     )
                     results = await self.process(batch)
-                    total_processed += len(batch)
+                    total_processed += len(results)
                     logger.info(
-                        f"🔗 Generated embeddings: {len(batch)} items in final batch, {total_processed} total processed"
+                        f"🔗 Generated embeddings: {len(results)} items in final batch, {total_processed} total processed"
                     )
 
                     for result in results:


### PR DESCRIPTION
# Pull Request

## Summary

This branch fixes embedding alignment and logging when empty chunks are skipped. It preserves input-to-embedding index mapping, prevents empty chunks from being upserted, and updates batch/total counts to reflect only valid embeddings.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected Components & Stages
The embedding pipeline stage is impacted: `EmbeddingService.get_embeddings()` and `EmbeddingWorker.process()` in the qdrant-loader package.

## Config Schema Changes
None identified. No breaking or additive configuration changes.

## Test Coverage
The PR objectives confirm tests pass, but the raw summary does not specify which test suites cover the modified code paths (embedding_service and embedding_worker changes).

## Security & Resource-Safety
No security concerns identified. The changes address data consistency: (1) reconstructing output embeddings to match original input indices, (2) preventing empty chunks from being upserted to Qdrant, (3) correcting batch and total counters to reflect only valid embeddings. These are correctness fixes that prevent resource waste from processing and storing invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->