### PR TITLE
chore(Dockerfile): create Dockerfile for Qdrant loader and MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Python - Every level
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
+**/.Python
+**/*.egg-info/
+**/.eggs/
+**/*.egg/
+**/*.pyc
+**/.ruff_cache/
+
+# Virtual environments - Every level
+**/venv/
+**/env/
+**/ENV/
+**/.venv/
+
+# IDE - Every level
+**/.vscode/
+**/.idea/
+**/*.swp
+**/*.swo
+
+# Testing - Every level
+**/.pytest_cache/
+**/.tox/
+**/tests/
+**/htmlcov/
+**/.coverage
+**/coverage.xml
+
+# Observability - Every level
+**/metrics/
+
+# Logging - Every level
+**/*.log
+
+# Environment - Every level
+**/.env
+**/.env.example
+
+# Git
+**/.git/
+**/.gitignore
+
+# Docker
+**/Dockerfile*
+**/docker-compose*
+**/.dockerignore
+
+# Documentation
+**/docs/
+
+# Config
+**/conf/

--- a/Dockerfile.qdrant-loader
+++ b/Dockerfile.qdrant-loader
@@ -1,0 +1,38 @@
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /qdrant-loader
+
+COPY uv.lock pyproject.toml README.md* LICENSE* ./
+COPY packages/qdrant-loader-core /qdrant-loader/packages/qdrant-loader-core
+COPY packages/qdrant-loader /qdrant-loader/packages/qdrant-loader
+
+RUN uv sync  --frozen --package qdrant-loader --package qdrant-loader-core --all-extras --no-dev --no-cache --no-install-project \
+    && .venv/bin/python -m spacy download en_core_web_md
+
+
+
+FROM python:3.12-slim
+
+WORKDIR /qdrant-loader
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=base /qdrant-loader/.venv /qdrant-loader/.venv
+COPY packages/qdrant-loader-core /qdrant-loader/packages/qdrant-loader-core
+COPY packages/qdrant-loader /qdrant-loader/packages/qdrant-loader
+
+ENV PATH="/qdrant-loader/.venv/bin:$PATH"
+
+# Default command
+# TUD
+CMD ["sh", "-c", "qdrant-loader --help; sleep infinity"]

--- a/Dockerfile.qdrant-loader
+++ b/Dockerfile.qdrant-loader
@@ -1,8 +1,8 @@
-FROM python:3.12-slim AS base
+FROM python:3.12.13-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /bin/
 
 WORKDIR /qdrant-loader
 
@@ -15,9 +15,12 @@ RUN uv sync  --frozen --package qdrant-loader --package qdrant-loader-core --all
 
 
 
-FROM python:3.12-slim
+FROM python:3.12.13-slim
 
 WORKDIR /qdrant-loader
+
+RUN useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /qdrant-loader
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -27,12 +30,14 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=base /qdrant-loader/.venv /qdrant-loader/.venv
-COPY packages/qdrant-loader-core /qdrant-loader/packages/qdrant-loader-core
-COPY packages/qdrant-loader /qdrant-loader/packages/qdrant-loader
+USER appuser
+
+COPY --chown=appuser:appuser --from=base /qdrant-loader/.venv /qdrant-loader/.venv
+COPY --chown=appuser:appuser packages/qdrant-loader-core /qdrant-loader/packages/qdrant-loader-core
+COPY --chown=appuser:appuser packages/qdrant-loader /qdrant-loader/packages/qdrant-loader
 
 ENV PATH="/qdrant-loader/.venv/bin:$PATH"
 
 # Default command
-# TUD
+# TBU
 CMD ["sh", "-c", "qdrant-loader --help; sleep infinity"]

--- a/Dockerfile.qdrant-loader-mcp-server
+++ b/Dockerfile.qdrant-loader-mcp-server
@@ -1,0 +1,36 @@
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /qdrant-loader-mcp-server
+
+COPY uv.lock pyproject.toml README.md* LICENSE* ./
+COPY packages/qdrant-loader-core /qdrant-loader-mcp-server/packages/qdrant-loader-core
+COPY packages/qdrant-loader-mcp-server /qdrant-loader-mcp-server/packages/qdrant-loader-mcp-server
+
+RUN uv sync  --frozen --package qdrant-loader-mcp-server --package qdrant-loader-core --all-extras --no-dev --no-cache --no-install-project \
+    && .venv/bin/python -m spacy download en_core_web_md
+
+RUN find /qdrant-loader-mcp-server/.venv -name "*.a" -delete && \
+    find /qdrant-loader-mcp-server/.venv -name "*.pyc" -delete && \
+    find /qdrant-loader-mcp-server/.venv -name "__pycache__" -type d -exec rm -rf {} +
+
+
+
+FROM python:3.12-slim
+
+WORKDIR /qdrant-loader-mcp-server
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+
+COPY --from=base /qdrant-loader-mcp-server/.venv /qdrant-loader-mcp-server/.venv
+COPY packages/qdrant-loader-core /qdrant-loader-mcp-server/packages/qdrant-loader-core
+COPY packages/qdrant-loader-mcp-server /qdrant-loader-mcp-server/packages/qdrant-loader-mcp-server
+
+ENV PATH="/qdrant-loader-mcp-server/.venv/bin:$PATH"
+
+CMD ["mcp-qdrant-loader", "--transport", "http", "--port", "8080", "--host", "0.0.0.0"]

--- a/Dockerfile.qdrant-loader-mcp-server
+++ b/Dockerfile.qdrant-loader-mcp-server
@@ -1,8 +1,8 @@
-FROM python:3.12-slim AS base
+FROM python:3.12.13-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /bin/
 
 WORKDIR /qdrant-loader-mcp-server
 
@@ -19,17 +19,21 @@ RUN find /qdrant-loader-mcp-server/.venv -name "*.a" -delete && \
 
 
 
-FROM python:3.12-slim
+FROM python:3.12.13-slim
 
 WORKDIR /qdrant-loader-mcp-server
+
+RUN useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /qdrant-loader-mcp-server
+USER appuser
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 
-COPY --from=base /qdrant-loader-mcp-server/.venv /qdrant-loader-mcp-server/.venv
-COPY packages/qdrant-loader-core /qdrant-loader-mcp-server/packages/qdrant-loader-core
-COPY packages/qdrant-loader-mcp-server /qdrant-loader-mcp-server/packages/qdrant-loader-mcp-server
+COPY --chown=appuser:appuser --from=base /qdrant-loader-mcp-server/.venv /qdrant-loader-mcp-server/.venv
+COPY --chown=appuser:appuser packages/qdrant-loader-core /qdrant-loader-mcp-server/packages/qdrant-loader-core
+COPY --chown=appuser:appuser packages/qdrant-loader-mcp-server /qdrant-loader-mcp-server/packages/qdrant-loader-mcp-server
 
 ENV PATH="/qdrant-loader-mcp-server/.venv/bin:$PATH"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,65 @@
+services:
+  qdrant:
+    container_name: qdrant
+    image: qdrant/qdrant:latest
+    restart: unless-stopped
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    environment:
+      - QDRANT__LOG_LEVEL=INFO
+      - QDRANT__SERVICE__HTTP_PORT=6333
+      - QDRANT__SERVICE__GRPC_PORT=6334
+    networks:
+      - qdrant-net
+  
+  qdrant-loader:
+    container_name: qdrant-loader
+    build:
+      context: .
+      dockerfile: Dockerfile.qdrant-loader
+    image: qdrant-loader:latest
+    restart: unless-stopped
+    depends_on: 
+      qdrant:
+        condition: service_healthy
+    networks:
+      - qdrant-net
+
+  qdrant-loader-mcp-server:
+    container_name: qdrant-loader-mcp-server
+    build:
+      context: .
+      dockerfile: Dockerfile.qdrant-loader-mcp-server
+    image: qdrant-loader-mcp-server:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - QDRANT_URL=${QDRANT_URL}
+      - QDRANT_COLLECTION_NAME=${QDRANT_COLLECTION_NAME}
+      - LLM_PROVIDER=${LLM_PROVIDER}
+      - LLM_BASE_URL=${LLM_BASE_URL}
+      - LLM_API_KEY=${LLM_API_KEY}
+      - LLM_EMBEDDING_MODEL=${LLM_EMBEDDING_MODEL}
+      - LLM_CHAT_MODEL=${LLM_CHAT_MODEL}
+      - MCP_LOG_LEVEL=${MCP_LOG_LEVEL:-INFO}
+      - MCP_LOG_FILE=${MCP_LOG_FILE:-mcp.log}
+      - MCP_DISABLE_CONSOLE_LOGGING=${MCP_DISABLE_CONSOLE_LOGGING:-false}
+    depends_on: 
+      qdrant:
+        condition: service_healthy
+    networks:
+      - qdrant-net
+
+volumes:
+  qdrant_data:
+    driver: local
+
+networks:
+  qdrant-net:
+    driver: bridge
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,18 @@ services:
     depends_on: 
       qdrant:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       - qdrant-net
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   qdrant:
     container_name: qdrant
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.18.0
     restart: unless-stopped
     ports:
       - "6333:6333"
@@ -12,6 +12,12 @@ services:
       - QDRANT__LOG_LEVEL=INFO
       - QDRANT__SERVICE__HTTP_PORT=6333
       - QDRANT__SERVICE__GRPC_PORT=6334
+    healthcheck:
+      test: bash -c ':> /dev/tcp/localhost/6333'
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     networks:
       - qdrant-net
   
@@ -39,7 +45,7 @@ services:
       - "8080:8080"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - QDRANT_URL=${QDRANT_URL}
+      - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
       - QDRANT_COLLECTION_NAME=${QDRANT_COLLECTION_NAME}
       - LLM_PROVIDER=${LLM_PROVIDER}
       - LLM_BASE_URL=${LLM_BASE_URL}


### PR DESCRIPTION
# Pull Request

## Summary

Create a Dockerfile to containerize the Qdrant loader and MCP server, providing a standardized and reproducible runtime environment.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [x] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Connectors & Pipeline Stages
No connectors or pipeline stages are modified; this PR only adds containerization for the Qdrant loader and MCP server.

Configuration Changes
Additive infra only: Dockerfile.qdrant-loader, Dockerfile.qdrant-loader-mcp-server, and docker-compose.yaml. Compose exposes env vars: OPENAI_API_KEY, QDRANT_URL (default http://qdrant:6333), QDRANT_COLLECTION_NAME, LLM_PROVIDER, LLM_BASE_URL, LLM_API_KEY, LLM_EMBEDDING_MODEL, LLM_CHAT_MODEL, and MCP logging vars. No changes to existing app config schemas.

Test Coverage
No tests or CI changes; Docker/build/runtime paths are not covered.

Security & Resource Concerns
Secrets are passed via plain environment variables (OPENAI_API_KEY, LLM_API_KEY). No CPU/memory limits in compose. Ports 6333/6334/8080 are published. Good: non-root appuser, pinned base images (python:3.12.13-slim, qdrant v1.18.0), healthchecks for services, and build-time cleanup to reduce image size; build downloads a spaCy model (increases image size).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/278)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->