### PR TITLE
Feat/sqlite job queue

### DIFF
--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -50,8 +50,14 @@ def _deterministic_sqlalchemy_url() -> str:
         if _is_special_sqlite_form(raw_path):
             return configured_url
 
-        if raw_path and not Path(raw_path).is_absolute() and config.config_file_name is not None:
-            resolved = (Path(config.config_file_name).resolve().parent / raw_path).resolve()
+        if (
+            raw_path
+            and not Path(raw_path).is_absolute()
+            and config.config_file_name is not None
+        ):
+            resolved = (
+                Path(config.config_file_name).resolve().parent / raw_path
+            ).resolve()
             return str(parsed.set(database=resolved.as_posix()))
 
     return configured_url

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
@@ -1,0 +1,5 @@
+"""Worker queue abstractions and implementations."""
+
+from qdrant_loader.core.worker.queue import JobQueue, SQLiteJobQueue
+
+__all__ = ["JobQueue", "SQLiteJobQueue"]

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -19,11 +19,13 @@ class JobQueue(Protocol):
     async def claim_next(self, lease_seconds: int = 60) -> Job | None:
         """Atomically claim the next visible pending job."""
 
-    async def mark_done(self, job_id: int) -> bool:
-        """Mark a job as completed."""
+    async def mark_done(self, job_id: int, claim_attempt: int) -> bool:
+        """Mark a claimed job as completed if claim ownership still matches."""
 
-    async def mark_failed(self, job_id: int, error_message: str) -> bool:
-        """Mark a job as failed with an error message."""
+    async def mark_failed(
+        self, job_id: int, error_message: str, claim_attempt: int
+    ) -> bool:
+        """Mark a claimed job as failed if claim ownership still matches."""
 
     async def list(self, status: str | None = None, limit: int = 100) -> list[Job]:
         """List jobs with optional status filter."""
@@ -61,6 +63,8 @@ class SQLiteJobQueue:
             return job
 
     async def claim_next(self, lease_seconds: int = 60) -> Job | None:
+        if lease_seconds < 0:
+            raise ValueError("lease_seconds must be non-negative")
         now = datetime.now(UTC)
         visibility_deadline = now + timedelta(seconds=lease_seconds)
 
@@ -102,12 +106,16 @@ class SQLiteJobQueue:
             claimed_job = await session.get(Job, claimed_job_id)
             return claimed_job
 
-    async def mark_done(self, job_id: int) -> bool:
+    async def mark_done(self, job_id: int, claim_attempt: int) -> bool:
         now = datetime.now(UTC)
         async with self._session_factory() as session:
             stmt = (
                 update(Job)
-                .where(Job.id == job_id)
+                .where(
+                    Job.id == job_id,
+                    Job.status == self.RUNNING,
+                    Job.attempts == claim_attempt,
+                )
                 .values(
                     status=self.DONE,
                     finished_at=now,
@@ -121,12 +129,18 @@ class SQLiteJobQueue:
             await session.commit()
             return updated_job_id is not None
 
-    async def mark_failed(self, job_id: int, error_message: str) -> bool:
+    async def mark_failed(
+        self, job_id: int, error_message: str, claim_attempt: int
+    ) -> bool:
         now = datetime.now(UTC)
         async with self._session_factory() as session:
             stmt = (
                 update(Job)
-                .where(Job.id == job_id)
+                .where(
+                    Job.id == job_id,
+                    Job.status == self.RUNNING,
+                    Job.attempts == claim_attempt,
+                )
                 .values(
                     status=self.FAILED,
                     finished_at=now,

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from sqlalchemy import or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from qdrant_loader.core.state.models import Job
+
+
+class JobQueue(Protocol):
+    """Queue protocol to allow backend swaps without changing worker logic."""
+
+    async def enqueue(self, job_type: str, payload: dict[str, Any]) -> Job:
+        """Create and persist a new pending job."""
+
+    async def claim_next(self, lease_seconds: int = 60) -> Job | None:
+        """Atomically claim the next visible pending job."""
+
+    async def mark_done(self, job_id: int) -> bool:
+        """Mark a job as completed."""
+
+    async def mark_failed(self, job_id: int, error_message: str) -> bool:
+        """Mark a job as failed with an error message."""
+
+    async def list(self, status: str | None = None, limit: int = 100) -> list[Job]:
+        """List jobs with optional status filter."""
+
+
+class SQLiteJobQueue:
+    """SQLite-backed job queue implementation using SQLAlchemy async sessions."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]):
+        self._session_factory = session_factory
+
+    async def enqueue(self, job_type: str, payload: dict[str, Any]) -> Job:
+        now = datetime.now(UTC)
+        job = Job(
+            type=job_type,
+            payload_json=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+            status=self.PENDING,
+            enqueued_at=now,
+            attempts=0,
+            started_at=None,
+            finished_at=None,
+            last_error=None,
+            visibility_deadline=None,
+        )
+
+        async with self._session_factory() as session:
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            return job
+
+    async def claim_next(self, lease_seconds: int = 60) -> Job | None:
+        now = datetime.now(UTC)
+        visibility_deadline = now + timedelta(seconds=lease_seconds)
+
+        async with self._session_factory() as session:
+            next_job_id = (
+                select(Job.id)
+                .where(
+                    or_(
+                        Job.status == self.PENDING,
+                        (Job.status == self.RUNNING) & (Job.visibility_deadline <= now),
+                    ),
+                )
+                .order_by(Job.enqueued_at.asc(), Job.id.asc())
+                .limit(1)
+                .scalar_subquery()
+            )
+
+            stmt = (
+                update(Job)
+                .where(Job.id == next_job_id)
+                .values(
+                    status=self.RUNNING,
+                    started_at=now,
+                    finished_at=None,
+                    visibility_deadline=visibility_deadline,
+                    attempts=Job.attempts + 1,
+                    last_error=None,
+                )
+                .returning(Job.id)
+            )
+
+            result = await session.execute(stmt)
+            claimed_job_id = result.scalar_one_or_none()
+            await session.commit()
+
+            if claimed_job_id is None:
+                return None
+
+            claimed_job = await session.get(Job, claimed_job_id)
+            return claimed_job
+
+    async def mark_done(self, job_id: int) -> bool:
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            stmt = (
+                update(Job)
+                .where(Job.id == job_id)
+                .values(
+                    status=self.DONE,
+                    finished_at=now,
+                    visibility_deadline=None,
+                    last_error=None,
+                )
+                .returning(Job.id)
+            )
+            result = await session.execute(stmt)
+            updated_job_id = result.scalar_one_or_none()
+            await session.commit()
+            return updated_job_id is not None
+
+    async def mark_failed(self, job_id: int, error_message: str) -> bool:
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            stmt = (
+                update(Job)
+                .where(Job.id == job_id)
+                .values(
+                    status=self.FAILED,
+                    finished_at=now,
+                    visibility_deadline=None,
+                    last_error=error_message,
+                )
+                .returning(Job.id)
+            )
+            result = await session.execute(stmt)
+            updated_job_id = result.scalar_one_or_none()
+            await session.commit()
+            return updated_job_id is not None
+
+    async def list(self, status: str | None = None, limit: int = 100) -> list[Job]:
+        async with self._session_factory() as session:
+            stmt = select(Job)
+            if status:
+                stmt = stmt.where(Job.status == status)
+            stmt = stmt.order_by(Job.enqueued_at.asc(), Job.id.asc()).limit(limit)
+
+            result = await session.execute(stmt)
+            return list(result.scalars().all())

--- a/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import pytest
-
 from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, inspect

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from qdrant_loader.config.state import StateManagementConfig
+from qdrant_loader.core.state.session import create_tables, dispose_engine
+from qdrant_loader.core.state.session import initialize_engine_and_session
+from qdrant_loader.core.worker.queue import SQLiteJobQueue
+
+
+@pytest_asyncio.fixture
+async def sqlite_job_queue(tmp_path: Path):
+    db_path = tmp_path / "worker_queue.db"
+    config = StateManagementConfig(database_path=str(db_path))
+    engine, session_factory = initialize_engine_and_session(config)
+    await create_tables(engine)
+
+    queue = SQLiteJobQueue(session_factory)
+    try:
+        yield queue
+    finally:
+        await dispose_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_enqueue_and_list(sqlite_job_queue: SQLiteJobQueue):
+    await sqlite_job_queue.enqueue("BULK_INGEST", {"source": "jira"})
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "git"})
+
+    jobs = await sqlite_job_queue.list()
+    pending_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.PENDING)
+
+    assert len(jobs) == 2
+    assert len(pending_jobs) == 2
+    assert jobs[0].payload_json
+
+
+@pytest.mark.asyncio
+async def test_claim_next_no_duplicates_under_race(sqlite_job_queue: SQLiteJobQueue):
+    total_jobs = 100
+    workers = 4
+
+    for i in range(total_jobs):
+        await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"sequence": i})
+
+    claimed_ids: set[int] = set()
+    duplicate_claims: list[int] = []
+    lock = asyncio.Lock()
+
+    async def worker() -> None:
+        while True:
+            job = await sqlite_job_queue.claim_next(lease_seconds=30)
+            if job is None:
+                return
+
+            async with lock:
+                if job.id in claimed_ids:
+                    duplicate_claims.append(job.id)
+                claimed_ids.add(job.id)
+
+            await sqlite_job_queue.mark_done(job.id)
+
+    await asyncio.gather(*(worker() for _ in range(workers)))
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    pending_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.PENDING)
+    running_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.RUNNING)
+
+    assert len(duplicate_claims) == 0
+    assert len(claimed_ids) == total_jobs
+    assert len(done_jobs) == total_jobs
+    assert len(pending_jobs) == 0
+    assert len(running_jobs) == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_sets_error(sqlite_job_queue: SQLiteJobQueue):
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
+
+    claimed = await sqlite_job_queue.claim_next()
+    assert claimed is not None
+    assert claimed.id == job.id
+
+    updated = await sqlite_job_queue.mark_failed(job.id, "source timeout")
+    assert updated is True
+
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
+    assert len(failed_jobs) == 1
+    assert failed_jobs[0].last_error == "source timeout"
+
+
+@pytest.mark.asyncio
+async def test_mark_done_sets_status_and_completion_fields(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    job = await sqlite_job_queue.enqueue("BULK_INGEST", {"source": "jira"})
+
+    claimed = await sqlite_job_queue.claim_next()
+    assert claimed is not None
+    assert claimed.id == job.id
+    assert claimed.status == SQLiteJobQueue.RUNNING
+    assert claimed.started_at is not None
+    assert claimed.visibility_deadline is not None
+    assert claimed.attempts == 1
+
+    updated = await sqlite_job_queue.mark_done(job.id)
+    assert updated is True
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    assert len(done_jobs) == 1
+
+    done_job = done_jobs[0]
+    assert done_job.id == job.id
+    assert done_job.finished_at is not None
+    assert done_job.visibility_deadline is None
+    assert done_job.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_claim_next_reclaims_after_lease_timeout(sqlite_job_queue: SQLiteJobQueue):
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
+
+    first_claim = await sqlite_job_queue.claim_next(lease_seconds=0)
+    assert first_claim is not None
+    assert first_claim.id == job.id
+    assert first_claim.status == SQLiteJobQueue.RUNNING
+    assert first_claim.attempts == 1
+
+    second_claim = await sqlite_job_queue.claim_next(lease_seconds=30)
+    assert second_claim is not None
+    assert second_claim.id == job.id
+    assert second_claim.status == SQLiteJobQueue.RUNNING
+    assert second_claim.attempts == 2

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -6,8 +6,11 @@ from pathlib import Path
 import pytest
 import pytest_asyncio
 from qdrant_loader.config.state import StateManagementConfig
-from qdrant_loader.core.state.session import create_tables, dispose_engine
-from qdrant_loader.core.state.session import initialize_engine_and_session
+from qdrant_loader.core.state.session import (
+    create_tables,
+    dispose_engine,
+    initialize_engine_and_session,
+)
 from qdrant_loader.core.worker.queue import SQLiteJobQueue
 
 
@@ -120,7 +123,9 @@ async def test_mark_done_sets_status_and_completion_fields(
 
 
 @pytest.mark.asyncio
-async def test_claim_next_reclaims_after_lease_timeout(sqlite_job_queue: SQLiteJobQueue):
+async def test_claim_next_reclaims_after_lease_timeout(
+    sqlite_job_queue: SQLiteJobQueue,
+):
     job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
 
     first_claim = await sqlite_job_queue.claim_next(lease_seconds=0)

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -64,7 +64,7 @@ async def test_claim_next_no_duplicates_under_race(sqlite_job_queue: SQLiteJobQu
                     duplicate_claims.append(job.id)
                 claimed_ids.add(job.id)
 
-            await sqlite_job_queue.mark_done(job.id)
+            await sqlite_job_queue.mark_done(job.id, claim_attempt=job.attempts)
 
     await asyncio.gather(*(worker() for _ in range(workers)))
 
@@ -87,7 +87,9 @@ async def test_mark_failed_sets_error(sqlite_job_queue: SQLiteJobQueue):
     assert claimed is not None
     assert claimed.id == job.id
 
-    updated = await sqlite_job_queue.mark_failed(job.id, "source timeout")
+    updated = await sqlite_job_queue.mark_failed(
+        job.id, "source timeout", claim_attempt=claimed.attempts
+    )
     assert updated is True
 
     failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
@@ -109,7 +111,7 @@ async def test_mark_done_sets_status_and_completion_fields(
     assert claimed.visibility_deadline is not None
     assert claimed.attempts == 1
 
-    updated = await sqlite_job_queue.mark_done(job.id)
+    updated = await sqlite_job_queue.mark_done(job.id, claim_attempt=claimed.attempts)
     assert updated is True
 
     done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
@@ -139,3 +141,28 @@ async def test_claim_next_reclaims_after_lease_timeout(
     assert second_claim.id == job.id
     assert second_claim.status == SQLiteJobQueue.RUNNING
     assert second_claim.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_mark_done_rejects_stale_claim_attempt(sqlite_job_queue: SQLiteJobQueue):
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
+
+    first_claim = await sqlite_job_queue.claim_next(lease_seconds=0)
+    assert first_claim is not None
+    assert first_claim.id == job.id
+    assert first_claim.attempts == 1
+
+    second_claim = await sqlite_job_queue.claim_next(lease_seconds=30)
+    assert second_claim is not None
+    assert second_claim.id == job.id
+    assert second_claim.attempts == 2
+
+    stale_update = await sqlite_job_queue.mark_done(
+        job.id, claim_attempt=first_claim.attempts
+    )
+    assert stale_update is False
+
+    fresh_update = await sqlite_job_queue.mark_done(
+        job.id, claim_attempt=second_claim.attempts
+    )
+    assert fresh_update is True


### PR DESCRIPTION
# Pull Request

## Summary

Implements the core SQLite queue engine and stable queue contract
## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Connectors/Pipeline Affected:**  
Introduces new worker layer with `JobQueue` protocol and `SQLiteJobQueue` implementation. Currently a standalone abstraction not yet integrated into existing pipeline stages. New worker module exposed via package `__init__.py`.

**Config Schema Changes (Additive):**  
Adds `jobs` table with 10 columns (id, type, payload_json, status, enqueued_at, started_at, finished_at, attempts, last_error, visibility_deadline) and composite index on (status, enqueued_at). No breaking changes; builds on existing `StateManagementConfig`. Migration is reversible.

**Test Coverage:**  
Comprehensive async test suite covering enqueue, list, claim_next with lease semantics, mark_done, and mark_failed. Race condition test validates atomicity: 100 jobs claimed by 4 concurrent workers with zero duplicate claims—strong evidence of thread-safe claiming logic.

**Security/Resource Concerns:**  
SQLAlchemy ORM prevents SQL injection. Lease-based visibility deadline prevents unbounded job retention. JSON payloads safely serialized. No obvious security issues; async session lifecycle properly managed in tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/281)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->