### PR TITLE
fix: resolve Alembic DB URL from Settings via wrapper script

### DIFF
--- a/docs/developers/cli/README.md
+++ b/docs/developers/cli/README.md
@@ -9,6 +9,7 @@ This document provides comprehensive reference for developing with the QDrant Lo
 - [Configuration](#-configuration)
 - [Exit Codes](#exit-codes)
 - [Development Patterns](#-development-patterns)
+- [Database Migrations](#-database-migrations)
 - [Testing](#-testing)
 
 ## 🚀 Main CLI Commands
@@ -366,6 +367,63 @@ qdrant-loader config --workspace . --format json
 qdrant-loader config --workspace .
 # Run ingestion with debug logging and profiling
 qdrant-loader --log-level DEBUG --workspace . ingest --profile
+```
+
+## 🗄️ Database Migrations
+
+QDrant Loader uses Alembic to manage SQLite schema migrations. Always run migrations through the provided wrapper script so the correct database path is resolved automatically from Settings (workspace/config/env aware).
+
+> **Important**: Do **not** run `python -m alembic -c alembic.ini ...` directly unless you manually export `STATE_DB_PATH` first. The direct command uses the fallback path in `alembic.ini`, which may not match your actual configured database.
+
+### Upgrade to Latest Schema
+
+```bash
+# Workspace mode (recommended)
+python scripts/alembic_with_settings.py --workspace . -- upgrade head
+
+# Non-workspace mode (uses config.yaml in current directory)
+python scripts/alembic_with_settings.py -- upgrade head
+
+# Non-workspace mode with explicit config and env files
+python scripts/alembic_with_settings.py --config path/to/config.yaml --env path/to/.env -- upgrade head
+```
+
+### Check Current Migration Revision
+
+```bash
+# Workspace mode
+python scripts/alembic_with_settings.py --workspace . -- current
+
+# Non-workspace mode
+python scripts/alembic_with_settings.py -- current
+```
+
+### How It Works
+
+The wrapper (`scripts/alembic_with_settings.py`):
+
+1. Loads Settings using the same mode/config/env as the app (`initialize_config` / `initialize_config_with_workspace`).
+2. Reads the resolved `database_path` from `settings.global_config.state_management.database_path`.
+3. Sets `STATE_DB_PATH` for the child Alembic process.
+4. Runs Alembic with the correct database path.
+
+| Mode | Resolved DB Path |
+|------|------------------|
+| Workspace (`--workspace .`) | `<workspace>/data/qdrant-loader.db` |
+| Non-workspace, config sets path directly | value from `global.state_management.database_path` in `config.yaml` |
+| Non-workspace, config uses `${STATE_DB_PATH}` | value of `STATE_DB_PATH` env var |
+| Non-workspace, no config/env | `./state.db` (default) |
+
+### Migration Script Options
+
+```bash
+python scripts/alembic_with_settings.py [OPTIONS] -- [ALEMBIC_ARGS]
+
+Options:
+  --workspace PATH     Workspace directory containing config.yaml and optional .env
+  --config PATH        Path to config.yaml (non-workspace mode)
+  --env PATH           Path to .env file (non-workspace mode)
+  --alembic-config     Path to alembic.ini (default: packages/qdrant-loader/alembic.ini)
 ```
 
 ## 🧪 Testing

--- a/packages/qdrant-loader/alembic.ini
+++ b/packages/qdrant-loader/alembic.ini
@@ -2,7 +2,7 @@
 script_location = migrations
 prepend_sys_path = .
 path_separator = os
-sqlalchemy.url = sqlite:///../../data/qdrant-loader.db
+sqlalchemy.url = sqlite:///../../state.db
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -50,8 +50,14 @@ def _deterministic_sqlalchemy_url() -> str:
         if _is_special_sqlite_form(raw_path):
             return configured_url
 
-        if raw_path and not Path(raw_path).is_absolute() and config.config_file_name is not None:
-            resolved = (Path(config.config_file_name).resolve().parent / raw_path).resolve()
+        if (
+            raw_path
+            and not Path(raw_path).is_absolute()
+            and config.config_file_name is not None
+        ):
+            resolved = (
+                Path(config.config_file_name).resolve().parent / raw_path
+            ).resolve()
             return str(parsed.set(database=resolved.as_posix()))
 
     return configured_url

--- a/scripts/alembic_with_settings.py
+++ b/scripts/alembic_with_settings.py
@@ -17,16 +17,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "alembic_args",
         nargs=argparse.REMAINDER,
-        help=(
-            "Arguments passed to Alembic, e.g.: upgrade head, current, history"
-        ),
+        help=("Arguments passed to Alembic, e.g.: upgrade head, current, history"),
     )
     parser.add_argument(
         "--workspace",
         type=Path,
         help="Workspace directory containing config.yaml and optional .env",
     )
-    parser.add_argument("--config", dest="config_path", type=Path, help="Path to config.yaml")
+    parser.add_argument(
+        "--config", dest="config_path", type=Path, help="Path to config.yaml"
+    )
     parser.add_argument("--env", dest="env_path", type=Path, help="Path to .env file")
     parser.add_argument(
         "--alembic-config",
@@ -38,7 +38,9 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _resolve_state_db_path(workspace: Path | None, config_path: Path | None, env_path: Path | None) -> str:
+def _resolve_state_db_path(
+    workspace: Path | None, config_path: Path | None, env_path: Path | None
+) -> str:
     repo_root = Path(__file__).resolve().parent.parent
     package_root = repo_root / "packages" / "qdrant-loader"
     src_path = package_root / "src"
@@ -46,8 +48,17 @@ def _resolve_state_db_path(workspace: Path | None, config_path: Path | None, env
     if str(src_path) not in sys.path:
         sys.path.insert(0, str(src_path))
 
-    from qdrant_loader.cli.config_loader import load_config_with_workspace, setup_workspace
-    from qdrant_loader.config import get_settings
+    try:
+        from qdrant_loader.cli.config_loader import (
+            load_config_with_workspace,
+            setup_workspace,
+        )
+        from qdrant_loader.config import get_settings
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise RuntimeError(
+            "Failed to import qdrant_loader settings modules; "
+            f"check package installation and sys.path (expected source path: {src_path})"
+        ) from exc
 
     workspace_config = setup_workspace(workspace) if workspace else None
 
@@ -70,7 +81,12 @@ def _resolve_state_db_path(workspace: Path | None, config_path: Path | None, env
     )
 
     settings = get_settings()
-    return settings.global_config.state_management.database_path
+    try:
+        return settings.global_config.state_management.database_path
+    except (AttributeError, TypeError) as exc:
+        raise RuntimeError(
+            "Invalid settings structure: missing global_config.state_management.database_path"
+        ) from exc
 
 
 def main() -> int:
@@ -84,6 +100,8 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     package_root = repo_root / "packages" / "qdrant-loader"
     alembic_config = args.alembic_config.resolve()
+    if not alembic_config.exists() or not alembic_config.is_file():
+        raise SystemExit(f"Alembic config file not found: {alembic_config}")
 
     if args.workspace and (args.config_path or args.env_path):
         parser.error("Cannot combine --workspace with --config/--env")

--- a/scripts/alembic_with_settings.py
+++ b/scripts/alembic_with_settings.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Alembic using DB path resolved from qdrant-loader Settings "
+            "(workspace/config/env aware)."
+        )
+    )
+    parser.add_argument(
+        "alembic_args",
+        nargs=argparse.REMAINDER,
+        help=(
+            "Arguments passed to Alembic, e.g.: upgrade head, current, history"
+        ),
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        help="Workspace directory containing config.yaml and optional .env",
+    )
+    parser.add_argument("--config", dest="config_path", type=Path, help="Path to config.yaml")
+    parser.add_argument("--env", dest="env_path", type=Path, help="Path to .env file")
+    parser.add_argument(
+        "--alembic-config",
+        dest="alembic_config",
+        type=Path,
+        default=Path("packages/qdrant-loader/alembic.ini"),
+        help="Path to alembic.ini (default: packages/qdrant-loader/alembic.ini)",
+    )
+    return parser
+
+
+def _resolve_state_db_path(workspace: Path | None, config_path: Path | None, env_path: Path | None) -> str:
+    repo_root = Path(__file__).resolve().parent.parent
+    package_root = repo_root / "packages" / "qdrant-loader"
+    src_path = package_root / "src"
+
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+    from qdrant_loader.cli.config_loader import load_config_with_workspace, setup_workspace
+    from qdrant_loader.config import get_settings
+
+    workspace_config = setup_workspace(workspace) if workspace else None
+
+    resolved_config = config_path
+    if resolved_config is None and workspace is None:
+        default_config = repo_root / "config.yaml"
+        if default_config.exists():
+            resolved_config = default_config
+
+    if resolved_config is not None:
+        resolved_config = resolved_config.resolve()
+    if env_path is not None:
+        env_path = env_path.resolve()
+
+    load_config_with_workspace(
+        workspace_config=workspace_config,
+        config_path=resolved_config,
+        env_path=env_path,
+        skip_validation=False,
+    )
+
+    settings = get_settings()
+    return settings.global_config.state_management.database_path
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    alembic_args = args.alembic_args or ["upgrade", "head"]
+    if alembic_args and alembic_args[0] == "--":
+        alembic_args = alembic_args[1:]
+
+    repo_root = Path(__file__).resolve().parent.parent
+    package_root = repo_root / "packages" / "qdrant-loader"
+    alembic_config = args.alembic_config.resolve()
+
+    if args.workspace and (args.config_path or args.env_path):
+        parser.error("Cannot combine --workspace with --config/--env")
+
+    db_path = _resolve_state_db_path(args.workspace, args.config_path, args.env_path)
+
+    child_env = os.environ.copy()
+    child_env["STATE_DB_PATH"] = db_path
+
+    cmd = [sys.executable, "-m", "alembic", "-c", str(alembic_config), *alembic_args]
+    print(f"Resolved STATE_DB_PATH={db_path}")
+    print("Running:", " ".join(cmd))
+
+    result = subprocess.run(cmd, cwd=package_root, env=child_env)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Pull Request

## Summary

add wrapper to run Alembic with dynamic database path

## Type of change

- [ ] Feature
- [x] Bug fix
- [x] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Connectors/Pipeline**: No connector or pipeline-stage code changed. This PR adds an Alembic wrapper and migration to manage a new jobs table used by state management (packages/qdrant-loader/migrations/versions/20260514_01_create_jobs_table.py).

**Config Schema**: No breaking schema changes. The wrapper reads the existing settings.global_config.state_management.database_path (and environment STATE_DB_PATH); alembic.ini default points to ./state.db. Config usage is additive/compatible with existing StateManagementConfig.

**Test Coverage**: Tests exist covering migrations (packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py) and config resolution; the PR adds no new test results and checklist items (tests/lint/docs) remain unchecked.

**Security/Resource Safety**: Wrapper enforces config validation (skip_validation=False) and sets STATE_DB_PATH for the subprocess. Path resolution is defensive; no direct SQL construction from untrusted input observed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->