### PR TITLE
feat(state): add jobs table and Alembic migration

### DIFF
--- a/packages/qdrant-loader/alembic.ini
+++ b/packages/qdrant-loader/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+path_separator = os
+sqlalchemy.url = sqlite:///state.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/packages/qdrant-loader/alembic.ini
+++ b/packages/qdrant-loader/alembic.ini
@@ -2,7 +2,7 @@
 script_location = migrations
 prepend_sys_path = .
 path_separator = os
-sqlalchemy.url = sqlite:///state.db
+sqlalchemy.url = sqlite:///../../data/qdrant-loader.db
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -27,6 +27,9 @@ def _deterministic_sqlalchemy_url() -> str:
         return f"sqlite:///{candidate.resolve().as_posix()}"
 
     configured_url = config.get_main_option("sqlalchemy.url")
+    if configured_url is None:
+        raise ValueError("Missing sqlalchemy.url in Alembic configuration")
+
     sqlite_prefix = "sqlite:///"
     if configured_url.startswith(sqlite_prefix):
         raw_path = configured_url[len(sqlite_prefix) :]

--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 # pyright: reportGeneralTypeIssues=false, reportAttributeAccessIssue=false
 import importlib
+import os
 from logging.config import fileConfig
+from pathlib import Path
 from typing import Any
 
 from qdrant_loader.core.state.models import Base
@@ -13,6 +15,28 @@ config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+
+def _deterministic_sqlalchemy_url() -> str:
+    """Resolve DB URL consistently regardless of current working directory."""
+    state_db_path = os.getenv("STATE_DB_PATH")
+    if state_db_path:
+        candidate = Path(state_db_path).expanduser()
+        if not candidate.is_absolute() and config.config_file_name is not None:
+            candidate = Path(config.config_file_name).resolve().parent / candidate
+        return f"sqlite:///{candidate.resolve().as_posix()}"
+
+    configured_url = config.get_main_option("sqlalchemy.url")
+    sqlite_prefix = "sqlite:///"
+    if configured_url.startswith(sqlite_prefix):
+        raw_path = configured_url[len(sqlite_prefix) :]
+        if raw_path and not Path(raw_path).is_absolute() and config.config_file_name is not None:
+            resolved = (Path(config.config_file_name).resolve().parent / raw_path).resolve()
+            return f"sqlite:///{resolved.as_posix()}"
+    return configured_url
+
+
+config.set_main_option("sqlalchemy.url", _deterministic_sqlalchemy_url())
 
 target_metadata = Base.metadata
 

--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from qdrant_loader.core.state.models import Base
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import make_url
 
 context: Any = importlib.import_module("alembic.context")
 config = context.config
@@ -17,10 +18,23 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 
+def _is_special_sqlite_form(raw_path: str) -> bool:
+    """Return True for SQLite in-memory/URI-memory forms that must not be rewritten."""
+    raw_path_lower = raw_path.lower()
+    if raw_path == ":memory:":
+        return True
+    return raw_path_lower.startswith("file:") and (
+        "mode=memory" in raw_path_lower or "memory" in raw_path_lower
+    )
+
+
 def _deterministic_sqlalchemy_url() -> str:
     """Resolve DB URL consistently regardless of current working directory."""
     state_db_path = os.getenv("STATE_DB_PATH")
     if state_db_path:
+        if _is_special_sqlite_form(state_db_path):
+            return f"sqlite:///{state_db_path}"
+
         candidate = Path(state_db_path).expanduser()
         if not candidate.is_absolute() and config.config_file_name is not None:
             candidate = Path(config.config_file_name).resolve().parent / candidate
@@ -30,12 +44,16 @@ def _deterministic_sqlalchemy_url() -> str:
     if configured_url is None:
         raise ValueError("Missing sqlalchemy.url in Alembic configuration")
 
-    sqlite_prefix = "sqlite:///"
-    if configured_url.startswith(sqlite_prefix):
-        raw_path = configured_url[len(sqlite_prefix) :]
+    parsed = make_url(configured_url)
+    if parsed.drivername.startswith("sqlite"):
+        raw_path = parsed.database or ""
+        if _is_special_sqlite_form(raw_path):
+            return configured_url
+
         if raw_path and not Path(raw_path).is_absolute() and config.config_file_name is not None:
             resolved = (Path(config.config_file_name).resolve().parent / raw_path).resolve()
-            return f"sqlite:///{resolved.as_posix()}"
+            return str(parsed.set(database=resolved.as_posix()))
+
     return configured_url
 
 

--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+# pyright: reportGeneralTypeIssues=false, reportAttributeAccessIssue=false
+import importlib
+from logging.config import fileConfig
+from typing import Any
+
+from qdrant_loader.core.state.models import Base
+from sqlalchemy import engine_from_config, pool
+
+context: Any = importlib.import_module("alembic.context")
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/packages/qdrant-loader/migrations/versions/20260514_01_create_jobs_table.py
+++ b/packages/qdrant-loader/migrations/versions/20260514_01_create_jobs_table.py
@@ -1,0 +1,46 @@
+"""create jobs table
+
+Revision ID: 20260514_01
+Revises:
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+# pyright: reportGeneralTypeIssues=false, reportAttributeAccessIssue=false
+import importlib
+from typing import Any
+
+import sqlalchemy as sa
+
+op: Any = importlib.import_module("alembic.op")
+
+revision = "20260514_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("enqueued_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("visibility_deadline", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_jobs_status_enqueued_at", "jobs", ["status", "enqueued_at"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_status_enqueued_at", table_name="jobs")
+    op.drop_table("jobs")

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/models.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/models.py
@@ -4,6 +4,7 @@ SQLAlchemy models for state management database.
 
 from datetime import UTC
 
+import sqlalchemy as sa
 from sqlalchemy import (
     Boolean,
     Column,
@@ -223,7 +224,7 @@ class Job(Base):
     enqueued_at = Column(UTCDateTime(timezone=True), nullable=False)
     started_at = Column(UTCDateTime(timezone=True), nullable=True)
     finished_at = Column(UTCDateTime(timezone=True), nullable=True)
-    attempts = Column(Integer, nullable=False, default=0)
+    attempts = Column(Integer, nullable=False, default=0, server_default=sa.text("0"))
     last_error = Column(Text, nullable=True)
     visibility_deadline = Column(UTCDateTime(timezone=True), nullable=True)
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/models.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/models.py
@@ -209,3 +209,22 @@ class DocumentStateRecord(Base):
         Index("ix_document_conversion_method", "conversion_method"),
         Index("ix_document_project_id", "project_id"),
     )
+
+
+class Job(Base):
+    """Queue job persisted in the state database."""
+
+    __tablename__ = "jobs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    type = Column(String, nullable=False)
+    payload_json = Column(Text, nullable=False)
+    status = Column(String, nullable=False)
+    enqueued_at = Column(UTCDateTime(timezone=True), nullable=False)
+    started_at = Column(UTCDateTime(timezone=True), nullable=True)
+    finished_at = Column(UTCDateTime(timezone=True), nullable=True)
+    attempts = Column(Integer, nullable=False, default=0)
+    last_error = Column(Text, nullable=True)
+    visibility_deadline = Column(UTCDateTime(timezone=True), nullable=True)
+
+    __table_args__ = (Index("ix_jobs_status_enqueued_at", "status", "enqueued_at"),)

--- a/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
@@ -1,0 +1,58 @@
+"""Smoke tests for state DB Alembic migrations."""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+
+def _build_alembic_config(package_root: Path, db_path: Path) -> Config:
+    cfg = Config(str(package_root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(package_root / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path.as_posix()}")
+    return cfg
+
+
+def test_jobs_migration_smoke_upgrade_and_downgrade(tmp_path: Path) -> None:
+    """Ensure WS-4.1 migration creates and removes jobs schema artifacts."""
+    package_root = Path(__file__).resolve().parents[4]
+    db_path = tmp_path / "state_ws41.db"
+    cfg = _build_alembic_config(package_root, db_path)
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path.as_posix()}")
+    inspector = inspect(engine)
+
+    assert "jobs" in inspector.get_table_names()
+
+    expected_columns = {
+        "id",
+        "type",
+        "payload_json",
+        "status",
+        "enqueued_at",
+        "started_at",
+        "finished_at",
+        "attempts",
+        "last_error",
+        "visibility_deadline",
+    }
+    actual_columns = {col["name"] for col in inspector.get_columns("jobs")}
+    assert expected_columns == actual_columns
+
+    indexes = inspector.get_indexes("jobs")
+    assert any(
+        idx.get("name") == "ix_jobs_status_enqueued_at"
+        and idx.get("column_names") == ["status", "enqueued_at"]
+        for idx in indexes
+    )
+    engine.dispose()
+
+    command.downgrade(cfg, "base")
+
+    engine_after = create_engine(f"sqlite:///{db_path.as_posix()}")
+    inspector_after = inspect(engine_after)
+    assert "jobs" not in inspector_after.get_table_names()
+    engine_after.dispose()

--- a/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect
@@ -14,8 +16,13 @@ def _build_alembic_config(package_root: Path, db_path: Path) -> Config:
     return cfg
 
 
-def test_jobs_migration_smoke_upgrade_and_downgrade(tmp_path: Path) -> None:
+def test_jobs_migration_smoke_upgrade_and_downgrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure WS-4.1 migration creates and removes jobs schema artifacts."""
+    # Keep this test isolated from developer shell env overrides.
+    monkeypatch.delenv("STATE_DB_PATH", raising=False)
+
     package_root = Path(__file__).resolve().parents[4]
     db_path = tmp_path / "state_ws41.db"
     cfg = _build_alembic_config(package_root, db_path)


### PR DESCRIPTION
# Pull Request

## Summary

 add jobs table with status-enqueued_at index and Alembic migration

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [x Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

**Connectors/Pipeline Stages Affected:**  
Adds state persistence for the job queue via a new Job ORM model and migration; affects any pipeline stages that enqueue, dequeue, or inspect jobs (state layer only).

**Config Schema Changes:**  
Additive only. New alembic.ini and deterministic env.py plus initial migration (20260514_01) creating a `jobs` table and non-unique composite index `ix_jobs_status_enqueued_at` on (status, enqueued_at). `attempts` has a server_default of 0. env.py resolves SQLite URLs deterministically (honors STATE_DB_PATH).

**Test Coverage:**  
Yes — a smoke test upgrades to head, verifies the `jobs` table columns and index, then downgrades and confirms removal.

**Security / Resource-Safety Concerns:**  
`payload_json` and `last_error` are unbounded Text columns (potential storage growth). Recommend documenting expected sizes, monitoring, or adding limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/280)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->