### PR TITLE
fix: support DB URL env + redact credentials in logs

### DIFF
--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -30,8 +30,16 @@ def _is_special_sqlite_form(raw_path: str) -> bool:
 
 def _deterministic_sqlalchemy_url() -> str:
     """Resolve DB URL consistently regardless of current working directory."""
+    state_db_url = os.getenv("STATE_DB_URL")
+    if state_db_url:
+        return state_db_url
+
     state_db_path = os.getenv("STATE_DB_PATH")
     if state_db_path:
+        # Backward compatibility: allow either legacy path values or full DSNs.
+        if "://" in state_db_path:
+            return state_db_path
+
         if _is_special_sqlite_form(state_db_path):
             return f"sqlite:///{state_db_path}"
 

--- a/scripts/alembic_with_settings.py
+++ b/scripts/alembic_with_settings.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -89,6 +90,59 @@ def _resolve_state_db_path(
         ) from exc
 
 
+def _is_special_sqlite_form(raw_path: str) -> bool:
+    raw_path_lower = raw_path.lower()
+    if raw_path == ":memory:":
+        return True
+    return raw_path_lower.startswith("file:") and (
+        "mode=memory" in raw_path_lower or "memory" in raw_path_lower
+    )
+
+
+def _to_sqlalchemy_database_url(database_value: str) -> str:
+    """Convert configured database value into a SQLAlchemy URL.
+
+    Accepts either a full DSN (e.g. postgresql+asyncpg://...) or a SQLite
+    filesystem path (existing behavior).
+    """
+    raw_value = database_value.strip()
+    if not raw_value:
+        raise RuntimeError("Resolved empty database value from settings")
+
+    if "://" in raw_value:
+        return raw_value
+
+    if _is_special_sqlite_form(raw_value):
+        return f"sqlite:///{raw_value}"
+
+    candidate = Path(raw_value).expanduser()
+    return f"sqlite:///{candidate.resolve().as_posix()}"
+
+
+def _redact_database_url(database_url: str) -> str:
+    """Redact credentials in DSN-style database URLs before logging."""
+    try:
+        parts = urlsplit(database_url)
+    except ValueError:
+        return database_url
+
+    if not parts.scheme or not parts.netloc:
+        return database_url
+
+    if "@" not in parts.netloc:
+        return database_url
+
+    userinfo, hostinfo = parts.netloc.rsplit("@", 1)
+    if ":" not in userinfo:
+        return database_url
+
+    username, _password = userinfo.split(":", 1)
+    redacted_netloc = f"{username}:***@{hostinfo}"
+    return urlunsplit(
+        (parts.scheme, redacted_netloc, parts.path, parts.query, parts.fragment)
+    )
+
+
 def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
@@ -106,13 +160,16 @@ def main() -> int:
     if args.workspace and (args.config_path or args.env_path):
         parser.error("Cannot combine --workspace with --config/--env")
 
-    db_path = _resolve_state_db_path(args.workspace, args.config_path, args.env_path)
+    database_value = _resolve_state_db_path(
+        args.workspace, args.config_path, args.env_path
+    )
+    database_url = _to_sqlalchemy_database_url(database_value)
 
     child_env = os.environ.copy()
-    child_env["STATE_DB_PATH"] = db_path
+    child_env["STATE_DB_URL"] = database_url
 
     cmd = [sys.executable, "-m", "alembic", "-c", str(alembic_config), *alembic_args]
-    print(f"Resolved STATE_DB_PATH={db_path}")
+    print(f"Resolved STATE_DB_URL={_redact_database_url(database_url)}")
     print("Running:", " ".join(cmd))
 
     result = subprocess.run(cmd, cwd=package_root, env=child_env)


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected Components & Connectors

The changes impact **state management/database migrations only**. Core data connectors (Git, Jira, Confluence, etc.) are unaffected. Modifications are isolated to:
- `packages/qdrant-loader/migrations/env.py` (Alembic environment)
- `scripts/alembic_with_settings.py` (migration runner)

## Config Schema Changes

**Additive, non-breaking:**
- New `STATE_DB_URL` environment variable becomes the preferred method for passing database configuration to Alembic
- `STATE_DB_PATH` remains supported for backward compatibility; `STATE_DB_URL` takes precedence
- New support for full DSN URLs (e.g., `postgresql+asyncpg://`) alongside existing SQLite paths
- Automatic conversion from filesystem paths to `sqlite:///` URLs

## Test Coverage

**Gap identified:** No dedicated unit tests found for:
- `_redact_database_url()` credential masking function
- `_to_sqlalchemy_database_url()` URL conversion utility
- New `STATE_DB_URL` environment variable handling in alembic_with_settings

Existing migration smoke test (`test_migrations_smoke.py`) explicitly clears `STATE_DB_PATH` but doesn't verify the new URL handling paths.

## Security & Resource Concerns

**Positive:** Credential redaction properly masks passwords in DSN URLs before logging (format: `scheme://username:***`@host/path``).

**Limitation:** Redaction is implemented only in the print statement within alembic_with_settings.py. URLs logged through the standard logging system elsewhere may bypass redaction unless they pass through existing log processors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->