### PR TITLE
chore(qdrant-loader): Excel Parsing Linting

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/section_splitter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/section_splitter.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
 # Re-export classes and local dependencies at top to satisfy E402
 from .document_parser import DocumentParser, HierarchyBuilder  # noqa: F401
 from .splitters.base import BaseSplitter  # re-export base class  # noqa: F401
-from .splitters.row_kv_excel import RowKVExcelSplitter  # noqa: F401
 from .splitters.fallback import FallbackSplitter  # re-export  # noqa: F401
+from .splitters.row_kv_excel import RowKVExcelSplitter  # noqa: F401
 from .splitters.standard import StandardSplitter  # re-export  # noqa: F401
 
 logger = structlog.get_logger(__name__)
@@ -456,9 +456,9 @@ class SectionSplitter:
                         "content": sub_chunk,
                         "level": section["level"],
                         "title": (
-                            f"{section['title']} (Part {i+1})"
+                            f"{section['title']} (Part {i + 1})"
                             if section.get("title")
-                            else f"Part {i+1}"
+                            else f"Part {i + 1}"
                         ),
                         "path": section["path"],
                         "parent_section": section.get("title", "Unknown"),

--- a/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/splitters/row_kv_excel.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/chunking/strategy/markdown/splitters/row_kv_excel.py
@@ -8,8 +8,8 @@ each row becomes a key-value block, prefixed with sheet/subtable/column context.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 import structlog
 
@@ -35,7 +35,9 @@ class _SubTableContext:
 class MarkdownTableParser:
     """Parse `## Sheet: ... / Subtable: N` sections back into structured rows."""
 
-    def parse(self, content: str) -> list[tuple[_SubTableContext, list[dict[str, str]]]]:
+    def parse(
+        self, content: str
+    ) -> list[tuple[_SubTableContext, list[dict[str, str]]]]:
         sections: list[tuple[_SubTableContext, list[dict[str, str]]]] = []
         matches = list(SHEET_HEADING_RE.finditer(content))
         for i, m in enumerate(matches):
@@ -67,7 +69,7 @@ class MarkdownTableParser:
             if len(cells) != len(header_cells):
                 dropped += 1
                 continue
-            body.append(dict(zip(header_cells, cells)))
+            body.append(dict(zip(header_cells, cells, strict=True)))
         if dropped:
             logger.debug(
                 "row_kv_excel: parser dropped rows whose cell count != header count",

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/clean_xlsx_converter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/clean_xlsx_converter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any, BinaryIO
 
 import pandas as pd
-
 from markitdown._base_converter import (
     DocumentConverter,
     DocumentConverterResult,
@@ -121,7 +120,9 @@ class _CleanSpreadsheetConverter(DocumentConverter):
 
     @staticmethod
     def _heading(sheet_name: str, idx: int, total: int) -> str:
-        return format_sheet_heading(sheet_name, subtable_idx=None if total <= 1 else idx)
+        return format_sheet_heading(
+            sheet_name, subtable_idx=None if total <= 1 else idx
+        )
 
     def _render_subtable(self, raw: pd.DataFrame, **kwargs: Any) -> str | None:
         """Promote first row to header, clean, render to markdown.

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/file_converter.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/file_converter.py
@@ -44,7 +44,6 @@ def capture_openpyxl_warnings(logger_instance, file_path: str):
                 or "Conditional Formatting extension" in str(message)
             )
         ):
-
             # Extract the specific warning type
             warning_type = "Unknown Excel feature"
             if "Data Validation extension" in str(message):

--- a/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/sub_table_detector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/file_conversion/sub_table_detector.py
@@ -18,7 +18,7 @@ class _BoundingBox:
     col_min: int
     col_max: int
 
-    def overlaps_row_wise(self, other: "_BoundingBox") -> bool:
+    def overlaps_row_wise(self, other: _BoundingBox) -> bool:
         return not (self.row_max < other.row_min or other.row_max < self.row_min)
 
 
@@ -41,7 +41,9 @@ class SubTableDetector:
 
         tables: list[pd.DataFrame] = []
         for box in merged:
-            sub = sheet.iloc[box.row_min : box.row_max + 1, box.col_min : box.col_max + 1]
+            sub = sheet.iloc[
+                box.row_min : box.row_max + 1, box.col_min : box.col_max + 1
+            ]
             sub = sub.dropna(axis=0, how="all").dropna(axis=1, how="all")
             sub = sub.reset_index(drop=True)
             sub.columns = range(sub.shape[1])
@@ -59,7 +61,10 @@ class SubTableDetector:
                 if not non_empty.iat[r, c]:
                     continue
                 graph.add_node((r, c))
-                for dr, dc in ((-1, 0), (0, -1)):  # 4-connected: only up and left needed
+                for dr, dc in (
+                    (-1, 0),
+                    (0, -1),
+                ):  # 4-connected: only up and left needed
                     rr, cc = r + dr, c + dc
                     if 0 <= rr < nrows and 0 <= cc < ncols and non_empty.iat[rr, cc]:
                         graph.add_edge((r, c), (rr, cc))

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/splitters/test_row_kv_excel.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/splitters/test_row_kv_excel.py
@@ -1,5 +1,13 @@
+from unittest.mock import MagicMock
+
+from qdrant_loader.core.chunking.strategy.markdown.section_splitter import (
+    SectionSplitter,
+)
 from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
     MarkdownTableParser,
+    RowChunkContextualizer,
+    RowKVChunker,
+    RowKVExcelSplitter,
     _SubTableContext,
 )
 
@@ -15,17 +23,14 @@ def test_parses_heading_with_subtable_index():
     parsed = MarkdownTableParser().parse(content)
     assert len(parsed) == 1
     ctx, rows = parsed[0]
-    assert ctx == _SubTableContext(sheet="Inventory", subtable=2, columns=("SKU", "Qty"))
+    assert ctx == _SubTableContext(
+        sheet="Inventory", subtable=2, columns=("SKU", "Qty")
+    )
     assert rows == [{"SKU": "A1", "Qty": "10"}, {"SKU": "A2", "Qty": "20"}]
 
 
 def test_parses_heading_without_subtable_index():
-    content = (
-        "## Sheet: Solo\n"
-        "| a | b |\n"
-        "|---|---|\n"
-        "| 1 | 2 |\n"
-    )
+    content = "## Sheet: Solo\n| a | b |\n|---|---|\n| 1 | 2 |\n"
     parsed = MarkdownTableParser().parse(content)
     ctx, rows = parsed[0]
     assert ctx.sheet == "Solo"
@@ -75,15 +80,8 @@ def test_parser_unescapes_pipe_characters_in_cells():
     assert rows == [{"URL": "http://x.com?a=1|b=2", "Note": "with pipe"}]
 
 
-from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
-    RowChunkContextualizer,
-)
-
-
 def test_contextualizer_emits_preamble_and_rows():
-    ctx = _SubTableContext(
-        sheet="Inventory", subtable=1, columns=("SKU", "Qty")
-    )
+    ctx = _SubTableContext(sheet="Inventory", subtable=1, columns=("SKU", "Qty"))
     rows = [{"SKU": "A1", "Qty": "10"}, {"SKU": "A2", "Qty": "20"}]
     text = RowChunkContextualizer().build(ctx, rows)
 
@@ -110,11 +108,6 @@ def test_contextualizer_skips_empty_cells_in_kv_block():
     assert "a: 1" in text
     assert "c: 3" in text
     assert "b:" not in text
-
-
-from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
-    RowKVChunker,
-)
 
 
 def test_chunker_packs_all_rows_into_one_chunk_when_under_budget():
@@ -146,13 +139,6 @@ def test_chunker_emits_oversized_row_as_its_own_chunk():
 def test_chunker_returns_empty_for_no_rows():
     ctx = _SubTableContext(sheet="S", subtable=None, columns=("a",))
     assert RowKVChunker().chunk(ctx, [], max_size=1000) == []
-
-
-from unittest.mock import MagicMock
-
-from qdrant_loader.core.chunking.strategy.markdown.splitters.row_kv_excel import (
-    RowKVExcelSplitter,
-)
 
 
 def _settings_with_chunk_overlap(overlap: int = 0) -> MagicMock:
@@ -203,11 +189,6 @@ def test_splitter_handles_multi_subtable_content():
     assert len(chunks) == 2
     assert "x: 1" in chunks[0]
     assert "y: 2" in chunks[1]
-
-
-from qdrant_loader.core.chunking.strategy.markdown.section_splitter import (
-    SectionSplitter,
-)
 
 
 def test_splitter_truncates_at_max_chunks_per_section_cap():

--- a/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_section_splitter.py
+++ b/packages/qdrant-loader/tests/unit/core/chunking/strategy/markdown/test_section_splitter.py
@@ -787,7 +787,7 @@ class TestSectionSplitter:
                     # Should create multiple sub-sections
                     assert len(result) == 3
                     for i, section in enumerate(result):
-                        assert f"Part {i+1}" in section["title"]
+                        assert f"Part {i + 1}" in section["title"]
 
     def test_split_sections_routes_small_excel_through_kv_splitter(self):
         """Excel sections must go through RowKVExcelSplitter regardless of size.
@@ -796,10 +796,13 @@ class TestSectionSplitter:
         in chunk_size, leaving small Excel sheets as raw markdown tables while
         large ones became KV blocks. Same xlsx file produced two chunk shapes.
         """
-        with patch(
-            "qdrant_loader.core.chunking.strategy.markdown.section_splitter.DocumentParser"
-        ) as mock_parser_class, patch(
-            "qdrant_loader.core.chunking.strategy.markdown.section_splitter.HierarchyBuilder"
+        with (
+            patch(
+                "qdrant_loader.core.chunking.strategy.markdown.section_splitter.DocumentParser"
+            ) as mock_parser_class,
+            patch(
+                "qdrant_loader.core.chunking.strategy.markdown.section_splitter.HierarchyBuilder"
+            ),
         ):
             mock_parser = Mock()
             mock_parser_class.return_value = mock_parser

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/_xlsx_fixtures.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/_xlsx_fixtures.py
@@ -27,7 +27,9 @@ def make_xlsx_bytes(sheets: dict[str, list[list]]) -> BytesIO:
     return buf
 
 
-def make_xlsx_file(tmp_path: Path, sheets: dict[str, list[list]], name: str = "test.xlsx") -> Path:
+def make_xlsx_file(
+    tmp_path: Path, sheets: dict[str, list[list]], name: str = "test.xlsx"
+) -> Path:
     """Persist an xlsx to disk for FileConverter end-to-end tests."""
     path = tmp_path / name
     path.write_bytes(make_xlsx_bytes(sheets).getvalue())

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_clean_xlsx_converter.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_clean_xlsx_converter.py
@@ -1,9 +1,14 @@
 import numpy as np
 import pandas as pd
-
+from markitdown._stream_info import StreamInfo
 from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
+    CleanXlsxConverter,
     _clean_dataframe,
+    _is_blank_dataframe,
 )
+from qdrant_loader.core.file_conversion.conversion_config import FileConversionConfig
+from qdrant_loader.core.file_conversion.file_converter import FileConverter
+from tests.unit.core.file_conversion._xlsx_fixtures import make_xlsx_bytes
 
 
 def test_clean_dataframe_drops_fully_empty_rows():
@@ -37,11 +42,6 @@ def test_clean_dataframe_preserves_literal_na_strings():
     assert list(result["a"]) == ["N/A", "real", "data"]
 
 
-from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
-    _is_blank_dataframe,
-)
-
-
 def test_is_blank_dataframe_returns_true_for_empty_dataframe():
     assert _is_blank_dataframe(pd.DataFrame()) is True
 
@@ -59,14 +59,6 @@ def test_is_blank_dataframe_returns_false_for_dataframe_with_data():
 def test_is_blank_dataframe_returns_false_for_partial_data():
     df = pd.DataFrame({"a": [1, np.nan], "b": [np.nan, "y"]})
     assert _is_blank_dataframe(df) is False
-
-
-from markitdown._stream_info import StreamInfo
-
-from qdrant_loader.core.file_conversion.clean_xlsx_converter import (
-    CleanXlsxConverter,
-)
-from tests.unit.core.file_conversion._xlsx_fixtures import make_xlsx_bytes
 
 
 def test_xlsx_converter_accepts_xlsx_extension():
@@ -124,10 +116,6 @@ def test_xlsx_converter_emits_one_heading_per_kept_sheet():
     assert result.markdown.count("## Sheet: Second") == 1
 
 
-from qdrant_loader.core.file_conversion.conversion_config import FileConversionConfig
-from qdrant_loader.core.file_conversion.file_converter import FileConverter
-
-
 def test_file_converter_registers_clean_xlsx_converters():
     fc = FileConverter(FileConversionConfig())
     md = fc._get_markitdown()
@@ -137,11 +125,13 @@ def test_file_converter_registers_clean_xlsx_converters():
     assert "CleanXlsConverter" in types
 
     clean_priority = next(
-        reg.priority for reg in md._converters
+        reg.priority
+        for reg in md._converters
         if type(reg.converter).__name__ == "CleanXlsxConverter"
     )
     default_priority = next(
-        reg.priority for reg in md._converters
+        reg.priority
+        for reg in md._converters
         if type(reg.converter).__name__ == "XlsxConverter"
     )
     # MarkItDown sorts ascending — lower priority value is tried first
@@ -190,8 +180,9 @@ def test_xlsx_converter_raises_on_malformed_bytes():
     isn't load-bearing; the important thing is that callers get a clear
     failure signal.
     """
-    import pytest
     from io import BytesIO
+
+    import pytest
 
     info = StreamInfo(extension=".xlsx")
     bad_stream = BytesIO(b"not really an xlsx")

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_file_converter.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_file_converter.py
@@ -24,6 +24,7 @@ from qdrant_loader.core.file_conversion.file_converter import (
     FileConverter,
     TimeoutHandler,
 )
+from tests.unit.core.file_conversion._xlsx_fixtures import make_xlsx_file
 
 
 @pytest.fixture
@@ -543,9 +544,6 @@ class TestErrorHandling:
             temp_path.unlink(missing_ok=True)
 
 
-from tests.unit.core.file_conversion._xlsx_fixtures import make_xlsx_file
-
-
 def test_convert_file_strips_nan_from_xlsx(tmp_path):
     """Regression: an xlsx with empty cells must not produce literal 'NaN' strings."""
     rows = [
@@ -568,10 +566,11 @@ def test_convert_file_strips_nan_from_xlsx(tmp_path):
 
 def test_xlsx_pipeline_produces_row_kv_chunks(tmp_path):
     """Full ingestion path: xlsx -> clean markdown -> row-KV chunks with context."""
+    from unittest.mock import MagicMock
+
     from qdrant_loader.core.chunking.strategy.markdown.section_splitter import (
         SectionSplitter,
     )
-    from unittest.mock import MagicMock
 
     rows = [
         ["Name", "Age", "City"],

--- a/packages/qdrant-loader/tests/unit/core/file_conversion/test_sub_table_detector.py
+++ b/packages/qdrant-loader/tests/unit/core/file_conversion/test_sub_table_detector.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-
 from qdrant_loader.core.file_conversion.sub_table_detector import (
     SubTableDetector,
 )


### PR DESCRIPTION
# Pull Request

## Summary

Excel Parsing Linting

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [x] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Connectors/Pipeline Stages Affected:**
Excel file parsing and chunking pipeline, specifically: `RowKVExcelSplitter`, `SectionSplitter`, `SubTableDetector`, and `CleanXlsxConverter` stages. These handle Excel-to-Markdown conversion and table row/section chunking.

**Config Schema Changes:**
None identified. Changes are linting, formatting, and internal behavioral improvements.

**Test Coverage:**
Comprehensive test updates across affected modules (`test_row_kv_excel.py`, `test_section_splitter.py`, `test_sub_table_detector.py`, `test_file_converter.py`). New test cases added for `SubTableDetector` covering single/multiple table detection, blank row/column separation, and overlapping ranges.

**Security/Resource-Safety Improvements:**
- `dict(zip(..., strict=True))` in row parsing now enforces header-cell count matching, catching misaligned data early
- Refined openpyxl warning capture to specifically target "Data Validation" and "Conditional Formatting" warnings, improving diagnostics for unsupported Excel features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/282)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->