### PR TITLE
feat: add concrete ingestion handler with bulk and incremental dispatch

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -1,6 +1,7 @@
 """Main orchestrator for the ingestion pipeline."""
 
 import traceback
+from datetime import datetime
 
 from qdrant_loader.config import Settings, SourcesConfig
 from qdrant_loader.connectors.base import ConnectorConfigurationError
@@ -57,6 +58,7 @@ class PipelineOrchestrator:
         source: str | None = None,
         project_id: str | None = None,
         force: bool = False,
+        since: datetime | None = None,
     ) -> list[Document]:
         """Main entry point for document processing.
 
@@ -66,6 +68,10 @@ class PipelineOrchestrator:
             source: Filter by specific source name
             project_id: Process documents for a specific project
             force: Force processing of all documents, bypassing change detection
+            since: Only collect documents updated after this timestamp (connector-level
+                filtering). Connectors that do not yet support time-based filtering will
+                fall back to fetching all documents and relying on hash-based change
+                detection.
 
         Returns:
             List of processed documents
@@ -113,7 +119,7 @@ class PipelineOrchestrator:
                     )
 
                 logger.debug("Processing all projects")
-                return await self._process_all_projects(source_type, source, force)
+                return await self._process_all_projects(source_type, source, force, since)
 
             # Check if filtered config is empty
             if source_type and not any(
@@ -129,7 +135,7 @@ class PipelineOrchestrator:
 
             # Collect documents from all sources
             documents = await self._collect_documents_from_sources(
-                filtered_config, current_project_id
+                filtered_config, current_project_id, since
             )
 
             if not documents:
@@ -179,6 +185,7 @@ class PipelineOrchestrator:
         source_type: str | None = None,
         source: str | None = None,
         force: bool = False,
+        since: datetime | None = None,
     ) -> list[Document]:
         """Process documents from all configured projects."""
         if not self.project_manager:
@@ -199,6 +206,7 @@ class PipelineOrchestrator:
                     source_type=source_type,
                     source=source,
                     force=force,
+                    since=since,
                 )
                 project_result = self.last_pipeline_result
                 all_documents.extend(project_documents)
@@ -276,9 +284,18 @@ class PipelineOrchestrator:
         return all_documents
 
     async def _collect_documents_from_sources(
-        self, filtered_config: SourcesConfig, project_id: str | None = None
+        self,
+        filtered_config: SourcesConfig,
+        project_id: str | None = None,
+        since: datetime | None = None,
     ) -> list[Document]:
         """Collect documents from all configured sources."""
+        if since is not None:
+            logger.warning(
+                "since parameter is set but connector-level time filtering is not yet "
+                "implemented; falling back to full fetch with hash-based change detection",
+                since=since.isoformat(),
+            )
         documents = []
 
         # Process each source type with project context

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
@@ -3,6 +3,7 @@
 from qdrant_loader.core.worker.handlers import (
     BaseJobHandler,
     HandlerRegistry,
+    IngestionJobHandler,
     JobHandler,
     PermanentJobError,
     TransientJobError,
@@ -19,6 +20,7 @@ __all__ = [
     # Handlers
     "JobHandler",
     "BaseJobHandler",
+    "IngestionJobHandler",
     "HandlerRegistry",
     "TransientJobError",
     "PermanentJobError",

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
@@ -3,12 +3,44 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import Any, Protocol
 
+from qdrant_loader.core.state.transitions import get_last_ingestion
 from qdrant_loader.utils.logging import LoggingConfig
 
 logger = LoggingConfig.get_logger(__name__)
+
+AsyncSessionFactory = Callable[[], Awaitable[Any]]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions (defined first — used by classes below)
+# ---------------------------------------------------------------------------
+
+
+class JobHandlerError(Exception):
+    """Base exception for job handler errors."""
+
+    pass
+
+
+class TransientJobError(JobHandlerError):
+    """Transient error (may succeed on retry)."""
+
+    pass
+
+
+class PermanentJobError(JobHandlerError):
+    """Permanent error (will not succeed on retry)."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Protocol / Abstract base
+# ---------------------------------------------------------------------------
 
 
 class JobHandler(Protocol):
@@ -49,6 +81,11 @@ class BaseJobHandler(ABC):
         return last_ingestion - timedelta(minutes=5)
 
 
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
 class HandlerRegistry:
     """Registry for mapping job types to handler implementations."""
 
@@ -75,19 +112,65 @@ class HandlerRegistry:
         return {jt: h.__class__.__name__ for jt, h in self._handlers.items()}
 
 
-class JobHandlerError(Exception):
-    """Base exception for job handler errors."""
-
-    pass
-
-
-class TransientJobError(JobHandlerError):
-    """Transient error (may succeed on retry)."""
-
-    pass
+# ---------------------------------------------------------------------------
+# Concrete handler
+# ---------------------------------------------------------------------------
 
 
-class PermanentJobError(JobHandlerError):
-    """Permanent error (will not succeed on retry)."""
+class IngestionJobHandler(BaseJobHandler):
+    """Concrete handler for BULK_INGEST and INCREMENTAL_PULL jobs.
 
-    pass
+    Delegates to PipelineOrchestrator for document processing.
+    """
+
+    def __init__(
+        self,
+        orchestrator: Any,
+        session_factory: AsyncSessionFactory,
+    ) -> None:
+        self._orchestrator = orchestrator
+        self._session_factory = session_factory
+
+    async def handle_bulk_ingest(self, payload: dict[str, Any]) -> None:
+        """Run a full ingestion for the source, bypassing change detection."""
+        try:
+            await self._orchestrator.process_documents(
+                source_type=payload.get("source_type"),
+                source=payload.get("source"),
+                project_id=payload.get("project_id"),
+                force=True,
+            )
+        except PermanentJobError:
+            raise
+        except Exception as exc:
+            raise TransientJobError(str(exc)) from exc
+
+    async def handle_incremental_pull(self, payload: dict[str, Any]) -> None:
+        """Run an incremental ingestion since last_ingestion - 5 min."""
+        try:
+            last = await get_last_ingestion(
+                self._session_factory,
+                source_type=payload["source_type"],
+                source=payload["source"],
+                project_id=payload.get("project_id"),
+            )
+            since = self._calculate_since_timestamp(
+                last.last_successful_ingestion if last else None
+            )
+            logger.info(
+                "incremental_pull.since",
+                source_type=payload.get("source_type"),
+                source=payload.get("source"),
+                since=since.isoformat() if since else None,
+            )
+            await self._orchestrator.process_documents(
+                source_type=payload.get("source_type"),
+                source=payload.get("source"),
+                project_id=payload.get("project_id"),
+                force=False,
+                since=since,
+            )
+        except PermanentJobError:
+            raise
+        except Exception as exc:
+            raise TransientJobError(str(exc)) from exc

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/handlers.py
@@ -131,13 +131,34 @@ class IngestionJobHandler(BaseJobHandler):
         self._orchestrator = orchestrator
         self._session_factory = session_factory
 
+    @staticmethod
+    def _validated_required_fields(payload: dict[str, Any]) -> tuple[str, str, str]:
+        """Validate required payload fields and return normalized values."""
+        required_fields = ("source_type", "source", "project_id")
+        missing_or_invalid = [
+            field
+            for field in required_fields
+            if not isinstance(payload.get(field), str) or not payload.get(field).strip()
+        ]
+        if missing_or_invalid:
+            fields = ", ".join(missing_or_invalid)
+            raise PermanentJobError(
+                f"Invalid job payload: missing or invalid required field(s): {fields}"
+            )
+
+        source_type = payload["source_type"].strip()
+        source = payload["source"].strip()
+        project_id = payload["project_id"].strip()
+        return source_type, source, project_id
+
     async def handle_bulk_ingest(self, payload: dict[str, Any]) -> None:
         """Run a full ingestion for the source, bypassing change detection."""
         try:
+            source_type, source, project_id = self._validated_required_fields(payload)
             await self._orchestrator.process_documents(
-                source_type=payload.get("source_type"),
-                source=payload.get("source"),
-                project_id=payload.get("project_id"),
+                source_type=source_type,
+                source=source,
+                project_id=project_id,
                 force=True,
             )
         except PermanentJobError:
@@ -148,25 +169,26 @@ class IngestionJobHandler(BaseJobHandler):
     async def handle_incremental_pull(self, payload: dict[str, Any]) -> None:
         """Run an incremental ingestion since last_ingestion - 5 min."""
         try:
+            source_type, source, project_id = self._validated_required_fields(payload)
             last = await get_last_ingestion(
                 self._session_factory,
-                source_type=payload["source_type"],
-                source=payload["source"],
-                project_id=payload.get("project_id"),
+                source_type=source_type,
+                source=source,
+                project_id=project_id,
             )
             since = self._calculate_since_timestamp(
                 last.last_successful_ingestion if last else None
             )
             logger.info(
                 "incremental_pull.since",
-                source_type=payload.get("source_type"),
-                source=payload.get("source"),
+                source_type=source_type,
+                source=source,
                 since=since.isoformat() if since else None,
             )
             await self._orchestrator.process_documents(
-                source_type=payload.get("source_type"),
-                source=payload.get("source"),
-                project_id=payload.get("project_id"),
+                source_type=source_type,
+                source=source,
+                project_id=project_id,
                 force=False,
                 since=since,
             )

--- a/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
+++ b/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
@@ -11,37 +11,33 @@ import pytest
 from qdrant_loader.core.worker.handlers import IngestionJobHandler
 
 
-def _setup_qdrant_loader_core_stubs():
+def _setup_qdrant_loader_core_stubs(monkeypatch: pytest.MonkeyPatch):
     """Ensure qdrant_loader_core and its submodules are importable in all environments."""
     workspace_root = Path(__file__).resolve().parents[6]
     core_src = workspace_root / "packages" / "qdrant-loader-core" / "src"
-    if str(core_src) not in sys.path:
-        sys.path.insert(0, str(core_src))
+    monkeypatch.syspath_prepend(str(core_src))
 
-    if "qdrant_loader_core" not in sys.modules:
-        pkg = types.ModuleType("qdrant_loader_core")
-        pkg.__path__ = []
-        sys.modules["qdrant_loader_core"] = pkg
+    pkg = types.ModuleType("qdrant_loader_core")
+    pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "qdrant_loader_core", pkg)
 
-    if "qdrant_loader_core.config" not in sys.modules:
-        config_mod = types.ModuleType("qdrant_loader_core.config")
-        config_mod.CollectionVectorCapabilities = object
-        config_mod.SparseRuntimeConfig = object
+    config_mod = types.ModuleType("qdrant_loader_core.config")
+    config_mod.CollectionVectorCapabilities = object
+    config_mod.SparseRuntimeConfig = object
 
-        def _parse_collection_capabilities(*_args, **_kwargs):
-            return None
+    def _parse_collection_capabilities(*_args, **_kwargs):
+        return None
 
-        config_mod.parse_collection_capabilities = _parse_collection_capabilities
-        sys.modules["qdrant_loader_core.config"] = config_mod
+    config_mod.parse_collection_capabilities = _parse_collection_capabilities
+    monkeypatch.setitem(sys.modules, "qdrant_loader_core.config", config_mod)
 
-    if "qdrant_loader_core.sparse" not in sys.modules:
-        sparse_mod = types.ModuleType("qdrant_loader_core.sparse")
+    sparse_mod = types.ModuleType("qdrant_loader_core.sparse")
 
-        def _get_sparse_encoder(*_args, **_kwargs):
-            return None
+    def _get_sparse_encoder(*_args, **_kwargs):
+        return None
 
-        sparse_mod.get_sparse_encoder = _get_sparse_encoder
-        sys.modules["qdrant_loader_core.sparse"] = sparse_mod
+    sparse_mod.get_sparse_encoder = _get_sparse_encoder
+    monkeypatch.setitem(sys.modules, "qdrant_loader_core.sparse", sparse_mod)
 
 
 @pytest.mark.asyncio
@@ -53,7 +49,7 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
     The orchestrator logs a warning (connectors not yet filtering by time) but does not
     raise.
     """
-    _setup_qdrant_loader_core_stubs()
+    _setup_qdrant_loader_core_stubs(monkeypatch)
 
     from qdrant_loader.core.pipeline.orchestrator import PipelineOrchestrator
 

--- a/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
+++ b/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from qdrant_loader.core.worker.handlers import IngestionJobHandler
+
+
+def _setup_qdrant_loader_core_stubs():
+    """Ensure qdrant_loader_core and its submodules are importable in all environments."""
+    workspace_root = Path(__file__).resolve().parents[6]
+    core_src = workspace_root / "packages" / "qdrant-loader-core" / "src"
+    if str(core_src) not in sys.path:
+        sys.path.insert(0, str(core_src))
+
+    if "qdrant_loader_core" not in sys.modules:
+        pkg = types.ModuleType("qdrant_loader_core")
+        pkg.__path__ = []
+        sys.modules["qdrant_loader_core"] = pkg
+
+    if "qdrant_loader_core.config" not in sys.modules:
+        config_mod = types.ModuleType("qdrant_loader_core.config")
+        config_mod.CollectionVectorCapabilities = object
+        config_mod.SparseRuntimeConfig = object
+
+        def _parse_collection_capabilities(*_args, **_kwargs):
+            return None
+
+        config_mod.parse_collection_capabilities = _parse_collection_capabilities
+        sys.modules["qdrant_loader_core.config"] = config_mod
+
+    if "qdrant_loader_core.sparse" not in sys.modules:
+        sparse_mod = types.ModuleType("qdrant_loader_core.sparse")
+
+        def _get_sparse_encoder(*_args, **_kwargs):
+            return None
+
+        sparse_mod.get_sparse_encoder = _get_sparse_encoder
+        sys.modules["qdrant_loader_core.sparse"] = sparse_mod
+
+
+@pytest.mark.asyncio
+async def test_incremental_pull_accepts_since_param(monkeypatch):
+    """Integration guard: handler passes `since` to orchestrator and it is accepted.
+
+    Ensures that PipelineOrchestrator.process_documents accepts the `since` kwarg
+    forwarded by IngestionJobHandler.handle_incremental_pull without raising TypeError.
+    The orchestrator logs a warning (connectors not yet filtering by time) but does not
+    raise.
+    """
+    _setup_qdrant_loader_core_stubs()
+
+    from qdrant_loader.core.pipeline.orchestrator import PipelineOrchestrator
+
+    orchestrator = PipelineOrchestrator(
+        settings=MagicMock(),
+        components=MagicMock(),
+        project_manager=MagicMock(),
+    )
+    # Stub deep enough so orchestrator.process_documents reaches
+    # _collect_documents_from_sources without needing real DB/Qdrant.
+    orchestrator._collect_documents_from_sources = AsyncMock(return_value=[])
+
+    history = MagicMock()
+    history.last_successful_ingestion = datetime(2026, 5, 20, 10, 0, 0, tzinfo=UTC)
+
+    import qdrant_loader.core.worker.handlers as handlers_module
+
+    monkeypatch.setattr(
+        handlers_module, "get_last_ingestion", AsyncMock(return_value=history)
+    )
+
+    handler = IngestionJobHandler(orchestrator, session_factory=MagicMock())
+
+    # Should complete without TypeError; `since` is accepted by orchestrator.
+    await handler.handle_incremental_pull(
+        {
+            "source_lock": "git:repo",
+            "source_type": "git",
+            "source": "repo",
+            "project_id": "proj-1",
+        }
+    )
+
+    # Confirm orchestrator was called with since != None
+    call_kwargs = orchestrator._collect_documents_from_sources.call_args
+    assert call_kwargs is not None, "_collect_documents_from_sources was not called"
+    passed_since = call_kwargs.kwargs.get("since") or (
+        call_kwargs.args[2] if len(call_kwargs.args) > 2 else None
+    )
+    assert passed_since is not None, "since was not forwarded to _collect_documents_from_sources"

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -127,7 +127,7 @@ class TestPipelineOrchestrator:
             self.mock_sources_config, None, None
         )
         self.orchestrator._collect_documents_from_sources.assert_called_once_with(
-            filtered_config, None
+            filtered_config, None, None
         )
         self.orchestrator._detect_document_changes.assert_called_once_with(
             mock_documents, filtered_config, None
@@ -208,7 +208,7 @@ class TestPipelineOrchestrator:
             self.mock_sources_config, "git", "my-repo"
         )
         self.orchestrator._collect_documents_from_sources.assert_called_once_with(
-            filtered_config, None
+            filtered_config, None, None
         )
         self.orchestrator._detect_document_changes.assert_called_once_with(
             mock_documents, filtered_config, None
@@ -261,7 +261,7 @@ class TestPipelineOrchestrator:
         # Verify
         assert result == []
         self.orchestrator._collect_documents_from_sources.assert_called_once_with(
-            filtered_config, None
+            filtered_config, None, None
         )
 
     @pytest.mark.asyncio

--- a/packages/qdrant-loader/tests/unit/core/worker/test_handlers.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_handlers.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from qdrant_loader.core.worker.handlers import (
+    BaseJobHandler,
+    HandlerRegistry,
+    IngestionJobHandler,
+    PermanentJobError,
+    TransientJobError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(last_ingestion: datetime | None = None) -> IngestionJobHandler:
+    """Return an IngestionJobHandler backed by mocks."""
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock()
+
+    session_factory = MagicMock()
+
+    history = None
+    if last_ingestion is not None:
+        history = MagicMock()
+        history.last_successful_ingestion = last_ingestion
+
+    handler = IngestionJobHandler(orchestrator, session_factory)
+    # Patch get_last_ingestion so tests don't need a real DB
+    handler._get_last_ingestion = AsyncMock(return_value=history)
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# BaseJobHandler dispatch
+# ---------------------------------------------------------------------------
+
+
+class ConcreteHandler(BaseJobHandler):
+    def __init__(self) -> None:
+        self.bulk_called_with: dict | None = None
+        self.incremental_called_with: dict | None = None
+
+    async def handle_bulk_ingest(self, payload: dict) -> None:
+        self.bulk_called_with = payload
+
+    async def handle_incremental_pull(self, payload: dict) -> None:
+        self.incremental_called_with = payload
+
+
+@pytest.mark.asyncio
+async def test_base_handler_dispatches_bulk_ingest():
+    handler = ConcreteHandler()
+    payload = {"source_lock": "s1", "source_type": "git", "source": "repo"}
+    await handler("BULK_INGEST", payload)
+    assert handler.bulk_called_with == payload
+    assert handler.incremental_called_with is None
+
+
+@pytest.mark.asyncio
+async def test_base_handler_dispatches_incremental_pull():
+    handler = ConcreteHandler()
+    payload = {"source_lock": "s1", "source_type": "git", "source": "repo"}
+    await handler("INCREMENTAL_PULL", payload)
+    assert handler.incremental_called_with == payload
+    assert handler.bulk_called_with is None
+
+
+@pytest.mark.asyncio
+async def test_base_handler_raises_permanent_error_for_unknown_job_type():
+    handler = ConcreteHandler()
+    with pytest.raises(PermanentJobError, match="Unknown job type"):
+        await handler("UNKNOWN_TYPE", {})
+
+
+# ---------------------------------------------------------------------------
+# _calculate_since_timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_since_timestamp_subtracts_five_minutes():
+    ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    result = ConcreteHandler._calculate_since_timestamp(ts)
+    assert result == ts - timedelta(minutes=5)
+
+
+def test_calculate_since_timestamp_returns_none_for_none():
+    assert ConcreteHandler._calculate_since_timestamp(None) is None
+
+
+# ---------------------------------------------------------------------------
+# IngestionJobHandler.handle_bulk_ingest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingestion_handler_bulk_ingest_calls_orchestrator_with_force_true():
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock()
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+
+    payload = {
+        "source_lock": "confluence:space-A",
+        "source_type": "confluence",
+        "source": "space-A",
+        "project_id": "proj-1",
+    }
+    await handler.handle_bulk_ingest(payload)
+
+    orchestrator.process_documents.assert_awaited_once_with(
+        source_type="confluence",
+        source="space-A",
+        project_id="proj-1",
+        force=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingestion_handler_bulk_ingest_without_project_id():
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock()
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+
+    await handler.handle_bulk_ingest(
+        {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+    )
+
+    orchestrator.process_documents.assert_awaited_once_with(
+        source_type="git",
+        source="repo",
+        project_id=None,
+        force=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# IngestionJobHandler.handle_incremental_pull
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingestion_handler_incremental_pull_passes_since_and_force_false(
+    monkeypatch,
+):
+    """since = last_successful_ingestion - 5min is passed to orchestrator."""
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock()
+
+    last_ts = datetime(2026, 5, 20, 10, 0, 0, tzinfo=UTC)
+    expected_since = last_ts - timedelta(minutes=5)
+    history = MagicMock()
+    history.last_successful_ingestion = last_ts
+
+    import qdrant_loader.core.worker.handlers as handlers_module
+
+    monkeypatch.setattr(
+        handlers_module, "get_last_ingestion", AsyncMock(return_value=history)
+    )
+
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+    payload = {
+        "source_lock": "confluence:space-A",
+        "source_type": "confluence",
+        "source": "space-A",
+        "project_id": "proj-1",
+    }
+    await handler.handle_incremental_pull(payload)
+
+    orchestrator.process_documents.assert_awaited_once_with(
+        source_type="confluence",
+        source="space-A",
+        project_id="proj-1",
+        force=False,
+        since=expected_since,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingestion_handler_incremental_pull_no_history_passes_since_none(
+    monkeypatch,
+):
+    """When no prior ingestion exists, since=None is passed to orchestrator."""
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock()
+
+    import qdrant_loader.core.worker.handlers as handlers_module
+
+    monkeypatch.setattr(
+        handlers_module, "get_last_ingestion", AsyncMock(return_value=None)
+    )
+
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+    await handler.handle_incremental_pull(
+        {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+    )
+
+    orchestrator.process_documents.assert_awaited_once_with(
+        source_type="git",
+        source="repo",
+        project_id=None,
+        force=False,
+        since=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# HandlerRegistry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registry_dispatches_to_registered_handler():
+    registry = HandlerRegistry()
+    concrete = ConcreteHandler()
+    registry.register("BULK_INGEST", concrete)
+
+    payload = {"source_lock": "s1", "source_type": "git", "source": "repo"}
+    await registry.handle("BULK_INGEST", payload)
+    assert concrete.bulk_called_with == payload
+
+
+@pytest.mark.asyncio
+async def test_registry_raises_permanent_error_for_unregistered_type():
+    registry = HandlerRegistry()
+    with pytest.raises(PermanentJobError, match="Unknown job type"):
+        await registry.handle("NOT_REGISTERED", {})
+
+
+def test_registry_list_handlers():
+    registry = HandlerRegistry()
+    registry.register("BULK_INGEST", ConcreteHandler())
+    assert registry.list_handlers() == {"BULK_INGEST": "ConcreteHandler"}
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_transient_error_is_job_handler_error():
+    err = TransientJobError("retry me")
+    assert isinstance(err, Exception)
+
+
+def test_permanent_error_is_job_handler_error():
+    err = PermanentJobError("no retry")
+    assert isinstance(err, Exception)
+
+
+# ---------------------------------------------------------------------------
+# Error wrapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_wraps_orchestrator_exception_as_transient(monkeypatch):
+    """Generic exceptions from orchestrator become TransientJobError."""
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock(side_effect=RuntimeError("network blip"))
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+
+    with pytest.raises(TransientJobError, match="network blip"):
+        await handler.handle_bulk_ingest(
+            {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_reraises_permanent_error_unchanged():
+    """PermanentJobError from orchestrator is not re-wrapped."""
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock(
+        side_effect=PermanentJobError("bad config")
+    )
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+
+    with pytest.raises(PermanentJobError, match="bad config"):
+        await handler.handle_bulk_ingest(
+            {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_incremental_pull_wraps_orchestrator_exception_as_transient(monkeypatch):
+    """Generic exceptions from orchestrator become TransientJobError."""
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock(side_effect=ConnectionError("timeout"))
+
+    import qdrant_loader.core.worker.handlers as handlers_module
+
+    monkeypatch.setattr(
+        handlers_module, "get_last_ingestion", AsyncMock(return_value=None)
+    )
+
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+    with pytest.raises(TransientJobError, match="timeout"):
+        await handler.handle_incremental_pull(
+            {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+        )

--- a/packages/qdrant-loader/tests/unit/core/worker/test_handlers.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_handlers.py
@@ -121,21 +121,17 @@ async def test_ingestion_handler_bulk_ingest_calls_orchestrator_with_force_true(
 
 
 @pytest.mark.asyncio
-async def test_ingestion_handler_bulk_ingest_without_project_id():
+async def test_ingestion_handler_bulk_ingest_without_project_id_raises_permanent_error():
     orchestrator = MagicMock()
     orchestrator.process_documents = AsyncMock()
     handler = IngestionJobHandler(orchestrator, MagicMock())
 
-    await handler.handle_bulk_ingest(
-        {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
-    )
+    with pytest.raises(PermanentJobError, match="project_id"):
+        await handler.handle_bulk_ingest(
+            {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+        )
 
-    orchestrator.process_documents.assert_awaited_once_with(
-        source_type="git",
-        source="repo",
-        project_id=None,
-        force=True,
-    )
+    orchestrator.process_documents.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -196,16 +192,67 @@ async def test_ingestion_handler_incremental_pull_no_history_passes_since_none(
 
     handler = IngestionJobHandler(orchestrator, MagicMock())
     await handler.handle_incremental_pull(
-        {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+        {
+            "source_lock": "git:repo",
+            "source_type": "git",
+            "source": "repo",
+            "project_id": "proj-1",
+        }
     )
 
     orchestrator.process_documents.assert_awaited_once_with(
         source_type="git",
         source="repo",
-        project_id=None,
+        project_id="proj-1",
         force=False,
         since=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_invalid_required_fields_raise_permanent_error():
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock()
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+
+    with pytest.raises(
+        PermanentJobError,
+        match=r"missing or invalid required field\(s\): source",
+    ):
+        await handler.handle_bulk_ingest(
+            {
+                "source_lock": "git:repo",
+                "source_type": "git",
+                "source": "   ",
+                "project_id": "proj-1",
+            }
+        )
+
+    orchestrator.process_documents.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_incremental_pull_invalid_required_fields_raise_permanent_error(monkeypatch):
+    orchestrator = MagicMock()
+    orchestrator.process_documents = AsyncMock()
+
+    import qdrant_loader.core.worker.handlers as handlers_module
+
+    monkeypatch.setattr(
+        handlers_module, "get_last_ingestion", AsyncMock(return_value=None)
+    )
+
+    handler = IngestionJobHandler(orchestrator, MagicMock())
+    with pytest.raises(PermanentJobError, match="source_type"):
+        await handler.handle_incremental_pull(
+            {
+                "source_lock": "git:repo",
+                "source": "repo",
+                "project_id": "proj-1",
+            }
+        )
+
+    orchestrator.process_documents.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +313,12 @@ async def test_bulk_ingest_wraps_orchestrator_exception_as_transient(monkeypatch
 
     with pytest.raises(TransientJobError, match="network blip"):
         await handler.handle_bulk_ingest(
-            {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+            {
+                "source_lock": "git:repo",
+                "source_type": "git",
+                "source": "repo",
+                "project_id": "proj-1",
+            }
         )
 
 
@@ -281,7 +333,12 @@ async def test_bulk_ingest_reraises_permanent_error_unchanged():
 
     with pytest.raises(PermanentJobError, match="bad config"):
         await handler.handle_bulk_ingest(
-            {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+            {
+                "source_lock": "git:repo",
+                "source_type": "git",
+                "source": "repo",
+                "project_id": "proj-1",
+            }
         )
 
 
@@ -300,5 +357,10 @@ async def test_incremental_pull_wraps_orchestrator_exception_as_transient(monkey
     handler = IngestionJobHandler(orchestrator, MagicMock())
     with pytest.raises(TransientJobError, match="timeout"):
         await handler.handle_incremental_pull(
-            {"source_lock": "git:repo", "source_type": "git", "source": "repo"}
+            {
+                "source_lock": "git:repo",
+                "source_type": "git",
+                "source": "repo",
+                "project_id": "proj-1",
+            }
         )


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pipeline Impact
The changes affect the core **PipelineOrchestrator**, modifying `process_documents`, `_process_all_projects`, and `_collect_documents_from_sources` to support time-based filtering. A new **IngestionJobHandler** is introduced to dispatch bulk (force=True) and incremental (force=False with `since` parameter) ingestion flows.

## Configuration Changes
**Additive, backward-compatible**: The orchestrator methods now accept an optional `since: datetime | None = None` parameter. The handler constructor requires `orchestrator` and `session_factory` arguments. No breaking changes to existing APIs.

## Test Coverage
**Well-covered**: 96 lines of integration tests verify `since` parameter forwarding without TypeError; 304 lines of unit tests cover bulk/incremental dispatch, timestamp calculation (5-minute offset), error hierarchy, and registry dispatch.

## Concerns
**Performance caveat**: Time-based filtering is not yet implemented; the pipeline falls back to full fetch with hash-based change detection. This is functionally safe but suboptimal for large datasets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->