### PR TITLE
feat: Excel Parsing And Ingestion

### DIFF
--- a/packages/qdrant-loader/pyproject.toml
+++ b/packages/qdrant-loader/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     "tree-sitter-languages>=1.10.0",
     "tree-sitter<0.21",
     "markitdown[all]>=0.1.3",
+    "networkx>=3.0.0",
     "rich>=13.0.0",
     "questionary>=2.0.0",
     "packaging>=21.0",

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/section_splitter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/section_splitter.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 # Re-export classes and local dependencies at top to satisfy E402
 from .document_parser import DocumentParser, HierarchyBuilder  # noqa: F401
 from .splitters.base import BaseSplitter  # re-export base class  # noqa: F401
-from .splitters.excel import ExcelSplitter  # re-export  # noqa: F401
+from .splitters.row_kv_excel import RowKVExcelSplitter  # noqa: F401
 from .splitters.fallback import FallbackSplitter  # re-export  # noqa: F401
 from .splitters.standard import StandardSplitter  # re-export  # noqa: F401
 
@@ -101,7 +101,7 @@ class SectionSplitter:
         """
         self.settings = settings
         self.standard_splitter = StandardSplitter(settings)
-        self.excel_splitter = ExcelSplitter(settings)
+        self.excel_splitter = RowKVExcelSplitter(settings)
         self.fallback_splitter = FallbackSplitter(settings)
 
     def _is_excel_document(self, document: Any) -> bool:

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/section_splitter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/section_splitter.py
@@ -425,18 +425,24 @@ class SectionSplitter:
         final_sections: list[dict[str, Any]] = []
 
         for section in sections:
-            if len(section["content"]) > chunk_size:
+            is_excel_sheet = section.get("is_excel_sheet", False)
+            # Excel sections always go through the KV splitter so chunk shape
+            # stays uniform across the file. Non-Excel content only splits when
+            # it exceeds the chunk budget — that's the standard-splitter
+            # bypass and is unchanged.
+            needs_split = is_excel_sheet or len(section["content"]) > chunk_size
+            if needs_split:
                 logger.debug(
-                    f"Section too large ({len(section['content'])} chars), splitting into smaller chunks",
+                    f"Splitting section ({len(section['content'])} chars)",
                     extra={
                         "section_title": section.get("title", "Unknown"),
                         "section_size": len(section["content"]),
                         "chunk_size_limit": chunk_size,
-                        "is_excel_sheet": section.get("is_excel_sheet", False),
+                        "is_excel_sheet": is_excel_sheet,
                     },
                 )
 
-                if section.get("is_excel_sheet", False):
+                if is_excel_sheet:
                     sub_chunks = self.excel_splitter.split_content(
                         section["content"], chunk_size
                     )

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/splitters/row_kv_excel.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/splitters/row_kv_excel.py
@@ -1,0 +1,149 @@
+"""Row-level KV chunking for converted xlsx documents.
+
+Implements the structure-aware chunking technique from arXiv 2605.00318
+("Structure-Aware Chunking for Tabular Data in Retrieval-Augmented Generation"):
+each row becomes a key-value block, prefixed with sheet/subtable/column context.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+from qdrant_loader.core.chunking.strategy.markdown.splitters.base import BaseSplitter
+from qdrant_loader.core.file_conversion.xlsx_markdown_format import SHEET_HEADING_RE
+
+# Split on `|` only when it is NOT preceded by a backslash (escaped pipe).
+_UNESCAPED_PIPE_RE = re.compile(r"(?<!\\)\|")
+
+
+@dataclass(frozen=True)
+class _SubTableContext:
+    sheet: str
+    subtable: int | None
+    columns: tuple[str, ...]
+
+
+class MarkdownTableParser:
+    """Parse `## Sheet: ... / Subtable: N` sections back into structured rows."""
+
+    def parse(self, content: str) -> list[tuple[_SubTableContext, list[dict[str, str]]]]:
+        sections: list[tuple[_SubTableContext, list[dict[str, str]]]] = []
+        matches = list(SHEET_HEADING_RE.finditer(content))
+        for i, m in enumerate(matches):
+            start = m.end()
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
+            block = content[start:end]
+            columns, rows = self._parse_table(block)
+            if not columns:
+                continue
+            ctx = _SubTableContext(
+                sheet=m.group("sheet").strip(),
+                subtable=int(m.group("idx")) if m.group("idx") else None,
+                columns=columns,
+            )
+            sections.append((ctx, rows))
+        return sections
+
+    @staticmethod
+    def _parse_table(block: str) -> tuple[tuple[str, ...], list[dict[str, str]]]:
+        lines = [ln.strip() for ln in block.splitlines() if ln.strip().startswith("|")]
+        if len(lines) < 2:
+            return (), []
+        header_cells = MarkdownTableParser._row_cells(lines[0])
+        body: list[dict[str, str]] = []
+        # lines[1] is the separator (`|---|---|`); skip it.
+        for line in lines[2:]:
+            cells = MarkdownTableParser._row_cells(line)
+            if len(cells) != len(header_cells):
+                continue
+            body.append(dict(zip(header_cells, cells)))
+        return tuple(header_cells), body
+
+    @staticmethod
+    def _row_cells(line: str) -> list[str]:
+        # Strip the leading and trailing pipe before splitting on UNESCAPED
+        # pipes (the converter escapes literal `|` in cell values as `\|` so
+        # they don't break this split). After splitting, unescape each cell.
+        inner = line.strip().strip("|")
+        cells = _UNESCAPED_PIPE_RE.split(inner)
+        return [c.strip().replace(r"\|", "|") for c in cells]
+
+
+class RowChunkContextualizer:
+    """Render a slice of rows with contextual preamble for embedding."""
+
+    def build(self, ctx: _SubTableContext, rows: Iterable[dict[str, str]]) -> str:
+        lines: list[str] = [f"Sheet: {ctx.sheet}"]
+        if ctx.subtable is not None:
+            lines.append(f"Subtable: {ctx.subtable}")
+        lines.append(f"Columns: {', '.join(ctx.columns)}")
+        lines.append("")
+        for row in rows:
+            lines.append("Row:")
+            for col in ctx.columns:
+                value = row.get(col, "")
+                if value == "":
+                    continue
+                lines.append(f"  {col}: {value}")
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
+
+
+class RowKVChunker:
+    """Pack rows into chunks under a character budget, re-emitting context per chunk."""
+
+    def __init__(self) -> None:
+        self._renderer = RowChunkContextualizer()
+
+    def chunk(
+        self,
+        ctx: _SubTableContext,
+        rows: list[dict[str, str]],
+        max_size: int,
+    ) -> list[str]:
+        if not rows:
+            return []
+        chunks: list[str] = []
+        current: list[dict[str, str]] = []
+        for row in rows:
+            candidate = current + [row]
+            if current and len(self._renderer.build(ctx, candidate)) > max_size:
+                chunks.append(self._renderer.build(ctx, current))
+                current = [row]
+            else:
+                current = candidate
+        if current:
+            chunks.append(self._renderer.build(ctx, current))
+        return chunks
+
+
+class RowKVExcelSplitter(BaseSplitter):
+    """BaseSplitter that emits row-level KV chunks for converted xlsx content.
+
+    Type-substitutable for the legacy ExcelSplitter at the BaseSplitter
+    interface — same `split_content(content, max_size) -> list[str]` signature
+    and the same dispatch site at section_splitter.py:104. The output shape is
+    materially different, however: ExcelSplitter emits markdown-table fragments,
+    while RowKVExcelSplitter emits prose-like context-prefixed KV blocks (the
+    STC technique from arXiv 2605.00318). Downstream consumers that re-parsed
+    chunks as markdown tables need updating; in-tree consumers (embedding,
+    reranking, retrieval) treat chunks as opaque text.
+    """
+
+    def __init__(self, settings) -> None:
+        super().__init__(settings)
+        self._parser = MarkdownTableParser()
+        self._chunker = RowKVChunker()
+
+    def split_content(self, content: str, max_size: int) -> list[str]:
+        sections = self._parser.parse(content)
+        if not sections:
+            # No structured heading — preserve content as a single chunk so
+            # upstream mis-classification doesn't drop content.
+            return [content]
+        chunks: list[str] = []
+        for ctx, rows in sections:
+            chunks.extend(self._chunker.chunk(ctx, rows, max_size=max_size))
+        return chunks

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/splitters/row_kv_excel.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/splitters/row_kv_excel.py
@@ -11,11 +11,18 @@ import re
 from dataclasses import dataclass
 from typing import Iterable
 
+import structlog
+
 from qdrant_loader.core.chunking.strategy.markdown.splitters.base import BaseSplitter
 from qdrant_loader.core.file_conversion.xlsx_markdown_format import SHEET_HEADING_RE
 
+logger = structlog.get_logger(__name__)
+
 # Split on `|` only when it is NOT preceded by a backslash (escaped pipe).
 _UNESCAPED_PIPE_RE = re.compile(r"(?<!\\)\|")
+
+# Separator between row blocks within a chunk body — a blank line.
+_ROW_SEP = "\n\n"
 
 
 @dataclass(frozen=True)
@@ -53,12 +60,21 @@ class MarkdownTableParser:
             return (), []
         header_cells = MarkdownTableParser._row_cells(lines[0])
         body: list[dict[str, str]] = []
+        dropped = 0
         # lines[1] is the separator (`|---|---|`); skip it.
         for line in lines[2:]:
             cells = MarkdownTableParser._row_cells(line)
             if len(cells) != len(header_cells):
+                dropped += 1
                 continue
             body.append(dict(zip(header_cells, cells)))
+        if dropped:
+            logger.debug(
+                "row_kv_excel: parser dropped rows whose cell count != header count",
+                dropped=dropped,
+                kept=len(body),
+                header_cells=len(header_cells),
+            )
         return tuple(header_cells), body
 
     @staticmethod
@@ -74,25 +90,40 @@ class MarkdownTableParser:
 class RowChunkContextualizer:
     """Render a slice of rows with contextual preamble for embedding."""
 
-    def build(self, ctx: _SubTableContext, rows: Iterable[dict[str, str]]) -> str:
+    def preamble(self, ctx: _SubTableContext) -> str:
+        """Render the sheet/subtable/columns header that prefixes every chunk."""
         lines: list[str] = [f"Sheet: {ctx.sheet}"]
         if ctx.subtable is not None:
             lines.append(f"Subtable: {ctx.subtable}")
         lines.append(f"Columns: {', '.join(ctx.columns)}")
-        lines.append("")
-        for row in rows:
-            lines.append("Row:")
-            for col in ctx.columns:
-                value = row.get(col, "")
-                if value == "":
-                    continue
-                lines.append(f"  {col}: {value}")
-            lines.append("")
-        return "\n".join(lines).rstrip() + "\n"
+        return "\n".join(lines)
+
+    def row_block(self, ctx: _SubTableContext, row: dict[str, str]) -> str:
+        """Render one row as a KV block (no trailing separator)."""
+        lines: list[str] = ["Row:"]
+        for col in ctx.columns:
+            value = row.get(col, "")
+            if value == "":
+                continue
+            lines.append(f"  {col}: {value}")
+        return "\n".join(lines)
+
+    def build(self, ctx: _SubTableContext, rows: Iterable[dict[str, str]]) -> str:
+        """Render preamble + body for the given rows. Compatible output format."""
+        preamble = self.preamble(ctx)
+        blocks = [self.row_block(ctx, r) for r in rows]
+        if not blocks:
+            return f"{preamble}\n"
+        return f"{preamble}\n\n{_ROW_SEP.join(blocks)}\n"
 
 
 class RowKVChunker:
-    """Pack rows into chunks under a character budget, re-emitting context per chunk."""
+    """Pack rows into chunks under a character budget, re-emitting context per chunk.
+
+    Single-pass O(N): pre-renders each row block once, then walks them while
+    tracking the projected chunk length. Only assembles the full chunk string
+    at emit time, not on every probe.
+    """
 
     def __init__(self) -> None:
         self._renderer = RowChunkContextualizer()
@@ -105,17 +136,27 @@ class RowKVChunker:
     ) -> list[str]:
         if not rows:
             return []
+        preamble = self._renderer.preamble(ctx)
+        blocks = [self._renderer.row_block(ctx, r) for r in rows]
+        # Chunk shape: "{preamble}\n\n{block}{_ROW_SEP}{block}...\n"
+        # — preamble + "\n\n" + (N blocks joined by _ROW_SEP) + trailing "\n".
+        overhead = len(preamble) + 2 + 1  # "\n\n" after preamble + trailing "\n"
+        sep_len = len(_ROW_SEP)
+
         chunks: list[str] = []
-        current: list[dict[str, str]] = []
-        for row in rows:
-            candidate = current + [row]
-            if current and len(self._renderer.build(ctx, candidate)) > max_size:
-                chunks.append(self._renderer.build(ctx, current))
-                current = [row]
+        current: list[str] = []
+        current_body_len = 0
+        for block in blocks:
+            addition = len(block) if not current else len(block) + sep_len
+            if current and overhead + current_body_len + addition > max_size:
+                chunks.append(f"{preamble}\n\n{_ROW_SEP.join(current)}\n")
+                current = [block]
+                current_body_len = len(block)
             else:
-                current = candidate
+                current.append(block)
+                current_body_len += addition
         if current:
-            chunks.append(self._renderer.build(ctx, current))
+            chunks.append(f"{preamble}\n\n{_ROW_SEP.join(current)}\n")
         return chunks
 
 
@@ -143,7 +184,28 @@ class RowKVExcelSplitter(BaseSplitter):
             # No structured heading — preserve content as a single chunk so
             # upstream mis-classification doesn't drop content.
             return [content]
+
+        # Match legacy ExcelSplitter: bound per-section output so a 50k-row
+        # sheet doesn't silently emit 50k chunks.
+        md_cfg = self.settings.global_config.chunking.strategies.markdown
+        per_section_cap = min(
+            md_cfg.max_chunks_per_section,
+            self.settings.global_config.chunking.max_chunks_per_document // 2,
+        )
+
         chunks: list[str] = []
         for ctx, rows in sections:
-            chunks.extend(self._chunker.chunk(ctx, rows, max_size=max_size))
+            section_chunks = self._chunker.chunk(ctx, rows, max_size=max_size)
+            if len(section_chunks) > per_section_cap:
+                logger.warning(
+                    "row_kv_excel: section reached max_chunks_per_section cap, truncating",
+                    sheet=ctx.sheet,
+                    subtable=ctx.subtable,
+                    produced=len(section_chunks),
+                    cap=per_section_cap,
+                    rows_dropped=len(rows)
+                    - sum(c.count("Row:") for c in section_chunks[:per_section_cap]),
+                )
+                section_chunks = section_chunks[:per_section_cap]
+            chunks.extend(section_chunks)
         return chunks

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/clean_xlsx_converter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/clean_xlsx_converter.py
@@ -28,8 +28,12 @@ def _clean_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     return cleaned
 
 
-def _should_skip_sheet(df: pd.DataFrame) -> bool:
-    """Return True for sheets that hold no real data after cleaning."""
+def _is_blank_dataframe(df: pd.DataFrame) -> bool:
+    """Return True for a DataFrame that holds no real data after cleaning.
+
+    Used on per-subtable frames, not full sheets — the name avoids the older
+    "_should_skip_sheet" misnomer.
+    """
     if df.empty:
         return True
     return bool(df.isna().all().all())
@@ -135,7 +139,7 @@ class _CleanSpreadsheetConverter(DocumentConverter):
         body = raw.iloc[1:].reset_index(drop=True)
         body.columns = header
         cleaned = _clean_dataframe(body)
-        if _should_skip_sheet(cleaned):
+        if _is_blank_dataframe(cleaned):
             return None
         escaped = cleaned.map(_escape_string_cell)
         html = escaped.to_html(index=False, na_rep="")

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/clean_xlsx_converter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/clean_xlsx_converter.py
@@ -1,0 +1,159 @@
+"""Custom MarkItDown converters that strip NaN/NaT noise from xlsx and xls output."""
+
+from __future__ import annotations
+
+from typing import Any, BinaryIO
+
+import pandas as pd
+
+from markitdown._base_converter import (
+    DocumentConverter,
+    DocumentConverterResult,
+)
+from markitdown._stream_info import StreamInfo
+from markitdown.converters._html_converter import HtmlConverter
+
+from qdrant_loader.core.file_conversion.sub_table_detector import SubTableDetector
+from qdrant_loader.core.file_conversion.xlsx_markdown_format import (
+    format_sheet_heading,
+)
+
+
+def _clean_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop rows and columns that are entirely missing."""
+    if df.empty:
+        return df
+    cleaned = df.dropna(axis=0, how="all")
+    cleaned = cleaned.dropna(axis=1, how="all")
+    return cleaned
+
+
+def _should_skip_sheet(df: pd.DataFrame) -> bool:
+    """Return True for sheets that hold no real data after cleaning."""
+    if df.empty:
+        return True
+    return bool(df.isna().all().all())
+
+
+def _cell_to_str(value: Any) -> str:
+    """Coerce a header cell to a clean string, mapping NaN/None to ''.
+
+    `Series.astype(str).tolist()` in current pandas can leak a Python `float`
+    NaN through instead of the string "nan", which breaks downstream `.replace`
+    calls on header values.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, float) and pd.isna(value):
+        return ""
+    return str(value)
+
+
+def _escape_string_cell(value: Any) -> Any:
+    """Escape `|` in string cells; pass non-strings through unchanged.
+
+    Body cells use this rather than `_cell_to_str` so pandas' `to_html` can
+    apply its smart numeric formatting (e.g. `1` not `1.0`, `0.5` not `0.50`).
+    NaN survives this pass and is rendered as `""` by `to_html(na_rep="")`.
+    """
+    if isinstance(value, str):
+        return value.replace("|", r"\|")
+    return value
+
+
+class _CleanSpreadsheetConverter(DocumentConverter):
+    """Shared logic for cleaning xlsx/xls output before handing it to MarkItDown."""
+
+    ENGINE: str = ""
+    EXTENSIONS: tuple[str, ...] = ()
+    MIME_PREFIXES: tuple[str, ...] = ()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._html_converter = HtmlConverter()
+        self._detector = SubTableDetector()
+
+    def accepts(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,
+    ) -> bool:
+        extension = (stream_info.extension or "").lower()
+        if extension in self.EXTENSIONS:
+            return True
+        mimetype = (stream_info.mimetype or "").lower()
+        return any(mimetype.startswith(prefix) for prefix in self.MIME_PREFIXES)
+
+    def convert(
+        self,
+        file_stream: BinaryIO,
+        stream_info: StreamInfo,
+        **kwargs: Any,
+    ) -> DocumentConverterResult:
+        # Read header-less so SubTableDetector can decide where headers start.
+        # keep_default_na=False preserves literal "N/A" strings; explicit
+        # na_values=[""] still treats genuinely empty cells as NaN.
+        sheets = pd.read_excel(
+            file_stream,
+            sheet_name=None,
+            engine=self.ENGINE,
+            header=None,
+            keep_default_na=False,
+            na_values=[""],
+        )
+
+        parts: list[str] = []
+        for name, sheet_df in sheets.items():
+            sub_tables = self._detector.detect(sheet_df)
+            for idx, raw in enumerate(sub_tables, start=1):
+                rendered = self._render_subtable(raw, **kwargs)
+                if rendered is None:
+                    continue
+                heading = self._heading(name, idx, total=len(sub_tables))
+                parts.append(f"{heading}\n{rendered}")
+
+        return DocumentConverterResult(markdown="\n\n".join(parts).strip())
+
+    @staticmethod
+    def _heading(sheet_name: str, idx: int, total: int) -> str:
+        return format_sheet_heading(sheet_name, subtable_idx=None if total <= 1 else idx)
+
+    def _render_subtable(self, raw: pd.DataFrame, **kwargs: Any) -> str | None:
+        """Promote first row to header, clean, render to markdown.
+
+        Headers and body cells take different paths on purpose: headers are
+        coerced to strings here (they become DataFrame column labels and feed
+        `.replace`), but body cells stay typed so pandas' `to_html` can apply
+        its native numeric formatting. Both paths escape `|` to survive the
+        downstream markdown-table parser; `HtmlConverter` passes cell text
+        through unchanged.
+        """
+        if raw.empty:
+            return None
+        header = [_cell_to_str(c).replace("|", r"\|") for c in raw.iloc[0].tolist()]
+        body = raw.iloc[1:].reset_index(drop=True)
+        body.columns = header
+        cleaned = _clean_dataframe(body)
+        if _should_skip_sheet(cleaned):
+            return None
+        escaped = cleaned.map(_escape_string_cell)
+        html = escaped.to_html(index=False, na_rep="")
+        return self._html_converter.convert_string(html, **kwargs).markdown.strip()
+
+
+class CleanXlsxConverter(_CleanSpreadsheetConverter):
+    ENGINE = "openpyxl"
+    EXTENSIONS = (".xlsx",)
+    MIME_PREFIXES = (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+
+class CleanXlsConverter(_CleanSpreadsheetConverter):
+    ENGINE = "xlrd"
+    EXTENSIONS = (".xls",)
+    MIME_PREFIXES = (
+        "application/vnd.ms-excel",
+        "application/excel",
+    )

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/file_converter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/file_converter.py
@@ -154,15 +154,12 @@ class FileConverter:
             try:
                 from markitdown import MarkItDown  # type: ignore
 
-                # Configure MarkItDown with LLM settings if enabled
                 if self.config.markitdown.enable_llm_descriptions:
                     self.logger.debug(
                         "Initializing MarkItDown with LLM configuration",
                         llm_model=self.config.markitdown.llm_model,
                         llm_endpoint=self.config.markitdown.llm_endpoint,
                     )
-
-                    # Warn when legacy MarkItDown overrides are in effect
                     try:
                         if (
                             self.config.markitdown.llm_model
@@ -178,9 +175,7 @@ class FileConverter:
                     except Exception:
                         pass
 
-                    # Create LLM client backed by provider (OpenAI-compatible wrapper)
                     llm_client = self._create_llm_client()
-
                     self._markitdown = MarkItDown(
                         llm_client=llm_client,
                         llm_model=self.config.markitdown.llm_model,
@@ -190,11 +185,26 @@ class FileConverter:
                     self._markitdown = MarkItDown()
                     self.logger.debug("MarkItDown initialized without LLM support")
 
+                self._register_custom_converters(self._markitdown)
+
             except ImportError as e:
                 raise MarkItDownError(
                     Exception("MarkItDown library not available")
                 ) from e
         return self._markitdown
+
+    def _register_custom_converters(self, markitdown_instance) -> None:
+        """Register qdrant-loader's custom converters at higher priority than the defaults."""
+        from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
+            CleanXlsConverter,
+            CleanXlsxConverter,
+        )
+
+        # priority=-1 beats MarkItDown's default PRIORITY_SPECIFIC_FILE_FORMAT (0.0 in
+        # installed version 0.1.5; task spec mentioned 10). Strictly lower priority
+        # ensures our converters are tried first during ascending-sort dispatch.
+        markitdown_instance.register_converter(CleanXlsxConverter(), priority=-1)
+        markitdown_instance.register_converter(CleanXlsConverter(), priority=-1)
 
     def _create_llm_client(self):
         """Create an OpenAI-compatible LLM client backed by core provider.

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/sub_table_detector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/sub_table_detector.py
@@ -1,0 +1,105 @@
+"""Connected-components sub-table detector for spreadsheet sheets.
+
+Algorithm reference: https://github.com/Unstructured-IO/unstructured/blob/main/unstructured/partition/xlsx.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import networkx as nx
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class _BoundingBox:
+    row_min: int
+    row_max: int
+    col_min: int
+    col_max: int
+
+    def overlaps_row_wise(self, other: "_BoundingBox") -> bool:
+        return not (self.row_max < other.row_min or other.row_max < self.row_min)
+
+
+def _box_width(box: _BoundingBox) -> int:
+    return box.col_max - box.col_min + 1
+
+
+class SubTableDetector:
+    """Detect logical sub-tables within a single header-less sheet DataFrame."""
+
+    def detect(self, sheet: pd.DataFrame) -> list[pd.DataFrame]:
+        """Return one DataFrame per detected sub-table, with NaN padding stripped."""
+        if sheet.empty or sheet.isna().all().all():
+            return []
+
+        graph = self._build_cell_graph(sheet)
+        components = [c for c in nx.connected_components(graph) if c]
+        boxes = [self._bounding_box(c) for c in components]
+        merged = self._merge_row_overlapping(boxes)
+
+        tables: list[pd.DataFrame] = []
+        for box in merged:
+            sub = sheet.iloc[box.row_min : box.row_max + 1, box.col_min : box.col_max + 1]
+            sub = sub.dropna(axis=0, how="all").dropna(axis=1, how="all")
+            sub = sub.reset_index(drop=True)
+            sub.columns = range(sub.shape[1])
+            if not sub.empty:
+                tables.append(sub)
+        return tables
+
+    @staticmethod
+    def _build_cell_graph(sheet: pd.DataFrame) -> nx.Graph:
+        graph = nx.Graph()
+        nrows, ncols = sheet.shape
+        non_empty = ~sheet.isna()
+        for r in range(nrows):
+            for c in range(ncols):
+                if not non_empty.iat[r, c]:
+                    continue
+                graph.add_node((r, c))
+                for dr, dc in ((-1, 0), (0, -1)):  # 4-connected: only up and left needed
+                    rr, cc = r + dr, c + dc
+                    if 0 <= rr < nrows and 0 <= cc < ncols and non_empty.iat[rr, cc]:
+                        graph.add_edge((r, c), (rr, cc))
+        return graph
+
+    @staticmethod
+    def _bounding_box(component: set[tuple[int, int]]) -> _BoundingBox:
+        rows = [r for r, _ in component]
+        cols = [c for _, c in component]
+        return _BoundingBox(
+            row_min=min(rows),
+            row_max=max(rows),
+            col_min=min(cols),
+            col_max=max(cols),
+        )
+
+    @staticmethod
+    def _merge_row_overlapping(boxes: list[_BoundingBox]) -> list[_BoundingBox]:
+        """Merge boxes that share row range when one is a narrow annotation column.
+
+        Two equal-width tables side-by-side (e.g. ``[A,B] | blank | [C,D]``) are
+        intentionally NOT merged — those are independent logical tables. We only
+        merge when one component is a single column wide, which matches the
+        "main table + adjacent notes column" pattern.
+        """
+        if not boxes:
+            return []
+        boxes = sorted(boxes, key=lambda b: (b.row_min, b.col_min))
+        merged: list[_BoundingBox] = [boxes[0]]
+        for box in boxes[1:]:
+            last = merged[-1]
+            if box.overlaps_row_wise(last) and (
+                _box_width(box) == 1 or _box_width(last) == 1
+            ):
+                merged[-1] = _BoundingBox(
+                    row_min=min(last.row_min, box.row_min),
+                    row_max=max(last.row_max, box.row_max),
+                    col_min=min(last.col_min, box.col_min),
+                    col_max=max(last.col_max, box.col_max),
+                )
+            else:
+                merged.append(box)
+        return merged

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/xlsx_markdown_format.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/xlsx_markdown_format.py
@@ -1,0 +1,23 @@
+"""Shared heading format for converted xlsx markdown.
+
+The xlsx converter emits sheet/subtable headings; the row-KV splitter parses
+them back to recover structure. Centralizing the format and regex here makes
+that contract explicit — change the template and the regex breaks loudly at
+import time instead of silently degrading ingestion at runtime.
+"""
+
+from __future__ import annotations
+
+import re
+
+SHEET_HEADING_RE = re.compile(
+    r"^##\s+Sheet:\s+(?P<sheet>.+?)(?:\s+/\s+Subtable:\s+(?P<idx>\d+))?\s*$",
+    re.MULTILINE,
+)
+
+
+def format_sheet_heading(sheet: str, subtable_idx: int | None) -> str:
+    """Render the H2 heading for a sheet (and optional subtable index)."""
+    if subtable_idx is None:
+        return f"## Sheet: {sheet}"
+    return f"## Sheet: {sheet} / Subtable: {subtable_idx}"

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/splitters/test_row_kv_excel.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/splitters/test_row_kv_excel.py
@@ -1,0 +1,216 @@
+from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
+    MarkdownTableParser,
+    _SubTableContext,
+)
+
+
+def test_parses_heading_with_subtable_index():
+    content = (
+        "## Sheet: Inventory / Subtable: 2\n"
+        "| SKU | Qty |\n"
+        "|-----|-----|\n"
+        "| A1  | 10  |\n"
+        "| A2  | 20  |\n"
+    )
+    parsed = MarkdownTableParser().parse(content)
+    assert len(parsed) == 1
+    ctx, rows = parsed[0]
+    assert ctx == _SubTableContext(sheet="Inventory", subtable=2, columns=("SKU", "Qty"))
+    assert rows == [{"SKU": "A1", "Qty": "10"}, {"SKU": "A2", "Qty": "20"}]
+
+
+def test_parses_heading_without_subtable_index():
+    content = (
+        "## Sheet: Solo\n"
+        "| a | b |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+    )
+    parsed = MarkdownTableParser().parse(content)
+    ctx, rows = parsed[0]
+    assert ctx.sheet == "Solo"
+    assert ctx.subtable is None
+    assert rows == [{"a": "1", "b": "2"}]
+
+
+def test_parses_multiple_sections_in_one_blob():
+    content = (
+        "## Sheet: A / Subtable: 1\n"
+        "| x |\n"
+        "|---|\n"
+        "| 1 |\n"
+        "\n"
+        "## Sheet: A / Subtable: 2\n"
+        "| y |\n"
+        "|---|\n"
+        "| 2 |\n"
+    )
+    parsed = MarkdownTableParser().parse(content)
+    assert [ctx.subtable for ctx, _ in parsed] == [1, 2]
+    assert parsed[0][1] == [{"x": "1"}]
+    assert parsed[1][1] == [{"y": "2"}]
+
+
+def test_returns_empty_when_no_matching_heading():
+    content = "Just some prose without a sheet heading.\n"
+    assert MarkdownTableParser().parse(content) == []
+
+
+def test_parser_unescapes_pipe_characters_in_cells():
+    """Cells containing literal `\\|` (escaped pipe) round-trip back to `|`.
+
+    The converter escapes literal pipes in cell values; the parser must split
+    on UNESCAPED pipes and unescape each cell so the original value survives.
+    """
+    content = (
+        "## Sheet: S\n"
+        "| URL | Note |\n"
+        "|-----|------|\n"
+        r"| http://x.com?a=1\|b=2 | with pipe |"
+        "\n"
+    )
+    parsed = MarkdownTableParser().parse(content)
+    assert len(parsed) == 1
+    _ctx, rows = parsed[0]
+    assert rows == [{"URL": "http://x.com?a=1|b=2", "Note": "with pipe"}]
+
+
+from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
+    RowChunkContextualizer,
+)
+
+
+def test_contextualizer_emits_preamble_and_rows():
+    ctx = _SubTableContext(
+        sheet="Inventory", subtable=1, columns=("SKU", "Qty")
+    )
+    rows = [{"SKU": "A1", "Qty": "10"}, {"SKU": "A2", "Qty": "20"}]
+    text = RowChunkContextualizer().build(ctx, rows)
+
+    assert text.startswith("Sheet: Inventory")
+    assert "Subtable: 1" in text
+    assert "Columns: SKU, Qty" in text
+    assert "Row:\n  SKU: A1\n  Qty: 10" in text
+    assert "Row:\n  SKU: A2\n  Qty: 20" in text
+
+
+def test_contextualizer_omits_subtable_line_when_absent():
+    ctx = _SubTableContext(sheet="Solo", subtable=None, columns=("a",))
+    text = RowChunkContextualizer().build(ctx, [{"a": "1"}])
+
+    assert "Subtable" not in text
+    assert "Sheet: Solo" in text
+
+
+def test_contextualizer_skips_empty_cells_in_kv_block():
+    """Per the STC paper: only non-empty cells are encoded as KV pairs."""
+    ctx = _SubTableContext(sheet="S", subtable=None, columns=("a", "b", "c"))
+    text = RowChunkContextualizer().build(ctx, [{"a": "1", "b": "", "c": "3"}])
+
+    assert "a: 1" in text
+    assert "c: 3" in text
+    assert "b:" not in text
+
+
+from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
+    RowKVChunker,
+)
+
+
+def test_chunker_packs_all_rows_into_one_chunk_when_under_budget():
+    ctx = _SubTableContext(sheet="S", subtable=None, columns=("a",))
+    rows = [{"a": str(i)} for i in range(3)]
+    chunks = RowKVChunker().chunk(ctx, rows, max_size=10_000)
+    assert len(chunks) == 1
+    assert chunks[0].count("Row:") == 3
+
+
+def test_chunker_splits_when_rows_exceed_budget():
+    ctx = _SubTableContext(sheet="S", subtable=None, columns=("a",))
+    rows = [{"a": "x" * 100} for _ in range(5)]
+    chunks = RowKVChunker().chunk(ctx, rows, max_size=300)
+    assert len(chunks) >= 2
+    # Every chunk re-emits the context preamble for retrieval-time grounding.
+    for chunk in chunks:
+        assert chunk.startswith("Sheet: S")
+
+
+def test_chunker_emits_oversized_row_as_its_own_chunk():
+    ctx = _SubTableContext(sheet="S", subtable=None, columns=("a",))
+    rows = [{"a": "y" * 1000}]
+    chunks = RowKVChunker().chunk(ctx, rows, max_size=200)
+    # One row that exceeds the budget is still emitted (truncation is a separate concern).
+    assert len(chunks) == 1
+
+
+def test_chunker_returns_empty_for_no_rows():
+    ctx = _SubTableContext(sheet="S", subtable=None, columns=("a",))
+    assert RowKVChunker().chunk(ctx, [], max_size=1000) == []
+
+
+from unittest.mock import MagicMock
+
+from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
+    RowKVExcelSplitter,
+)
+
+
+def _settings_with_chunk_overlap(overlap: int = 0) -> MagicMock:
+    settings = MagicMock()
+    settings.global_config.chunking.chunk_overlap = overlap
+    settings.global_config.chunking.max_chunks_per_document = 10_000
+    settings.global_config.chunking.strategies.markdown.max_chunks_per_section = 10_000
+    return settings
+
+
+def test_splitter_emits_one_chunk_per_row_group():
+    content = (
+        "## Sheet: Inventory / Subtable: 1\n"
+        "| SKU | Qty |\n"
+        "|-----|-----|\n"
+        "| A1  | 10  |\n"
+        "| A2  | 20  |\n"
+    )
+    splitter = RowKVExcelSplitter(_settings_with_chunk_overlap())
+    chunks = splitter.split_content(content, max_size=10_000)
+    assert len(chunks) == 1
+    assert "Sheet: Inventory" in chunks[0]
+    assert "SKU: A1" in chunks[0]
+    assert "SKU: A2" in chunks[0]
+
+
+def test_splitter_falls_back_to_passthrough_when_no_heading():
+    """If content lacks the structured heading, return it unchanged in one chunk.
+
+    This preserves the BaseSplitter contract for non-xlsx markdown that may
+    transit through this splitter due to mis-classification upstream.
+    """
+    content = "Just prose, no table heading."
+    splitter = RowKVExcelSplitter(_settings_with_chunk_overlap())
+    chunks = splitter.split_content(content, max_size=10_000)
+    assert chunks == [content]
+
+
+def test_splitter_handles_multi_subtable_content():
+    content = (
+        "## Sheet: A / Subtable: 1\n"
+        "| x |\n|---|\n| 1 |\n\n"
+        "## Sheet: A / Subtable: 2\n"
+        "| y |\n|---|\n| 2 |\n"
+    )
+    splitter = RowKVExcelSplitter(_settings_with_chunk_overlap())
+    chunks = splitter.split_content(content, max_size=10_000)
+    assert len(chunks) == 2
+    assert "x: 1" in chunks[0]
+    assert "y: 2" in chunks[1]
+
+
+from qdrant_loader.core.chunking.strategy.markdown.section_splitter import (
+    SectionSplitter,
+)
+
+
+def test_section_splitter_uses_row_kv_excel_splitter():
+    settings = _settings_with_chunk_overlap()
+    splitter = SectionSplitter(settings)
+    assert type(splitter.excel_splitter).__name__ == "RowKVExcelSplitter"

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/splitters/test_row_kv_excel.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/splitters/test_row_kv_excel.py
@@ -210,6 +210,25 @@ from qdrant_loader.core.chunking.strategy.markdown.section_splitter import (
 )
 
 
+def test_splitter_truncates_at_max_chunks_per_section_cap():
+    """Match legacy ExcelSplitter: stop producing chunks once the per-section
+    cap (or half the per-document cap) is reached. A 50k-row sheet must not
+    silently produce 50k chunks just because the budget allows it."""
+    settings = MagicMock()
+    settings.global_config.chunking.chunk_overlap = 0
+    settings.global_config.chunking.max_chunks_per_document = 10
+    settings.global_config.chunking.strategies.markdown.max_chunks_per_section = 3
+    # 10 rows in one subtable, tight budget so each row becomes its own chunk.
+    rows_md = "\n".join(f"| {i} |" for i in range(10))
+    content = f"## Sheet: Big\n| n |\n|---|\n{rows_md}\n"
+
+    splitter = RowKVExcelSplitter(settings)
+    chunks = splitter.split_content(content, max_size=40)
+
+    expected_cap = min(3, 10 // 2)  # min(per_section, per_doc // 2) = 3
+    assert len(chunks) == expected_cap
+
+
 def test_section_splitter_uses_row_kv_excel_splitter():
     settings = _settings_with_chunk_overlap()
     splitter = SectionSplitter(settings)

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_section_splitter.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_section_splitter.py
@@ -4,12 +4,15 @@ from unittest.mock import Mock, patch
 
 from qdrant_loader.core.chunking.strategy.markdown.section_splitter import (
     BaseSplitter,
-    ExcelSplitter,
     FallbackSplitter,
     HeaderAnalysis,
+    RowKVExcelSplitter,
     SectionMetadata,
     SectionSplitter,
     StandardSplitter,
+)
+from qdrant_loader.core.chunking.strategy.markdown.splitters.excel import (
+    ExcelSplitter,
 )
 
 
@@ -492,7 +495,7 @@ class TestSectionSplitter:
         """Test SectionSplitter initialization."""
         assert self.splitter.settings is self.mock_settings
         assert isinstance(self.splitter.standard_splitter, StandardSplitter)
-        assert isinstance(self.splitter.excel_splitter, ExcelSplitter)
+        assert isinstance(self.splitter.excel_splitter, RowKVExcelSplitter)
         assert isinstance(self.splitter.fallback_splitter, FallbackSplitter)
 
     def test_analyze_header_distribution(self):

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_section_splitter.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_section_splitter.py
@@ -789,6 +789,46 @@ class TestSectionSplitter:
                     for i, section in enumerate(result):
                         assert f"Part {i+1}" in section["title"]
 
+    def test_split_sections_routes_small_excel_through_kv_splitter(self):
+        """Excel sections must go through RowKVExcelSplitter regardless of size.
+
+        Pre-fix, section_splitter.py:428 bypassed the splitter when content fit
+        in chunk_size, leaving small Excel sheets as raw markdown tables while
+        large ones became KV blocks. Same xlsx file produced two chunk shapes.
+        """
+        with patch(
+            "qdrant_loader.core.chunking.strategy.markdown.section_splitter.DocumentParser"
+        ) as mock_parser_class, patch(
+            "qdrant_loader.core.chunking.strategy.markdown.section_splitter.HierarchyBuilder"
+        ):
+            mock_parser = Mock()
+            mock_parser_class.return_value = mock_parser
+            # H2 sheet section, well under chunk_size (1000 in setup_method)
+            small_content = "## Sheet: Tiny\n| a | b |\n|---|---|\n| 1 | 2 |\n"
+            mock_parser.parse_document_structure.return_value = [
+                {
+                    "type": "header",
+                    "level": 2,
+                    "title": "Sheet: Tiny",
+                    "text": "## Sheet: Tiny",
+                },
+                {"type": "content", "text": "| a | b |\n|---|---|\n| 1 | 2 |"},
+            ]
+            mock_parser.extract_section_title.return_value = "Sheet: Tiny"
+
+            excel_doc = Mock()
+            excel_doc.metadata = {"original_file_type": "xlsx"}
+
+            with patch.object(
+                self.splitter.excel_splitter, "split_content"
+            ) as mock_split:
+                mock_split.return_value = ["KV chunk"]
+                self.splitter.split_sections(small_content, document=excel_doc)
+                assert mock_split.called, (
+                    "small Excel section must still route through excel_splitter "
+                    "so chunk shape stays uniform"
+                )
+
     def test_merge_related_sections_empty_list(self):
         """Test merge_related_sections with empty input."""
         result = self.splitter.merge_related_sections([])

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/_xlsx_fixtures.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/_xlsx_fixtures.py
@@ -1,0 +1,34 @@
+# packages/qdrant-loader/tests/unit/core/file_conversion/_xlsx_fixtures.py
+"""Shared programmatic xlsx fixture builders for converter and splitter tests.
+
+Each function returns either a BytesIO or a Path so tests can choose between
+in-memory streams (converter unit tests) and on-disk files (FileConverter e2e).
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from openpyxl import Workbook
+
+
+def make_xlsx_bytes(sheets: dict[str, list[list]]) -> BytesIO:
+    """Build an in-memory xlsx from {sheet_name: rows}."""
+    wb = Workbook()
+    wb.remove(wb.active)
+    for name, rows in sheets.items():
+        ws = wb.create_sheet(title=name)
+        for row in rows:
+            ws.append(row)
+    buf = BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def make_xlsx_file(tmp_path: Path, sheets: dict[str, list[list]], name: str = "test.xlsx") -> Path:
+    """Persist an xlsx to disk for FileConverter end-to-end tests."""
+    path = tmp_path / name
+    path.write_bytes(make_xlsx_bytes(sheets).getvalue())
+    return path

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_clean_xlsx_converter.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_clean_xlsx_converter.py
@@ -38,27 +38,27 @@ def test_clean_dataframe_preserves_literal_na_strings():
 
 
 from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
-    _should_skip_sheet,
+    _is_blank_dataframe,
 )
 
 
-def test_should_skip_sheet_returns_true_for_empty_dataframe():
-    assert _should_skip_sheet(pd.DataFrame()) is True
+def test_is_blank_dataframe_returns_true_for_empty_dataframe():
+    assert _is_blank_dataframe(pd.DataFrame()) is True
 
 
-def test_should_skip_sheet_returns_true_for_all_nan_dataframe():
+def test_is_blank_dataframe_returns_true_for_all_nan_dataframe():
     df = pd.DataFrame({"a": [np.nan, np.nan], "b": [np.nan, np.nan]})
-    assert _should_skip_sheet(df) is True
+    assert _is_blank_dataframe(df) is True
 
 
-def test_should_skip_sheet_returns_false_for_dataframe_with_data():
+def test_is_blank_dataframe_returns_false_for_dataframe_with_data():
     df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-    assert _should_skip_sheet(df) is False
+    assert _is_blank_dataframe(df) is False
 
 
-def test_should_skip_sheet_returns_false_for_partial_data():
+def test_is_blank_dataframe_returns_false_for_partial_data():
     df = pd.DataFrame({"a": [1, np.nan], "b": [np.nan, "y"]})
-    assert _should_skip_sheet(df) is False
+    assert _is_blank_dataframe(df) is False
 
 
 from markitdown._stream_info import StreamInfo

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_clean_xlsx_converter.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_clean_xlsx_converter.py
@@ -1,0 +1,263 @@
+import numpy as np
+import pandas as pd
+
+from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
+    _clean_dataframe,
+)
+
+
+def test_clean_dataframe_drops_fully_empty_rows():
+    df = pd.DataFrame({"a": [1, np.nan, 3], "b": ["x", np.nan, "z"]})
+    result = _clean_dataframe(df)
+    assert list(result["a"]) == [1, 3]
+    assert list(result["b"]) == ["x", "z"]
+
+
+def test_clean_dataframe_drops_fully_empty_columns():
+    df = pd.DataFrame(
+        {"a": [1, 2, 3], "empty": [np.nan, np.nan, np.nan], "b": ["x", "y", "z"]}
+    )
+    result = _clean_dataframe(df)
+    assert list(result.columns) == ["a", "b"]
+
+
+def test_clean_dataframe_keeps_rows_with_partial_data():
+    df = pd.DataFrame({"a": [1, np.nan, 3], "b": ["x", "y", np.nan]})
+    result = _clean_dataframe(df)
+    assert len(result) == 3
+
+
+def test_clean_dataframe_handles_empty_input():
+    assert _clean_dataframe(pd.DataFrame()).empty
+
+
+def test_clean_dataframe_preserves_literal_na_strings():
+    df = pd.DataFrame({"a": ["N/A", "real", "data"]})
+    result = _clean_dataframe(df)
+    assert list(result["a"]) == ["N/A", "real", "data"]
+
+
+from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
+    _should_skip_sheet,
+)
+
+
+def test_should_skip_sheet_returns_true_for_empty_dataframe():
+    assert _should_skip_sheet(pd.DataFrame()) is True
+
+
+def test_should_skip_sheet_returns_true_for_all_nan_dataframe():
+    df = pd.DataFrame({"a": [np.nan, np.nan], "b": [np.nan, np.nan]})
+    assert _should_skip_sheet(df) is True
+
+
+def test_should_skip_sheet_returns_false_for_dataframe_with_data():
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    assert _should_skip_sheet(df) is False
+
+
+def test_should_skip_sheet_returns_false_for_partial_data():
+    df = pd.DataFrame({"a": [1, np.nan], "b": [np.nan, "y"]})
+    assert _should_skip_sheet(df) is False
+
+
+from markitdown._stream_info import StreamInfo
+
+from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
+    CleanXlsxConverter,
+)
+from tests.unit.core.file_conversion._xlsx_fixtures import make_xlsx_bytes
+
+
+def test_xlsx_converter_accepts_xlsx_extension():
+    converter = CleanXlsxConverter()
+    info = StreamInfo(extension=".xlsx")
+    assert converter.accepts(make_xlsx_bytes({"S": [["a"], [1]]}), info) is True
+
+
+def test_xlsx_converter_rejects_non_xlsx():
+    converter = CleanXlsxConverter()
+    info = StreamInfo(extension=".pdf")
+    assert converter.accepts(make_xlsx_bytes({"S": [["a"], [1]]}), info) is False
+
+
+def test_xlsx_converter_does_not_emit_nan():
+    rows = [
+        ["Name", "Age", "City"],
+        ["Alice", 30, "NYC"],
+        ["Bob", None, "LA"],
+        ["Carol", 25, None],
+    ]
+    stream = make_xlsx_bytes({"Sheet1": rows})
+    info = StreamInfo(extension=".xlsx")
+
+    result = CleanXlsxConverter().convert(stream, info)
+
+    assert "NaN" not in result.markdown
+    assert "nan" not in result.markdown
+    assert "NaT" not in result.markdown
+    assert "Alice" in result.markdown
+    assert "Bob" in result.markdown
+    assert "Carol" in result.markdown
+
+
+def test_xlsx_converter_skips_empty_sheets():
+    sheets = {
+        "Real": [["a", "b"], [1, 2]],
+        "Empty": [[None, None], [None, None]],
+    }
+    info = StreamInfo(extension=".xlsx")
+
+    result = CleanXlsxConverter().convert(make_xlsx_bytes(sheets), info)
+
+    assert "## Sheet: Real" in result.markdown
+    assert "## Sheet: Empty" not in result.markdown
+
+
+def test_xlsx_converter_emits_one_heading_per_kept_sheet():
+    sheets = {"First": [["a"], [1]], "Second": [["b"], [2]]}
+    info = StreamInfo(extension=".xlsx")
+
+    result = CleanXlsxConverter().convert(make_xlsx_bytes(sheets), info)
+
+    assert result.markdown.count("## Sheet: First") == 1
+    assert result.markdown.count("## Sheet: Second") == 1
+
+
+from qdrant_loader.core.file_conversion.conversion_config import FileConversionConfig
+from qdrant_loader.core.file_conversion.file_converter import FileConverter
+
+
+def test_file_converter_registers_clean_xlsx_converters():
+    fc = FileConverter(FileConversionConfig())
+    md = fc._get_markitdown()
+
+    types = [type(reg.converter).__name__ for reg in md._converters]
+    assert "CleanXlsxConverter" in types
+    assert "CleanXlsConverter" in types
+
+    clean_priority = next(
+        reg.priority for reg in md._converters
+        if type(reg.converter).__name__ == "CleanXlsxConverter"
+    )
+    default_priority = next(
+        reg.priority for reg in md._converters
+        if type(reg.converter).__name__ == "XlsxConverter"
+    )
+    # MarkItDown sorts ascending — lower priority value is tried first
+    assert clean_priority < default_priority
+
+
+def test_xlsx_converter_emits_one_section_per_subtable():
+    """A sheet with two sub-tables separated by a blank row produces two sections."""
+    sheet = [
+        ["Name", "Age"],
+        ["Alice", 30],
+        ["Bob", 25],
+        [None, None],
+        [None, None],
+        ["Product", "Price"],
+        ["Widget", 9.99],
+        ["Gadget", 14.99],
+    ]
+    info = StreamInfo(extension=".xlsx")
+
+    result = CleanXlsxConverter().convert(make_xlsx_bytes({"Mixed": sheet}), info)
+
+    assert "## Sheet: Mixed / Subtable: 1" in result.markdown
+    assert "## Sheet: Mixed / Subtable: 2" in result.markdown
+    assert "Alice" in result.markdown
+    assert "Widget" in result.markdown
+
+
+def test_xlsx_converter_uses_simple_heading_when_only_one_subtable():
+    """A clean single-table sheet keeps the simple `Sheet: X` heading (no Subtable suffix)."""
+    sheet = [["a", "b"], [1, 2], [3, 4]]
+    info = StreamInfo(extension=".xlsx")
+
+    result = CleanXlsxConverter().convert(make_xlsx_bytes({"Solo": sheet}), info)
+
+    assert "## Sheet: Solo\n" in result.markdown
+    assert "Subtable" not in result.markdown
+
+
+def test_xlsx_converter_raises_on_malformed_bytes():
+    """A non-xlsx blob carrying an `.xlsx` extension surfaces as an exception.
+
+    Documents the failure-mode contract: rather than silently returning
+    garbage markdown, the converter raises (pandas / openpyxl emit a
+    `BadZipFile`, `ValueError`, or similar). The specific exception type
+    isn't load-bearing; the important thing is that callers get a clear
+    failure signal.
+    """
+    import pytest
+    from io import BytesIO
+
+    info = StreamInfo(extension=".xlsx")
+    bad_stream = BytesIO(b"not really an xlsx")
+
+    with pytest.raises(Exception):
+        CleanXlsxConverter().convert(bad_stream, info)
+
+
+def test_xlsx_converter_pipe_round_trip_through_splitter():
+    """A cell containing a literal `|` survives the converter -> splitter round-trip.
+
+    Without escaping, `MarkdownTableParser._row_cells` over-splits the row,
+    the cell count diverges from the header count, and the row is silently
+    dropped. The fix is render-side `|` -> `\\|` escape plus an
+    unescaped-pipe split in the parser.
+    """
+    from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
+        MarkdownTableParser,
+    )
+
+    rows = [
+        ["URL", "Description"],
+        ["http://x.com?a=1|b=2", "pipe in url"],
+        ["plain", "no pipe here"],
+    ]
+    info = StreamInfo(extension=".xlsx")
+
+    md = CleanXlsxConverter().convert(make_xlsx_bytes({"Sheet1": rows}), info).markdown
+
+    # Render-side: literal `|` in cell text is escaped as `\|`.
+    assert r"http://x.com?a=1\|b=2" in md
+
+    # Parser-side: the row survives, and the unescape is symmetric.
+    parsed = MarkdownTableParser().parse(md)
+    assert len(parsed) == 1
+    _ctx, parsed_rows = parsed[0]
+    assert len(parsed_rows) == 2
+    assert parsed_rows[0] == {
+        "URL": "http://x.com?a=1|b=2",
+        "Description": "pipe in url",
+    }
+    assert parsed_rows[1] == {"URL": "plain", "Description": "no pipe here"}
+
+
+def test_xlsx_converter_handles_nan_in_header_row():
+    """A first-row cell that's empty must not crash header coercion.
+
+    Reproduces a real failure on `Brief_Agency Partner_VLG.xlsx`: when a sheet's
+    first row contains an empty cell, `Series.astype(str).tolist()` in this
+    pandas version leaves the NaN as a Python float, so the header-escape
+    comprehension blows up with
+    `AttributeError: 'float' object has no attribute 'replace'`.
+
+    Expected behavior: empty header cells render as empty strings (matching the
+    body path, which already coerces NaN to "" via `to_html(na_rep="")`).
+    """
+    sheet = [
+        ["Title cell", None],
+        ["row1col1", "row1col2"],
+        ["row2col1", "row2col2"],
+    ]
+    info = StreamInfo(extension=".xlsx")
+
+    result = CleanXlsxConverter().convert(make_xlsx_bytes({"S": sheet}), info)
+
+    assert "Title cell" in result.markdown
+    assert "row1col1" in result.markdown
+    assert "nan" not in result.markdown
+    assert "NaN" not in result.markdown

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_file_converter.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_file_converter.py
@@ -543,5 +543,59 @@ class TestErrorHandling:
             temp_path.unlink(missing_ok=True)
 
 
+from tests.unit.core.file_conversion._xlsx_fixtures import make_xlsx_file
+
+
+def test_convert_file_strips_nan_from_xlsx(tmp_path):
+    """Regression: an xlsx with empty cells must not produce literal 'NaN' strings."""
+    rows = [
+        ["Name", "Age", "City"],
+        ["Alice", 30, "NYC"],
+        ["Bob", None, "LA"],
+        ["Carol", 25, None],
+    ]
+    xlsx_path = make_xlsx_file(tmp_path, {"Data": rows}, name="people.xlsx")
+
+    fc = FileConverter(FileConversionConfig())
+    markdown = fc.convert_file(str(xlsx_path))
+
+    assert "NaN" not in markdown
+    assert "NaT" not in markdown
+    assert "Alice" in markdown
+    assert "Bob" in markdown
+    assert "Carol" in markdown
+
+
+def test_xlsx_pipeline_produces_row_kv_chunks(tmp_path):
+    """Full ingestion path: xlsx -> clean markdown -> row-KV chunks with context."""
+    from qdrant_loader.core.chunking.strategy.markdown.section_splitter import (
+        SectionSplitter,
+    )
+    from unittest.mock import MagicMock
+
+    rows = [
+        ["Name", "Age", "City"],
+        ["Alice", 30, "NYC"],
+        ["Bob", 25, "LA"],
+    ]
+    xlsx_path = make_xlsx_file(tmp_path, {"People": rows}, name="people.xlsx")
+
+    fc = FileConverter(FileConversionConfig())
+    markdown = fc.convert_file(str(xlsx_path))
+
+    settings = MagicMock()
+    settings.global_config.chunking.chunk_overlap = 0
+    settings.global_config.chunking.max_chunks_per_document = 10_000
+    settings.global_config.chunking.strategies.markdown.max_chunks_per_section = 10_000
+    chunks = SectionSplitter(settings).excel_splitter.split_content(
+        markdown, max_size=10_000
+    )
+
+    assert any("Sheet: People" in c for c in chunks)
+    assert any("Name: Alice" in c for c in chunks)
+    assert any("Name: Bob" in c for c in chunks)
+    assert all("NaN" not in c for c in chunks)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_sub_table_detector.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_sub_table_detector.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pandas as pd
+
+from qdrant_loader.core.file_conversion.sub_table_detector import (
+    SubTableDetector,
+)
+
+
+def _grid(*rows: list) -> pd.DataFrame:
+    """Build a header-less DataFrame from a literal grid of cell values."""
+    return pd.DataFrame(rows)
+
+
+def test_detects_single_table():
+    sheet = _grid(
+        ["A", "B"],
+        [1, 2],
+        [3, 4],
+    )
+    tables = SubTableDetector().detect(sheet)
+    assert len(tables) == 1
+    assert tables[0].shape == (3, 2)
+
+
+def test_detects_two_tables_separated_by_blank_row():
+    sheet = _grid(
+        ["A", "B"],
+        [1, 2],
+        [np.nan, np.nan],
+        ["C", "D"],
+        [5, 6],
+    )
+    tables = SubTableDetector().detect(sheet)
+    assert len(tables) == 2
+    assert tables[0].iloc[0].tolist() == ["A", "B"]
+    assert tables[1].iloc[0].tolist() == ["C", "D"]
+
+
+def test_detects_two_tables_separated_by_blank_column():
+    sheet = _grid(
+        ["A", "B", np.nan, "C", "D"],
+        [1, 2, np.nan, 5, 6],
+        [3, 4, np.nan, 7, 8],
+    )
+    tables = SubTableDetector().detect(sheet)
+    assert len(tables) == 2
+    assert tables[0].shape == (3, 2)
+    assert tables[1].shape == (3, 2)
+
+
+def test_merges_tables_overlapping_row_wise():
+    """If two components share row range, treat as one logical table.
+
+    This handles the common case of an annotation column to the right of the
+    main table — splitting it would lose the row-level association.
+    """
+    sheet = _grid(
+        ["A", "B", np.nan, "Notes"],
+        [1, 2, np.nan, "ok"],
+        [3, 4, np.nan, "review"],
+    )
+    tables = SubTableDetector().detect(sheet)
+    assert len(tables) == 1
+
+
+def test_returns_empty_list_for_empty_sheet():
+    sheet = _grid([np.nan, np.nan], [np.nan, np.nan])
+    assert SubTableDetector().detect(sheet) == []
+
+
+def test_detector_drops_nan_padding_around_each_subtable():
+    sheet = _grid(
+        [np.nan, np.nan, np.nan],
+        [np.nan, "A", "B"],
+        [np.nan, 1, 2],
+        [np.nan, np.nan, np.nan],
+    )
+    tables = SubTableDetector().detect(sheet)
+    assert len(tables) == 1
+    assert tables[0].iloc[0].tolist() == ["A", "B"]

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_xlsx_markdown_format.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_xlsx_markdown_format.py
@@ -1,0 +1,59 @@
+"""Tests for the shared xlsx heading format used by the converter and splitter.
+
+The converter and splitter previously held two independent string/regex
+representations of `## Sheet: X / Subtable: N`. This module centralizes the
+contract; these tests pin the round-trip so future renames break loudly at
+import time, not silently at runtime.
+"""
+
+from __future__ import annotations
+
+from qdrant_loader.core.file_conversion.xlsx_markdown_format import (
+    SHEET_HEADING_RE,
+    format_sheet_heading,
+)
+
+
+def test_format_heading_single_subtable_omits_index():
+    """When a sheet has only one subtable, the heading drops the suffix."""
+    assert format_sheet_heading("Solo", subtable_idx=None) == "## Sheet: Solo"
+
+
+def test_format_heading_with_index_includes_subtable_suffix():
+    assert (
+        format_sheet_heading("Inventory", subtable_idx=2)
+        == "## Sheet: Inventory / Subtable: 2"
+    )
+
+
+def test_regex_matches_simple_heading():
+    m = SHEET_HEADING_RE.match("## Sheet: Solo")
+    assert m is not None
+    assert m.group("sheet") == "Solo"
+    assert m.group("idx") is None
+
+
+def test_regex_matches_heading_with_subtable_index():
+    m = SHEET_HEADING_RE.match("## Sheet: Inventory / Subtable: 2")
+    assert m is not None
+    assert m.group("sheet") == "Inventory"
+    assert m.group("idx") == "2"
+
+
+def test_regex_tolerates_sheet_name_with_spaces_and_punctuation():
+    """Real xlsx sheets have names like '6. Core Banking System ' (note trailing space)."""
+    m = SHEET_HEADING_RE.match("## Sheet: 6. Core Banking System  / Subtable: 3")
+    assert m is not None
+    assert m.group("sheet").strip() == "6. Core Banking System"
+    assert m.group("idx") == "3"
+
+
+def test_round_trip_format_then_parse():
+    """format -> regex round-trip recovers the original sheet name and index."""
+    for sheet, idx in [("Solo", None), ("Inventory", 2), ("A B C", 10)]:
+        rendered = format_sheet_heading(sheet, idx)
+        m = SHEET_HEADING_RE.match(rendered)
+        assert m is not None, f"regex failed to match: {rendered!r}"
+        assert m.group("sheet") == sheet
+        parsed_idx = int(m.group("idx")) if m.group("idx") else None
+        assert parsed_idx == idx


### PR DESCRIPTION
# Pull Request

## Summary

Bring qdrant-loader's XLSX/XLS ingestion in line with the 2025–26 state-of-the-art described in [paper](https://arxiv.org/pdf/2605.00318), clean parsing, structurally-detected sub-tables, row-level KV chunking with contextual prefixing.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected Pipeline Stages
**File conversion (new):** Excel ingestion replaces legacy converters with clean XLSX/XLS processors using `SubTableDetector` for sub-table segmentation.  
**Chunking strategy:** Markdown section splitter now routes Excel sections through new `RowKVExcelSplitter` (replaces `ExcelSplitter`) producing row-level key-value chunks.

## Config/Dependency Changes
**Additive:** NetworkX ≥3.0.0 added as runtime dependency (required by `SubTableDetector` for connected-component analysis).  
**Behavioral change:** Excel sections now bypass size checks and always use structured row-KV chunking (via `needs_split` flag).

## Test Coverage
Comprehensive: 667 new test lines across 4 dedicated modules plus integration tests in `test_file_converter.py` and `test_section_splitter.py`, covering parsing, chunking, sub-table detection, and end-to-end conversion.

## Resource/Safety Concerns
**Critical (unresolved per reviewer):** `RowKVChunker` ignores `max_chunks_per_section` cap, allowing large sheets (50k+ rows) to exceed bounds and violate chunking contract.  
**Performance:** O(N²) chunk text rebuilding in loop. Silent row drops when cell count mismatches headers (should log warnings).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->