### PR TITLE
feat: add concurrent queue worker pool with per-source locks

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
@@ -1,6 +1,25 @@
 """Worker queue abstractions and implementations."""
 
+from qdrant_loader.core.worker.handlers import (
+    BaseJobHandler,
+    HandlerRegistry,
+    JobHandler,
+    PermanentJobError,
+    TransientJobError,
+)
 from qdrant_loader.core.worker.pool import QueueWorkerPool
 from qdrant_loader.core.worker.queue import JobQueue, SQLiteJobQueue
 
-__all__ = ["JobQueue", "SQLiteJobQueue", "QueueWorkerPool"]
+__all__ = [
+    # Queue abstractions
+    "JobQueue",
+    "SQLiteJobQueue",
+    # Pool
+    "QueueWorkerPool",
+    # Handlers
+    "JobHandler",
+    "BaseJobHandler",
+    "HandlerRegistry",
+    "TransientJobError",
+    "PermanentJobError",
+]

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
@@ -1,5 +1,6 @@
 """Worker queue abstractions and implementations."""
 
+from qdrant_loader.core.worker.pool import QueueWorkerPool
 from qdrant_loader.core.worker.queue import JobQueue, SQLiteJobQueue
 
-__all__ = ["JobQueue", "SQLiteJobQueue"]
+__all__ = ["JobQueue", "SQLiteJobQueue", "QueueWorkerPool"]

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
@@ -29,7 +29,7 @@ class BaseJobHandler(ABC):
         elif job_type == "INCREMENTAL_PULL":
             return await self.handle_incremental_pull(payload)
         else:
-            raise ValueError(f"Unknown job type: {job_type}")
+            raise PermanentJobError(f"Unknown job type: {job_type}")
 
     @abstractmethod
     async def handle_bulk_ingest(self, payload: dict[str, Any]) -> None:
@@ -66,7 +66,7 @@ class HandlerRegistry:
     async def handle(self, job_type: str, payload: dict[str, Any]) -> None:
         """Execute a job by dispatching to the registered handler."""
         if job_type not in self._handlers:
-            raise ValueError(f"No handler registered for job type: {job_type}")
+            raise PermanentJobError(f"Unknown job type: {job_type}")
         handler = self._handlers[job_type]
         await handler(job_type, payload)
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
@@ -1,0 +1,93 @@
+"""Job handlers for queue-based ingestion workflows."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+from typing import Any, Protocol
+
+from qdrant_loader.utils.logging import LoggingConfig
+
+logger = LoggingConfig.get_logger(__name__)
+
+
+class JobHandler(Protocol):
+    """Protocol for job handlers invoked by QueueWorkerPool."""
+
+    async def __call__(self, job_type: str, payload: dict[str, Any]) -> None:
+        """Execute a job of the given type with the provided payload."""
+        ...
+
+
+class BaseJobHandler(ABC):
+    """Base class for job handlers."""
+
+    async def __call__(self, job_type: str, payload: dict[str, Any]) -> None:
+        """Dispatch to handler method based on job_type."""
+        if job_type == "BULK_INGEST":
+            return await self.handle_bulk_ingest(payload)
+        elif job_type == "INCREMENTAL_PULL":
+            return await self.handle_incremental_pull(payload)
+        else:
+            raise ValueError(f"Unknown job type: {job_type}")
+
+    @abstractmethod
+    async def handle_bulk_ingest(self, payload: dict[str, Any]) -> None:
+        """Handle BULK_INGEST job."""
+        ...
+
+    @abstractmethod
+    async def handle_incremental_pull(self, payload: dict[str, Any]) -> None:
+        """Handle INCREMENTAL_PULL job."""
+        ...
+
+    @staticmethod
+    def _calculate_since_timestamp(last_ingestion: datetime | None) -> datetime | None:
+        """Calculate the 'since' timestamp for incremental pulls (last_ingestion - 5min)."""
+        if last_ingestion is None:
+            return None
+        return last_ingestion - timedelta(minutes=5)
+
+
+class HandlerRegistry:
+    """Registry for mapping job types to handler implementations."""
+
+    def __init__(self) -> None:
+        """Initialize empty registry."""
+        self._handlers: dict[str, BaseJobHandler] = {}
+
+    def register(self, job_type: str, handler: BaseJobHandler) -> None:
+        """Register a handler for a specific job type."""
+        self._handlers[job_type] = handler
+        logger.debug(
+            "Registered handler", job_type=job_type, handler=handler.__class__.__name__
+        )
+
+    async def handle(self, job_type: str, payload: dict[str, Any]) -> None:
+        """Execute a job by dispatching to the registered handler."""
+        if job_type not in self._handlers:
+            raise ValueError(f"No handler registered for job type: {job_type}")
+        handler = self._handlers[job_type]
+        await handler(job_type, payload)
+
+    def list_handlers(self) -> dict[str, str]:
+        """List all registered handlers."""
+        return {jt: h.__class__.__name__ for jt, h in self._handlers.items()}
+
+
+class JobHandlerError(Exception):
+    """Base exception for job handler errors."""
+
+    pass
+
+
+class TransientJobError(JobHandlerError):
+    """Transient error (may succeed on retry)."""
+
+    pass
+
+
+class PermanentJobError(JobHandlerError):
+    """Permanent error (will not succeed on retry)."""
+
+    pass

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import Awaitable, Callable
 from json import JSONDecodeError
 from typing import Any
 
+from qdrant_loader.core.worker.handlers import JobHandler
 from qdrant_loader.core.worker.queue import JobQueue
 from qdrant_loader.utils.logging import LoggingConfig
 
 logger = LoggingConfig.get_logger(__name__)
-
-JobHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 
 
 class QueueWorkerPool:

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import Awaitable, Callable
 from json import JSONDecodeError
 from typing import Any
 
 from qdrant_loader.core.worker.queue import JobQueue
+from qdrant_loader.utils.logging import LoggingConfig
+
+logger = LoggingConfig.get_logger(__name__)
 
 JobHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 
@@ -82,10 +86,27 @@ class QueueWorkerPool:
                     continue
                 source_lock = await self._get_source_lock(source_key)
 
+                logger.info(
+                    "job.claimed",
+                    job_id=job.id,
+                    job_type=job.type,
+                    source_key=source_key,
+                    attempt=job.attempts,
+                )
+
                 async with source_lock:
+                    logger.info(
+                        "job.handler_started",
+                        job_id=job.id,
+                        job_type=job.type,
+                        source_key=source_key,
+                        attempt=job.attempts,
+                    )
+                    t0 = time.monotonic()
                     try:
                         await self._handler(job.type, payload)
                     except Exception as exc:
+                        duration_ms = round((time.monotonic() - t0) * 1000)
                         async with self._queue_io_guard:
                             if job.attempts < self._max_attempts:
                                 retry_after_seconds = 0
@@ -100,15 +121,45 @@ class QueueWorkerPool:
                                     claim_attempt=job.attempts,
                                     retry_after_seconds=retry_after_seconds,
                                 )
+                                logger.info(
+                                    "job.retry_scheduled",
+                                    job_id=job.id,
+                                    job_type=job.type,
+                                    source_key=source_key,
+                                    attempt=job.attempts,
+                                    max_attempts=self._max_attempts,
+                                    retry_after_seconds=retry_after_seconds,
+                                    duration_ms=duration_ms,
+                                    error=str(exc),
+                                )
                             else:
                                 await self._queue.mark_failed(
                                     job.id, str(exc), claim_attempt=job.attempts
                                 )
+                                logger.info(
+                                    "job.failed",
+                                    job_id=job.id,
+                                    job_type=job.type,
+                                    source_key=source_key,
+                                    attempt=job.attempts,
+                                    max_attempts=self._max_attempts,
+                                    duration_ms=duration_ms,
+                                    error=str(exc),
+                                )
                     else:
+                        duration_ms = round((time.monotonic() - t0) * 1000)
                         async with self._queue_io_guard:
                             await self._queue.mark_done(
                                 job.id, claim_attempt=job.attempts
                             )
+                        logger.info(
+                            "job.done",
+                            job_id=job.id,
+                            job_type=job.type,
+                            source_key=source_key,
+                            attempt=job.attempts,
+                            duration_ms=duration_ms,
+                        )
 
                 async with processed_count_guard:
                     processed_count += 1

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -70,7 +70,16 @@ class QueueWorkerPool:
                         processed_count += 1
                     continue
 
-                source_key = self._extract_source_key(payload)
+                try:
+                    source_key = self._extract_source_key(payload)
+                except KeyError as exc:
+                    async with self._queue_io_guard:
+                        await self._queue.mark_failed(
+                            job.id, str(exc), claim_attempt=job.attempts
+                        )
+                    async with processed_count_guard:
+                        processed_count += 1
+                    continue
                 source_lock = await self._get_source_lock(source_key)
 
                 async with source_lock:
@@ -128,9 +137,20 @@ class QueueWorkerPool:
 
     @classmethod
     def _extract_source_key(cls, payload: dict[str, Any]) -> str:
-        # Prefer explicit source lock key if provided by scheduler/producer.
-        for field_name in ("source_lock", "source", "source_name", "project_source"):
-            value = payload.get(field_name)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return cls.DEFAULT_SOURCE_KEY
+        """Return the per-source concurrency key from the job payload.
+
+        Producers *must* set ``source_lock`` to a non-empty string.  This is
+        the explicit contract: the pool will never silently fall back to a
+        global key, because that would serialize the entire pool and hide a
+        missing-field bug until production load.
+
+        Raises:
+            KeyError: if ``source_lock`` is absent or blank.
+        """
+        value = payload.get("source_lock")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        raise KeyError(
+            "job payload is missing a non-empty 'source_lock' field — "
+            "all producers must set it explicitly"
+        )

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from json import JSONDecodeError
+from typing import Any
+
+from qdrant_loader.core.worker.queue import JobQueue
+
+JobHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
+
+
+class QueueWorkerPool:
+    """Run queue jobs with bounded concurrency and per-source serialization."""
+
+    DEFAULT_SOURCE_KEY = "__global__"
+
+    def __init__(
+        self,
+        queue: JobQueue,
+        handler: JobHandler,
+        worker_count: int = 4,
+        lease_seconds: int = 60,
+    ) -> None:
+        if worker_count < 1:
+            raise ValueError("worker_count must be >= 1")
+
+        self._queue = queue
+        self._handler = handler
+        self._worker_count = worker_count
+        self._lease_seconds = lease_seconds
+        self._source_locks: dict[str, asyncio.Lock] = {}
+        self._source_locks_guard = asyncio.Lock()
+        self._queue_io_guard = asyncio.Lock()
+
+    async def run_until_empty(self) -> int:
+        """Drain the queue once and return number of attempted jobs."""
+        processed_count = 0
+        processed_count_guard = asyncio.Lock()
+
+        async def worker() -> None:
+            nonlocal processed_count
+
+            while True:
+                async with self._queue_io_guard:
+                    job = await self._queue.claim_next(lease_seconds=self._lease_seconds)
+                if job is None:
+                    return
+
+                payload, error_message = self._decode_payload(job.payload_json)
+                if error_message is not None:
+                    await self._queue.mark_failed(
+                        job.id, error_message, claim_attempt=job.attempts
+                    )
+                    async with processed_count_guard:
+                        processed_count += 1
+                    continue
+
+                source_key = self._extract_source_key(payload)
+                source_lock = await self._get_source_lock(source_key)
+
+                async with source_lock:
+                    try:
+                        await self._handler(job.type, payload)
+                    except Exception as exc:
+                        async with self._queue_io_guard:
+                            await self._queue.mark_failed(
+                                job.id, str(exc), claim_attempt=job.attempts
+                            )
+                    else:
+                        async with self._queue_io_guard:
+                            await self._queue.mark_done(
+                                job.id, claim_attempt=job.attempts
+                            )
+
+                async with processed_count_guard:
+                    processed_count += 1
+
+        await asyncio.gather(*(worker() for _ in range(self._worker_count)))
+        return processed_count
+
+    async def _get_source_lock(self, source_key: str) -> asyncio.Lock:
+        async with self._source_locks_guard:
+            lock = self._source_locks.get(source_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._source_locks[source_key] = lock
+            return lock
+
+    @staticmethod
+    def _decode_payload(payload_json: str) -> tuple[dict[str, Any], str | None]:
+        try:
+            payload = json.loads(payload_json)
+        except JSONDecodeError as exc:
+            return {}, f"Invalid payload_json: {exc.msg}"
+
+        if not isinstance(payload, dict):
+            return {}, "Invalid payload_json: expected JSON object"
+        return payload, None
+
+    @classmethod
+    def _extract_source_key(cls, payload: dict[str, Any]) -> str:
+        # Prefer explicit source lock key if provided by scheduler/producer.
+        for field_name in ("source_lock", "source", "source_name", "project_source"):
+            value = payload.get(field_name)
+            if isinstance(value, str) and value.strip():
+                return value
+        return cls.DEFAULT_SOURCE_KEY

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -22,16 +22,24 @@ class QueueWorkerPool:
         handler: JobHandler,
         worker_count: int = 4,
         lease_seconds: int = 60,
+        max_attempts: int = 1,
+        retry_backoff_base_seconds: int = 0,
     ) -> None:
         if worker_count < 1:
             raise ValueError("worker_count must be >= 1")
         if lease_seconds < 1:
             raise ValueError("lease_seconds must be >= 1")
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        if retry_backoff_base_seconds < 0:
+            raise ValueError("retry_backoff_base_seconds must be >= 0")
 
         self._queue = queue
         self._handler = handler
         self._worker_count = worker_count
         self._lease_seconds = lease_seconds
+        self._max_attempts = max_attempts
+        self._retry_backoff_base_seconds = retry_backoff_base_seconds
         self._source_locks: dict[str, asyncio.Lock] = {}
         self._source_locks_guard = asyncio.Lock()
         self._queue_io_guard = asyncio.Lock()
@@ -46,7 +54,9 @@ class QueueWorkerPool:
 
             while True:
                 async with self._queue_io_guard:
-                    job = await self._queue.claim_next(lease_seconds=self._lease_seconds)
+                    job = await self._queue.claim_next(
+                        lease_seconds=self._lease_seconds
+                    )
                 if job is None:
                     return
 
@@ -68,9 +78,23 @@ class QueueWorkerPool:
                         await self._handler(job.type, payload)
                     except Exception as exc:
                         async with self._queue_io_guard:
-                            await self._queue.mark_failed(
-                                job.id, str(exc), claim_attempt=job.attempts
-                            )
+                            if job.attempts < self._max_attempts:
+                                retry_after_seconds = 0
+                                if self._retry_backoff_base_seconds > 0:
+                                    retry_after_seconds = (
+                                        self._retry_backoff_base_seconds
+                                        * (2 ** (job.attempts - 1))
+                                    )
+                                await self._queue.release_for_retry(
+                                    job.id,
+                                    str(exc),
+                                    claim_attempt=job.attempts,
+                                    retry_after_seconds=retry_after_seconds,
+                                )
+                            else:
+                                await self._queue.mark_failed(
+                                    job.id, str(exc), claim_attempt=job.attempts
+                                )
                     else:
                         async with self._queue_io_guard:
                             await self._queue.mark_done(

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -25,6 +25,8 @@ class QueueWorkerPool:
     ) -> None:
         if worker_count < 1:
             raise ValueError("worker_count must be >= 1")
+        if lease_seconds < 1:
+            raise ValueError("lease_seconds must be >= 1")
 
         self._queue = queue
         self._handler = handler
@@ -105,5 +107,5 @@ class QueueWorkerPool:
         for field_name in ("source_lock", "source", "source_name", "project_source"):
             value = payload.get(field_name)
             if isinstance(value, str) and value.strip():
-                return value
+                return value.strip()
         return cls.DEFAULT_SOURCE_KEY

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -52,9 +52,10 @@ class QueueWorkerPool:
 
                 payload, error_message = self._decode_payload(job.payload_json)
                 if error_message is not None:
-                    await self._queue.mark_failed(
-                        job.id, error_message, claim_attempt=job.attempts
-                    )
+                    async with self._queue_io_guard:
+                        await self._queue.mark_failed(
+                            job.id, error_message, claim_attempt=job.attempts
+                        )
                     async with processed_count_guard:
                         processed_count += 1
                     continue

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -27,6 +27,15 @@ class JobQueue(Protocol):
     ) -> bool:
         """Mark a claimed job as failed if claim ownership still matches."""
 
+    async def release_for_retry(
+        self,
+        job_id: int,
+        error_message: str,
+        claim_attempt: int,
+        retry_after_seconds: int = 0,
+    ) -> bool:
+        """Release a claimed job back to pending for a later retry."""
+
     async def list(self, status: str | None = None, limit: int = 100) -> list[Job]:
         """List jobs with optional status filter."""
 
@@ -68,7 +77,8 @@ class SQLiteJobQueue:
         now = datetime.now(UTC)
         visibility_deadline = now + timedelta(seconds=lease_seconds)
         claimable_filter = or_(
-            Job.status == self.PENDING,
+            (Job.status == self.PENDING)
+            & ((Job.visibility_deadline.is_(None)) | (Job.visibility_deadline <= now)),
             (Job.status == self.RUNNING) & (Job.visibility_deadline <= now),
         )
 
@@ -144,6 +154,45 @@ class SQLiteJobQueue:
                     status=self.FAILED,
                     finished_at=now,
                     visibility_deadline=None,
+                    last_error=error_message,
+                )
+                .returning(Job.id)
+            )
+            result = await session.execute(stmt)
+            updated_job_id = result.scalar_one_or_none()
+            await session.commit()
+            return updated_job_id is not None
+
+    async def release_for_retry(
+        self,
+        job_id: int,
+        error_message: str,
+        claim_attempt: int,
+        retry_after_seconds: int = 0,
+    ) -> bool:
+        if retry_after_seconds < 0:
+            raise ValueError("retry_after_seconds must be non-negative")
+
+        now = datetime.now(UTC)
+        retry_deadline = (
+            now + timedelta(seconds=retry_after_seconds)
+            if retry_after_seconds > 0
+            else None
+        )
+
+        async with self._session_factory() as session:
+            stmt = (
+                update(Job)
+                .where(
+                    Job.id == job_id,
+                    Job.status == self.RUNNING,
+                    Job.attempts == claim_attempt,
+                )
+                .values(
+                    status=self.PENDING,
+                    started_at=None,
+                    finished_at=None,
+                    visibility_deadline=retry_deadline,
                     last_error=error_message,
                 )
                 .returning(Job.id)

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -67,16 +67,15 @@ class SQLiteJobQueue:
             raise ValueError("lease_seconds must be non-negative")
         now = datetime.now(UTC)
         visibility_deadline = now + timedelta(seconds=lease_seconds)
+        claimable_filter = or_(
+            Job.status == self.PENDING,
+            (Job.status == self.RUNNING) & (Job.visibility_deadline <= now),
+        )
 
         async with self._session_factory() as session:
             next_job_id = (
                 select(Job.id)
-                .where(
-                    or_(
-                        Job.status == self.PENDING,
-                        (Job.status == self.RUNNING) & (Job.visibility_deadline <= now),
-                    ),
-                )
+                .where(claimable_filter)
                 .order_by(Job.enqueued_at.asc(), Job.id.asc())
                 .limit(1)
                 .scalar_subquery()
@@ -84,7 +83,7 @@ class SQLiteJobQueue:
 
             stmt = (
                 update(Job)
-                .where(Job.id == next_job_id)
+                .where(Job.id == next_job_id, claimable_filter)
                 .values(
                     status=self.RUNNING,
                     started_at=now,

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -106,7 +106,8 @@ class SQLiteJobQueue:
             )
 
             result = await session.execute(stmt)
-            claimed_job_id = result.scalar_one_or_none()
+            rows = result.fetchall()
+            claimed_job_id = rows[0][0] if rows else None
             await session.commit()
 
             if claimed_job_id is None:
@@ -134,7 +135,8 @@ class SQLiteJobQueue:
                 .returning(Job.id)
             )
             result = await session.execute(stmt)
-            updated_job_id = result.scalar_one_or_none()
+            rows = result.fetchall()
+            updated_job_id = rows[0][0] if rows else None
             await session.commit()
             return updated_job_id is not None
 
@@ -159,7 +161,8 @@ class SQLiteJobQueue:
                 .returning(Job.id)
             )
             result = await session.execute(stmt)
-            updated_job_id = result.scalar_one_or_none()
+            rows = result.fetchall()
+            updated_job_id = rows[0][0] if rows else None
             await session.commit()
             return updated_job_id is not None
 
@@ -198,7 +201,8 @@ class SQLiteJobQueue:
                 .returning(Job.id)
             )
             result = await session.execute(stmt)
-            updated_job_id = result.scalar_one_or_none()
+            rows = result.fetchall()
+            updated_job_id = rows[0][0] if rows else None
             await session.commit()
             return updated_job_id is not None
 

--- a/packages/qdrant-loader/tests/scripts/check_worker_pool.py
+++ b/packages/qdrant-loader/tests/scripts/check_worker_pool.py
@@ -34,6 +34,8 @@ async def main() -> None:
     )
 
     db_path = Path(args.db).resolve()
+    if db_path.exists():
+        db_path.unlink()
     cfg = StateManagementConfig(database_path=str(db_path))
     engine, session_factory = initialize_engine_and_session(cfg)
     await create_tables(engine)

--- a/packages/qdrant-loader/tests/scripts/check_worker_pool.py
+++ b/packages/qdrant-loader/tests/scripts/check_worker_pool.py
@@ -71,17 +71,18 @@ async def main() -> None:
             job_type, source, seq, active_total, active_by_source[source]
         )
 
-        await asyncio.sleep(0.05)
+        try:
+            await asyncio.sleep(0.05)
 
-        if args.fail_every > 0 and seq % args.fail_every == 0:
-            raise RuntimeError(f"forced failure for seq={seq}")
+            if args.fail_every > 0 and seq % args.fail_every == 0:
+                raise RuntimeError(f"forced failure for seq={seq}")
 
-        elapsed_ms = int((time.perf_counter() - start) * 1000)
-        LOG.info("END   source=%s seq=%s elapsed_ms=%s", source, seq, elapsed_ms)
-
-        async with guard:
-            active_total -= 1
-            active_by_source[source] -= 1
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            LOG.info("END   source=%s seq=%s elapsed_ms=%s", source, seq, elapsed_ms)
+        finally:
+            async with guard:
+                active_total -= 1
+                active_by_source[source] -= 1
 
     # 2) Configure worker_count here
     pool = QueueWorkerPool(

--- a/packages/qdrant-loader/tests/scripts/check_worker_pool.py
+++ b/packages/qdrant-loader/tests/scripts/check_worker_pool.py
@@ -17,6 +17,7 @@ from qdrant_loader.core.worker.queue import SQLiteJobQueue
 
 LOG = logging.getLogger("qa.worker.pool")
 
+
 async def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--db", default="qa_worker_pool.db")
@@ -68,7 +69,11 @@ async def main() -> None:
 
         LOG.info(
             "START job_type=%s source=%s seq=%s active_total=%s active_source=%s",
-            job_type, source, seq, active_total, active_by_source[source]
+            job_type,
+            source,
+            seq,
+            active_total,
+            active_by_source[source],
         )
 
         try:
@@ -97,8 +102,13 @@ async def main() -> None:
     failed = await queue.list(status=SQLiteJobQueue.FAILED, limit=100000)
     running = await queue.list(status=SQLiteJobQueue.RUNNING, limit=100000)
 
-    LOG.info("SUMMARY processed=%s done=%s failed=%s running=%s",
-             processed, len(done), len(failed), len(running))
+    LOG.info(
+        "SUMMARY processed=%s done=%s failed=%s running=%s",
+        processed,
+        len(done),
+        len(failed),
+        len(running),
+    )
     LOG.info("SUMMARY max_active_total=%s", max_active_total)
 
     # Print per-source max concurrency for QA evidence
@@ -106,6 +116,7 @@ async def main() -> None:
         LOG.info("SUMMARY source=%s max_active=%s", src, max_by_source[src])
 
     await dispose_engine(engine)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/packages/qdrant-loader/tests/scripts/check_worker_pool.py
+++ b/packages/qdrant-loader/tests/scripts/check_worker_pool.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+from qdrant_loader.config.state import StateManagementConfig
+from qdrant_loader.core.state.session import (
+    create_tables,
+    dispose_engine,
+    initialize_engine_and_session,
+)
+from qdrant_loader.core.worker.pool import QueueWorkerPool
+from qdrant_loader.core.worker.queue import SQLiteJobQueue
+
+LOG = logging.getLogger("qa.worker.pool")
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default="qa_worker_pool.db")
+    parser.add_argument("--jobs", type=int, default=40)
+    parser.add_argument("--worker-count", type=int, default=4)
+    parser.add_argument("--lease-seconds", type=int, default=60)
+    parser.add_argument("--same-source", action="store_true")
+    parser.add_argument("--fail-every", type=int, default=0)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
+
+    db_path = Path(args.db).resolve()
+    cfg = StateManagementConfig(database_path=str(db_path))
+    engine, session_factory = initialize_engine_and_session(cfg)
+    await create_tables(engine)
+    queue = SQLiteJobQueue(session_factory)
+
+    # 1) Prepare jobs
+    for i in range(args.jobs):
+        if args.same_source:
+            source = "jira-main"
+        else:
+            source = f"source-{i % 10}"
+        payload = {"source": source, "seq": i}
+        await queue.enqueue("INCREMENTAL_PULL", payload)
+
+    active_total = 0
+    max_active_total = 0
+    active_by_source: dict[str, int] = {}
+    max_by_source: dict[str, int] = {}
+    guard = asyncio.Lock()
+
+    async def handler(job_type: str, payload: dict) -> None:
+        nonlocal active_total, max_active_total
+        source = str(payload.get("source", "unknown"))
+        seq = int(payload.get("seq", -1))
+        start = time.perf_counter()
+
+        async with guard:
+            active_total += 1
+            max_active_total = max(max_active_total, active_total)
+            now_active_src = active_by_source.get(source, 0) + 1
+            active_by_source[source] = now_active_src
+            max_by_source[source] = max(max_by_source.get(source, 0), now_active_src)
+
+        LOG.info(
+            "START job_type=%s source=%s seq=%s active_total=%s active_source=%s",
+            job_type, source, seq, active_total, active_by_source[source]
+        )
+
+        await asyncio.sleep(0.05)
+
+        if args.fail_every > 0 and seq % args.fail_every == 0:
+            raise RuntimeError(f"forced failure for seq={seq}")
+
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        LOG.info("END   source=%s seq=%s elapsed_ms=%s", source, seq, elapsed_ms)
+
+        async with guard:
+            active_total -= 1
+            active_by_source[source] -= 1
+
+    # 2) Configure worker_count here
+    pool = QueueWorkerPool(
+        queue=queue,
+        handler=handler,
+        worker_count=args.worker_count,
+        lease_seconds=args.lease_seconds,
+    )
+
+    processed = await pool.run_until_empty()
+    done = await queue.list(status=SQLiteJobQueue.DONE, limit=100000)
+    failed = await queue.list(status=SQLiteJobQueue.FAILED, limit=100000)
+    running = await queue.list(status=SQLiteJobQueue.RUNNING, limit=100000)
+
+    LOG.info("SUMMARY processed=%s done=%s failed=%s running=%s",
+             processed, len(done), len(failed), len(running))
+    LOG.info("SUMMARY max_active_total=%s", max_active_total)
+
+    # Print per-source max concurrency for QA evidence
+    for src in sorted(max_by_source.keys()):
+        LOG.info("SUMMARY source=%s max_active=%s", src, max_by_source[src])
+
+    await dispose_engine(engine)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from qdrant_loader.config.state import StateManagementConfig
+from qdrant_loader.core.state.session import (
+    create_tables,
+    dispose_engine,
+    initialize_engine_and_session,
+)
+from qdrant_loader.core.worker.pool import QueueWorkerPool
+from qdrant_loader.core.worker.queue import SQLiteJobQueue
+
+
+@pytest_asyncio.fixture
+async def sqlite_job_queue(tmp_path: Path):
+    db_path = tmp_path / "worker_pool.db"
+    config = StateManagementConfig(database_path=str(db_path))
+    engine, session_factory = initialize_engine_and_session(config)
+    await create_tables(engine)
+
+    queue = SQLiteJobQueue(session_factory)
+    try:
+        yield queue
+    finally:
+        await dispose_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_processes_queue_with_four_workers(sqlite_job_queue: SQLiteJobQueue):
+    total_jobs = 100
+    for i in range(total_jobs):
+        await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": f"source-{i}"})
+
+    in_flight = 0
+    max_in_flight = 0
+    guard = asyncio.Lock()
+
+    async def handler(_job_type: str, _payload: dict[str, str]) -> None:
+        nonlocal in_flight, max_in_flight
+        async with guard:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+
+        await asyncio.sleep(0.005)
+
+        async with guard:
+            in_flight -= 1
+
+    pool = QueueWorkerPool(sqlite_job_queue, handler=handler, worker_count=4)
+    processed = await pool.run_until_empty()
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
+
+    assert processed == total_jobs
+    assert len(done_jobs) == total_jobs
+    assert len(failed_jobs) == 0
+    assert max_in_flight <= 4
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_uses_per_source_lock(sqlite_job_queue: SQLiteJobQueue):
+    total_jobs = 20
+    for _ in range(total_jobs):
+        await sqlite_job_queue.enqueue("BULK_INGEST", {"source": "jira-main"})
+
+    active_by_source: dict[str, int] = {}
+    max_by_source: dict[str, int] = {}
+    guard = asyncio.Lock()
+
+    async def handler(_job_type: str, payload: dict[str, str]) -> None:
+        source = payload["source"]
+
+        async with guard:
+            active_now = active_by_source.get(source, 0) + 1
+            active_by_source[source] = active_now
+            max_by_source[source] = max(max_by_source.get(source, 0), active_now)
+
+        await asyncio.sleep(0.005)
+
+        async with guard:
+            active_by_source[source] -= 1
+
+    pool = QueueWorkerPool(sqlite_job_queue, handler=handler, worker_count=4)
+    processed = await pool.run_until_empty()
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+
+    assert processed == total_jobs
+    assert len(done_jobs) == total_jobs
+    assert max_by_source["jira-main"] == 1

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import update
+
 from qdrant_loader.config.state import StateManagementConfig
+from qdrant_loader.core.state.models import Job
 from qdrant_loader.core.state.session import (
     create_tables,
     dispose_engine,
@@ -30,7 +34,9 @@ async def sqlite_job_queue(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_worker_pool_processes_queue_with_four_workers(sqlite_job_queue: SQLiteJobQueue):
+async def test_worker_pool_processes_queue_with_four_workers(
+    sqlite_job_queue: SQLiteJobQueue,
+):
     total_jobs = 100
     for i in range(total_jobs):
         await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": f"source-{i}"})
@@ -98,12 +104,131 @@ async def test_worker_pool_uses_per_source_lock(sqlite_job_queue: SQLiteJobQueue
 
 
 @pytest.mark.asyncio
-async def test_worker_pool_rejects_invalid_lease_seconds(sqlite_job_queue: SQLiteJobQueue):
+async def test_worker_pool_rejects_invalid_lease_seconds(
+    sqlite_job_queue: SQLiteJobQueue,
+):
     async def handler(_job_type: str, _payload: dict[str, str]) -> None:
         return None
 
     with pytest.raises(ValueError, match="lease_seconds must be >= 1"):
         QueueWorkerPool(sqlite_job_queue, handler=handler, lease_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_retries_transient_errors_until_success(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "jira-main"})
+
+    attempts = 0
+
+    async def handler(_job_type: str, _payload: dict[str, str]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise RuntimeError("temporary jira 502")
+
+    pool = QueueWorkerPool(
+        sqlite_job_queue,
+        handler=handler,
+        worker_count=1,
+        max_attempts=3,
+    )
+    processed = await pool.run_until_empty()
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
+
+    assert processed == 3
+    assert attempts == 3
+    assert len(done_jobs) == 1
+    assert len(failed_jobs) == 0
+    assert done_jobs[0].attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_marks_failed_after_max_attempts_exhausted(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "jira-main"})
+
+    async def handler(_job_type: str, _payload: dict[str, str]) -> None:
+        raise RuntimeError("always failing")
+
+    pool = QueueWorkerPool(
+        sqlite_job_queue,
+        handler=handler,
+        worker_count=1,
+        max_attempts=2,
+    )
+    processed = await pool.run_until_empty()
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
+
+    assert processed == 2
+    assert len(done_jobs) == 0
+    assert len(failed_jobs) == 1
+    assert failed_jobs[0].attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_rejects_invalid_max_attempts(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    async def handler(_job_type: str, _payload: dict[str, str]) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="max_attempts must be >= 1"):
+        QueueWorkerPool(sqlite_job_queue, handler=handler, max_attempts=0)
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_reclaims_job_after_visibility_timeout(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """WS-4 AC: Container killed mid-run, restarted — interrupted job picked up
+    after visibility timeout expires.
+
+    Simulates a job that was claimed and set to RUNNING (e.g. by a previous
+    container that died) with an already-expired visibility_deadline.
+    The pool must reclaim and complete it without manual intervention.
+    """
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "jira-main"})
+
+    # Simulate a previous container that claimed the job but never finished:
+    # set status=RUNNING with a visibility_deadline in the past.
+    past_deadline = datetime.now(UTC) - timedelta(seconds=10)
+    async with sqlite_job_queue._session_factory() as session:
+        await session.execute(
+            update(Job)
+            .where(Job.id == job.id)
+            .values(
+                status=SQLiteJobQueue.RUNNING,
+                started_at=datetime.now(UTC) - timedelta(seconds=70),
+                visibility_deadline=past_deadline,
+                attempts=1,
+            )
+        )
+        await session.commit()
+
+    completed = []
+
+    async def handler(job_type: str, payload: dict) -> None:
+        completed.append(payload["source"])
+
+    pool = QueueWorkerPool(sqlite_job_queue, handler=handler, worker_count=2)
+    processed = await pool.run_until_empty()
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    running_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.RUNNING)
+
+    assert processed == 1
+    assert len(done_jobs) == 1
+    assert len(running_jobs) == 0
+    assert completed == ["jira-main"]
+    # attempts incremented once more by the reclaim
+    assert done_jobs[0].attempts == 2
 
 
 def test_extract_source_key_trims_whitespace():

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -39,7 +39,9 @@ async def test_worker_pool_processes_queue_with_four_workers(
 ):
     total_jobs = 100
     for i in range(total_jobs):
-        await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": f"source-{i}"})
+        await sqlite_job_queue.enqueue(
+            "INCREMENTAL_PULL", {"source_lock": f"source-{i}"}
+        )
 
     in_flight = 0
     max_in_flight = 0
@@ -73,14 +75,14 @@ async def test_worker_pool_uses_per_source_lock(sqlite_job_queue: SQLiteJobQueue
     total_jobs = 20
     sources = ("jira-main", "confluence-main")
     for i in range(total_jobs):
-        await sqlite_job_queue.enqueue("BULK_INGEST", {"source": sources[i % 2]})
+        await sqlite_job_queue.enqueue("BULK_INGEST", {"source_lock": sources[i % 2]})
 
     active_by_source: dict[str, int] = {}
     max_by_source: dict[str, int] = {}
     guard = asyncio.Lock()
 
     async def handler(_job_type: str, payload: dict[str, str]) -> None:
-        source = payload["source"]
+        source = payload["source_lock"]
 
         async with guard:
             active_now = active_by_source.get(source, 0) + 1
@@ -118,7 +120,7 @@ async def test_worker_pool_rejects_invalid_lease_seconds(
 async def test_worker_pool_retries_transient_errors_until_success(
     sqlite_job_queue: SQLiteJobQueue,
 ):
-    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "jira-main"})
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source_lock": "jira-main"})
 
     attempts = 0
 
@@ -150,7 +152,7 @@ async def test_worker_pool_retries_transient_errors_until_success(
 async def test_worker_pool_marks_failed_after_max_attempts_exhausted(
     sqlite_job_queue: SQLiteJobQueue,
 ):
-    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "jira-main"})
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source_lock": "jira-main"})
 
     async def handler(_job_type: str, _payload: dict[str, str]) -> None:
         raise RuntimeError("always failing")
@@ -194,7 +196,9 @@ async def test_worker_pool_reclaims_job_after_visibility_timeout(
     container that died) with an already-expired visibility_deadline.
     The pool must reclaim and complete it without manual intervention.
     """
-    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "jira-main"})
+    job = await sqlite_job_queue.enqueue(
+        "INCREMENTAL_PULL", {"source_lock": "jira-main"}
+    )
 
     # Simulate a previous container that claimed the job but never finished:
     # set status=RUNNING with a visibility_deadline in the past.
@@ -215,7 +219,7 @@ async def test_worker_pool_reclaims_job_after_visibility_timeout(
     completed = []
 
     async def handler(job_type: str, payload: dict) -> None:
-        completed.append(payload["source"])
+        completed.append(payload["source_lock"])
 
     pool = QueueWorkerPool(sqlite_job_queue, handler=handler, worker_count=2)
     processed = await pool.run_until_empty()
@@ -232,5 +236,28 @@ async def test_worker_pool_reclaims_job_after_visibility_timeout(
 
 
 def test_extract_source_key_trims_whitespace():
-    key = QueueWorkerPool._extract_source_key({"source": "  jira-main  "})
+    key = QueueWorkerPool._extract_source_key({"source_lock": "  jira-main  "})
     assert key == "jira-main"
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_marks_failed_for_missing_source_lock(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """A job payload without source_lock must be marked FAILED immediately;
+    the pool must not crash or fall back to a global serialization key."""
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "jira-main"})
+
+    async def handler(_job_type: str, _payload: dict) -> None:  # pragma: no cover
+        pass
+
+    pool = QueueWorkerPool(sqlite_job_queue, handler=handler, worker_count=1)
+    processed = await pool.run_until_empty()
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
+
+    assert processed == 1
+    assert len(done_jobs) == 0
+    assert len(failed_jobs) == 1
+    assert "source_lock" in failed_jobs[0].last_error

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -65,8 +65,9 @@ async def test_worker_pool_processes_queue_with_four_workers(sqlite_job_queue: S
 @pytest.mark.asyncio
 async def test_worker_pool_uses_per_source_lock(sqlite_job_queue: SQLiteJobQueue):
     total_jobs = 20
-    for _ in range(total_jobs):
-        await sqlite_job_queue.enqueue("BULK_INGEST", {"source": "jira-main"})
+    sources = ("jira-main", "confluence-main")
+    for i in range(total_jobs):
+        await sqlite_job_queue.enqueue("BULK_INGEST", {"source": sources[i % 2]})
 
     active_by_source: dict[str, int] = {}
     max_by_source: dict[str, int] = {}
@@ -93,3 +94,18 @@ async def test_worker_pool_uses_per_source_lock(sqlite_job_queue: SQLiteJobQueue
     assert processed == total_jobs
     assert len(done_jobs) == total_jobs
     assert max_by_source["jira-main"] == 1
+    assert max_by_source["confluence-main"] == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_rejects_invalid_lease_seconds(sqlite_job_queue: SQLiteJobQueue):
+    async def handler(_job_type: str, _payload: dict[str, str]) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="lease_seconds must be >= 1"):
+        QueueWorkerPool(sqlite_job_queue, handler=handler, lease_seconds=0)
+
+
+def test_extract_source_key_trims_whitespace():
+    key = QueueWorkerPool._extract_source_key({"source": "  jira-main  "})
+    assert key == "jira-main"

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -166,3 +166,54 @@ async def test_mark_done_rejects_stale_claim_attempt(sqlite_job_queue: SQLiteJob
         job.id, claim_attempt=second_claim.attempts
     )
     assert fresh_update is True
+
+
+@pytest.mark.asyncio
+async def test_release_for_retry_requeues_without_incrementing_attempts(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
+
+    first_claim = await sqlite_job_queue.claim_next(lease_seconds=30)
+    assert first_claim is not None
+    assert first_claim.id == job.id
+    assert first_claim.attempts == 1
+
+    released = await sqlite_job_queue.release_for_retry(
+        job.id,
+        "transient network error",
+        claim_attempt=first_claim.attempts,
+    )
+    assert released is True
+
+    second_claim = await sqlite_job_queue.claim_next(lease_seconds=30)
+    assert second_claim is not None
+    assert second_claim.id == job.id
+    assert second_claim.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_release_for_retry_with_delay_hides_pending_job_until_due(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
+
+    claimed = await sqlite_job_queue.claim_next(lease_seconds=30)
+    assert claimed is not None
+    assert claimed.id == job.id
+
+    released = await sqlite_job_queue.release_for_retry(
+        job.id,
+        "transient timeout",
+        claim_attempt=claimed.attempts,
+        retry_after_seconds=1,
+    )
+    assert released is True
+
+    hidden = await sqlite_job_queue.claim_next(lease_seconds=30)
+    assert hidden is None
+
+    await asyncio.sleep(1.05)
+    due = await sqlite_job_queue.claim_next(lease_seconds=30)
+    assert due is not None
+    assert due.id == job.id


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Connectors/pipeline stages: No connector or pipeline-stage code modified. Adds core worker utility (QueueWorkerPool), handler abstractions (JobHandler, BaseJobHandler, HandlerRegistry) and extends JobQueue API (release_for_retry) / SQLiteJobQueue — exported but not yet wired into existing pipelines.

Config schema changes: No breaking schema changes. New runtime options are constructor parameters (worker_count, lease_seconds, max_attempts, retry_backoff_base_seconds) — additive and local to the pool.

Test coverage: Yes — extensive async unit tests plus a QA script cover global worker concurrency, per-source serialization, payload validation, missing/invalid source_lock handling, retry/backoff semantics, visibility/lease reclaiming, and release_for_retry behavior.

Security / resource-safety concerns: Per-source asyncio.Locking and queue I/O guards reduce race conditions; malformed payloads are failed fast. SQLite-backed queue implies single-process semantics—multi-process/multi-node coordination, DB scaling, and production visibility/locking guarantees require review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->