### PR TITLE
fix: catch autoflush IntegrityError and suggest state DB reset. Resol…

### DIFF
--- a/docs/users/troubleshooting/common-issues.md
+++ b/docs/users/troubleshooting/common-issues.md
@@ -240,6 +240,30 @@ qdrant-loader ingest --workspace .
 
 ## ⚙️ Configuration Issues
 
+### Issue: `UNIQUE constraint failed: projects.collection_name` during multi-project ingest
+
+**Symptoms:**
+
+- `qdrant-loader ingest --workspace .` fails when initializing projects
+- Error includes `sqlite3.IntegrityError: UNIQUE constraint failed: projects.collection_name`
+
+**Cause:**
+
+- Your existing state database was created with an older schema that enforced a unique constraint on `projects.collection_name`.
+- In workspace mode, multiple projects can share the same global collection name.
+
+**Fix (one-time):**
+
+```bash
+qdrant-loader init --workspace . --force
+qdrant-loader ingest --workspace .
+```
+
+**Notes:**
+
+- `--force` resets the state DB metadata for the workspace.
+- If needed, you can also delete the workspace state DB file manually, then run `init` again.
+
 ### Issue: Configuration validation fails
 
 **Symptoms:**

--- a/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from inspect import isawaitable
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from qdrant_loader.config.models import ProjectConfig, ProjectsConfig
@@ -193,10 +194,21 @@ class ProjectManager:
                 # Best-effort add; proceed to commit
                 pass
 
-        # Update project sources
-        await self._update_project_sources(session, context.project_id, config)
-
-        await session.commit()
+        try:
+            # Update project sources
+            await self._update_project_sources(session, context.project_id, config)
+            await session.commit()
+        except IntegrityError as e:
+            # The unique-constraint error can be triggered by autoflush during
+            # session.execute() inside _update_project_sources, before commit.
+            await session.rollback()
+            err = str(e)
+            if "projects.collection_name" in err or "uix_project_collection" in err:
+                raise ValueError(
+                    "State DB schema is outdated and still enforces unique projects.collection_name. "
+                    "Reset state DB once and retry: `qdrant-loader init --workspace . --force`."
+                ) from e
+            raise
 
     async def _update_project_sources(
         self, session: AsyncSession, project_id: str, config: ProjectConfig

--- a/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
@@ -209,6 +209,9 @@ class ProjectManager:
                     "Reset state DB once and retry: `qdrant-loader init --workspace . --force`."
                 ) from e
             raise
+        except Exception:
+            await session.rollback()
+            raise
 
     async def _update_project_sources(
         self, session: AsyncSession, project_id: str, config: ProjectConfig

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/models.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/models.py
@@ -70,10 +70,7 @@ class Project(Base):
         "DocumentStateRecord", back_populates="project", cascade="all, delete-orphan"
     )
 
-    __table_args__ = (
-        UniqueConstraint("collection_name", name="uix_project_collection"),
-        Index("ix_project_display_name", "display_name"),
-    )
+    __table_args__ = (Index("ix_project_display_name", "display_name"),)
 
 
 class ProjectSource(Base):

--- a/packages/qdrant-loader/tests/unit/core/test_project_manager.py
+++ b/packages/qdrant-loader/tests/unit/core/test_project_manager.py
@@ -8,8 +8,13 @@ import pytest
 from pydantic import AnyUrl
 from qdrant_loader.config.models import ProjectConfig, ProjectsConfig
 from qdrant_loader.config.sources import SourcesConfig
+from qdrant_loader.config.state import StateManagementConfig
 from qdrant_loader.connectors.git.config import GitRepoConfig
 from qdrant_loader.core.project_manager import ProjectContext, ProjectManager
+from qdrant_loader.core.state.models import Project
+from qdrant_loader.core.state.state_manager import StateManager
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -184,3 +189,103 @@ def test_project_listing(project_manager):
     assert len(all_contexts) == 2
     assert all_contexts["project-1"].display_name == "Project 1"
     assert all_contexts["project-2"].display_name == "Project 2"
+
+
+@pytest.mark.asyncio
+async def test_multi_project_shared_collection_name_allowed():
+    """Two projects should be persisted even when sharing global collection name."""
+    git_config_1 = GitRepoConfig(
+        source_type="git",
+        source="repo-1",
+        base_url=AnyUrl("https://github.com/test/repo-1.git"),
+        branch="main",
+        token="test-token",
+        temp_dir="/tmp/test-1",
+        file_types=["md"],
+    )
+    git_config_2 = GitRepoConfig(
+        source_type="git",
+        source="repo-2",
+        base_url=AnyUrl("https://github.com/test/repo-2.git"),
+        branch="main",
+        token="test-token",
+        temp_dir="/tmp/test-2",
+        file_types=["md"],
+    )
+
+    sources_1 = SourcesConfig()
+    sources_1.git = {"repo-1": git_config_1}
+    sources_2 = SourcesConfig()
+    sources_2.git = {"repo-2": git_config_2}
+
+    project_1 = ProjectConfig(
+        project_id="project-1",
+        display_name="Project 1",
+        description="First project",
+        sources=sources_1,
+    )
+    project_2 = ProjectConfig(
+        project_id="project-2",
+        display_name="Project 2",
+        description="Second project",
+        sources=sources_2,
+    )
+
+    projects_config = ProjectsConfig()
+    projects_config.projects = {
+        "project-1": project_1,
+        "project-2": project_2,
+    }
+
+    state_manager = StateManager(StateManagementConfig(database_path=":memory:"))
+    await state_manager.initialize()
+    try:
+        async with await state_manager.get_session() as session:
+            manager = ProjectManager(
+                projects_config=projects_config,
+                global_collection_name="shared_collection",
+            )
+            await manager.initialize(session)
+
+            result = await session.execute(select(Project))
+            projects = result.scalars().all()
+
+            assert len(projects) == 2
+            assert all(p.collection_name == "shared_collection" for p in projects)
+    finally:
+        await state_manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_outdated_state_db_error_surfaces_actionable_hint(project_manager):
+    """Autoflush IntegrityError should be converted to a clear recovery hint."""
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = mock_result
+
+    async def _raise_autoflush_error(*_args, **_kwargs):
+        raise IntegrityError(
+            statement="INSERT INTO projects ...",
+            params={},
+            orig=Exception("UNIQUE constraint failed: projects.collection_name"),
+        )
+
+    project_manager._update_project_sources = _raise_autoflush_error  # type: ignore[method-assign]
+
+    context = ProjectContext(
+        project_id="test-project",
+        display_name="Test Project",
+        description="A test project",
+        collection_name="global_collection",
+        config=project_manager.projects_config.projects["test-project"],
+    )
+
+    with pytest.raises(ValueError, match="State DB schema is outdated"):
+        await project_manager._ensure_project_in_database(  # type: ignore[attr-defined]
+            mock_session,
+            context,
+            project_manager.projects_config.projects["test-project"],
+        )
+
+    mock_session.rollback.assert_awaited_once()


### PR DESCRIPTION

# Pull Request

## Summary

handle autoflush integrity errors and surface state DB reset guidance

## Type of change

- [ ] Feature
- [x] Bug fix
- [x] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [x] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Affected Components: Core ProjectManager state DB logic — impacts any connector or pipeline stage that persists project metadata (multi-project ingestion and project initialization).

Config Schema Changes: Breaking DB-model change — removed UniqueConstraint on projects.collection_name, making shared global_collection_name allowed (additive behavior for multi-project sharing, but breaking if tooling expected uniqueness).

Test Coverage: Tests added cover both behaviors: shared-collection persistence and handling autoflush IntegrityError by surfacing a ValueError with a “State DB schema is outdated” hint and ensuring session.rollback is awaited.

Security/Resource Concerns: Allowing multiple projects to share a collection increases risk of cross-project data/noise and conflicts; responsibility shifts to application-level isolation. The PR improves error messaging for schema mismatches but does not add safeguards to prevent logical data contamination.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/270)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->