### PR TITLE
feat:  add monotonic incremental scheduler with pending/running dedup

### DIFF
--- a/packages/qdrant-loader/migrations/versions/20260514_01_create_jobs_table.py
+++ b/packages/qdrant-loader/migrations/versions/20260514_01_create_jobs_table.py
@@ -22,23 +22,34 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "jobs",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("type", sa.String(), nullable=False),
-        sa.Column("payload_json", sa.Text(), nullable=False),
-        sa.Column("status", sa.String(), nullable=False),
-        sa.Column("enqueued_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
-        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("last_error", sa.Text(), nullable=True),
-        sa.Column("visibility_deadline", sa.DateTime(timezone=True), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        "ix_jobs_status_enqueued_at", "jobs", ["status", "enqueued_at"], unique=False
-    )
+    # Use checkfirst=True / if_not_exists=True so this migration is idempotent.
+    # This handles databases that already have the jobs table created directly
+    # by SQLAlchemy (create_all) before Alembic was introduced.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "jobs" not in existing_tables:
+        op.create_table(
+            "jobs",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("type", sa.String(), nullable=False),
+            sa.Column("payload_json", sa.Text(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("enqueued_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column("visibility_deadline", sa.DateTime(timezone=True), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("jobs")} if "jobs" in existing_tables else set()
+    if "ix_jobs_status_enqueued_at" not in existing_indexes:
+        op.create_index(
+            "ix_jobs_status_enqueued_at", "jobs", ["status", "enqueued_at"], unique=False
+        )
 
 
 def downgrade() -> None:

--- a/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
@@ -469,8 +469,11 @@ class Settings(BaseSettings):
             _get_logger().debug("Processing environment variables in configuration")
             config_data = cls._substitute_env_vars(config_data)
 
-            # Step 3.5: Validate that all required environment variables were substituted
-            cls._validate_env_substitution(config_data)
+            # Step 3.5: In strict mode, fail fast if placeholders remain unresolved.
+            # Tests and template flows often use skip_validation=True and should keep
+            # legacy behavior where unresolved placeholders can remain in config.
+            if not skip_validation:
+                cls._validate_env_substitution(config_data)
 
             # Step 4: Use multi-project parser to parse configuration
             validator = ConfigValidator()

--- a/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
@@ -399,6 +399,35 @@ class Settings(BaseSettings):
             return [Settings._substitute_env_vars(item) for item in data]
         return data
 
+    @staticmethod
+    def _validate_env_substitution(data: Any) -> None:
+        """Validate that all environment variables in config have been substituted.
+        
+        Raises:
+            ValueError: If any ${VAR_NAME} pattern remains in the configuration.
+        """
+        pattern = r"\$\{([^}]+)\}"
+        
+        def check_value(value: Any, path: str = "") -> None:
+            if isinstance(value, str):
+                matches = re.finditer(pattern, value)
+                for match in matches:
+                    var_name = match.group(1)
+                    location = f" at {path}" if path else ""
+                    raise ValueError(
+                        f"Environment variable {var_name!r} not found{location}. "
+                        f"Please set {var_name} in your environment or .env file, "
+                        f"or comment out the configuration line that references it."
+                    )
+            elif isinstance(value, dict):
+                for k, v in value.items():
+                    check_value(v, f"{path}.{k}" if path else k)
+            elif isinstance(value, list):
+                for i, item in enumerate(value):
+                    check_value(item, f"{path}[{i}]")
+        
+        check_value(data)
+
     @classmethod
     def from_yaml(
         cls,
@@ -439,6 +468,9 @@ class Settings(BaseSettings):
             # Step 3: Process all environment variables in config using substitution
             _get_logger().debug("Processing environment variables in configuration")
             config_data = cls._substitute_env_vars(config_data)
+
+            # Step 3.5: Validate that all required environment variables were substituted
+            cls._validate_env_substitution(config_data)
 
             # Step 4: Use multi-project parser to parse configuration
             validator = ConfigValidator()

--- a/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
@@ -14,6 +14,7 @@ from qdrant_loader.config.embedding import EmbeddingConfig
 from qdrant_loader.config.qdrant import QdrantConfig
 from qdrant_loader.config.sources import SourcesConfig
 from qdrant_loader.config.state import StateManagementConfig
+from qdrant_loader.config.workers import WorkersConfig
 from qdrant_loader.core.file_conversion import FileConversionConfig
 
 
@@ -55,6 +56,10 @@ class GlobalConfig(BaseConfig):
     )
     qdrant: QdrantConfig = Field(
         default_factory=QdrantConfig, description="Qdrant configuration"
+    )
+    workers: WorkersConfig = Field(
+        default_factory=WorkersConfig,
+        description="Worker scheduling and runtime configuration",
     )
 
     def __init__(self, **data):
@@ -98,4 +103,5 @@ class GlobalConfig(BaseConfig):
                 },
             },
             "qdrant": self.qdrant.to_dict(),
+            "workers": self.workers.to_dict(),
         }

--- a/packages/qdrant-loader/src/qdrant_loader/config/workers.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/workers.py
@@ -1,0 +1,132 @@
+"""Worker scheduling configuration."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import Field, field_validator
+
+from qdrant_loader.config.base import BaseConfig
+
+_SHORT_DURATION_RE = re.compile(
+    r"^\s*(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?(?:(?P<seconds>\d+)s)?\s*$",
+    re.IGNORECASE,
+)
+_ISO_DURATION_RE = re.compile(
+    r"^P(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+)S)?)$",
+    re.IGNORECASE,
+)
+
+
+def parse_interval_seconds(value: int | float | str) -> int:
+    """Parse an interval value into seconds.
+
+    Accepted formats:
+    - Integer/float seconds: 300, 300.0
+    - Numeric strings: "300"
+    - Short duration strings: "30s", "5m", "2h", "1h30m"
+    - ISO-8601 duration (time portion): "PT5M", "PT1H30M"
+    """
+    if isinstance(value, bool):
+        raise ValueError("interval must be a positive duration")
+
+    if isinstance(value, (int, float)):
+        seconds = int(value)
+        if seconds < 1:
+            raise ValueError("interval must be at least 1 second")
+        return seconds
+
+    if not isinstance(value, str):
+        raise ValueError("interval must be an int, float, or string duration")
+
+    raw = value.strip()
+    if not raw:
+        raise ValueError("interval cannot be empty")
+
+    if raw.isdigit():
+        seconds = int(raw)
+        if seconds < 1:
+            raise ValueError("interval must be at least 1 second")
+        return seconds
+
+    short_match = _SHORT_DURATION_RE.match(raw)
+    if short_match:
+        hours = int(short_match.group("hours") or 0)
+        minutes = int(short_match.group("minutes") or 0)
+        seconds = int(short_match.group("seconds") or 0)
+        total = hours * 3600 + minutes * 60 + seconds
+        if total < 1:
+            raise ValueError("interval must be at least 1 second")
+        return total
+
+    iso_match = _ISO_DURATION_RE.match(raw)
+    if iso_match:
+        hours = int(iso_match.group("hours") or 0)
+        minutes = int(iso_match.group("minutes") or 0)
+        seconds = int(iso_match.group("seconds") or 0)
+        total = hours * 3600 + minutes * 60 + seconds
+        if total < 1:
+            raise ValueError("interval must be at least 1 second")
+        return total
+
+    raise ValueError(
+        "Invalid interval format. Use seconds, short durations like '5m', or ISO-8601 like 'PT5M'."
+    )
+
+
+class IncrementalPullScheduleConfig(BaseConfig):
+    """Periodic scheduling config for INCREMENTAL_PULL jobs."""
+
+    enabled: bool = Field(default=False, description="Enable periodic scheduling")
+    interval_seconds: int = Field(
+        default=300,
+        alias="interval",
+        description="Interval in seconds (supports '5m', 'PT5M', or integer seconds)",
+    )
+    dedup_statuses: list[str] = Field(
+        default_factory=lambda: ["pending", "running"],
+        description="Job statuses considered active for deduplication",
+    )
+    payload_defaults: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra payload fields merged into each scheduled job payload",
+    )
+
+    @field_validator("interval_seconds", mode="before")
+    @classmethod
+    def validate_interval_seconds(cls, value: int | float | str) -> int:
+        return parse_interval_seconds(value)
+
+    @field_validator("dedup_statuses")
+    @classmethod
+    def validate_dedup_statuses(cls, values: list[str]) -> list[str]:
+        allowed = {"pending", "running", "done", "failed"}
+        normalized = []
+        for item in values:
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError("dedup statuses must be non-empty strings")
+            status = item.strip().lower()
+            if status not in allowed:
+                raise ValueError(
+                    f"Invalid dedup status '{item}'. Allowed: {sorted(allowed)}"
+                )
+            normalized.append(status)
+
+        if not normalized:
+            raise ValueError("dedup_statuses cannot be empty")
+        return normalized
+
+
+class WorkerSchedulesConfig(BaseConfig):
+    """Container for worker schedule definitions."""
+
+    incremental_pull: IncrementalPullScheduleConfig = Field(
+        default_factory=IncrementalPullScheduleConfig
+    )
+
+
+class WorkersConfig(BaseConfig):
+    """Worker runtime and scheduling configuration."""
+
+    schedules: WorkerSchedulesConfig = Field(default_factory=WorkerSchedulesConfig)

--- a/packages/qdrant-loader/src/qdrant_loader/config/workers.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/workers.py
@@ -117,6 +117,42 @@ class IncrementalPullScheduleConfig(BaseConfig):
             raise ValueError("dedup_statuses cannot be empty")
         return normalized
 
+    @field_validator("payload_defaults")
+    @classmethod
+    def validate_payload_defaults(cls, value: dict[str, Any]) -> dict[str, Any]:
+        def _validate_json_like(v: Any, path: str) -> Any:
+            if v is None or isinstance(v, (str, int, float, bool)):
+                return v
+
+            if isinstance(v, list):
+                return [
+                    _validate_json_like(item, f"{path}[{idx}]")
+                    for idx, item in enumerate(v)
+                ]
+
+            if isinstance(v, dict):
+                cleaned: dict[str, Any] = {}
+                for key, item in v.items():
+                    if not isinstance(key, str):
+                        raise ValueError(f"{path} keys must be strings")
+                    cleaned[key] = _validate_json_like(item, f"{path}.{key}")
+                return cleaned
+
+            raise ValueError(
+                f"{path} contains unsupported type {type(v).__name__}; "
+                "allowed types are str, int, float, bool, None, list, dict"
+            )
+
+        if not isinstance(value, dict):
+            raise ValueError("payload_defaults must be a dictionary")
+
+        cleaned: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError("payload_defaults keys must be strings")
+            cleaned[key] = _validate_json_like(item, f"payload_defaults.{key}")
+        return cleaned
+
 
 class WorkerSchedulesConfig(BaseConfig):
     """Container for worker schedule definitions."""

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/__init__.py
@@ -10,6 +10,7 @@ from qdrant_loader.core.worker.handlers import (
 )
 from qdrant_loader.core.worker.pool import QueueWorkerPool
 from qdrant_loader.core.worker.queue import JobQueue, SQLiteJobQueue
+from qdrant_loader.core.worker.scheduler import IncrementalPullScheduler
 
 __all__ = [
     # Queue abstractions
@@ -17,6 +18,8 @@ __all__ = [
     "SQLiteJobQueue",
     # Pool
     "QueueWorkerPool",
+    # Scheduler
+    "IncrementalPullScheduler",
     # Handlers
     "JobHandler",
     "BaseJobHandler",

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/scheduler.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/scheduler.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import Callable
+
+from qdrant_loader.config.models import ProjectsConfig
+from qdrant_loader.config.workers import IncrementalPullScheduleConfig
+from qdrant_loader.core.worker.queue import JobQueue
+from qdrant_loader.utils.logging import LoggingConfig
+
+logger = LoggingConfig.get_logger(__name__)
+
+
+class IncrementalPullScheduler:
+    """Create periodic INCREMENTAL_PULL jobs using a monotonic clock."""
+
+    SOURCE_TYPES = ("publicdocs", "git", "confluence", "jira", "localfile")
+
+    def __init__(
+        self,
+        queue: JobQueue,
+        projects_config: ProjectsConfig,
+        schedule: IncrementalPullScheduleConfig,
+        monotonic: Callable[[], float] | None = None,
+    ) -> None:
+        self._queue = queue
+        self._projects_config = projects_config
+        self._schedule = schedule
+        self._monotonic = monotonic or time.monotonic
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        """Run periodic scheduling loop until stop_event is set."""
+        if not self._schedule.enabled:
+            logger.info("scheduler.incremental_pull.disabled")
+            return
+
+        interval = float(self._schedule.interval_seconds)
+        next_run_at = self._monotonic() + interval
+
+        logger.info(
+            "scheduler.incremental_pull.started",
+            interval_seconds=self._schedule.interval_seconds,
+        )
+
+        while not stop_event.is_set():
+            now = self._monotonic()
+            if now >= next_run_at:
+                created = await self.run_once()
+                logger.info("scheduler.incremental_pull.tick", created=created)
+
+                while next_run_at <= now:
+                    next_run_at += interval
+
+            timeout = max(0.0, min(1.0, next_run_at - self._monotonic()))
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=timeout)
+            except TimeoutError:
+                pass
+
+        logger.info("scheduler.incremental_pull.stopped")
+
+    async def run_once(self) -> int:
+        """Attempt to enqueue all due INCREMENTAL_PULL jobs once."""
+        if not self._schedule.enabled:
+            return 0
+
+        dedup_keys = await self._load_active_dedup_keys()
+        created = 0
+
+        for project_id, source_type, source_name in self._iter_project_sources():
+            dedup_key = ("INCREMENTAL_PULL", project_id, source_type, source_name)
+            if dedup_key in dedup_keys:
+                continue
+
+            payload = {
+                "project_id": project_id,
+                "source_type": source_type,
+                "source": source_name,
+                "source_lock": f"{project_id}:{source_type}:{source_name}",
+                "force": False,
+            }
+            payload.update(self._schedule.payload_defaults)
+
+            await self._queue.enqueue("INCREMENTAL_PULL", payload)
+            dedup_keys.add(dedup_key)
+            created += 1
+
+        return created
+
+    def _iter_project_sources(self):
+        for project in self._projects_config.projects.values():
+            for source_type in self.SOURCE_TYPES:
+                source_map = getattr(project.sources, source_type, {}) or {}
+                for source_name in source_map.keys():
+                    yield project.project_id, source_type, source_name
+
+    async def _load_active_dedup_keys(self) -> set[tuple[str, str, str, str]]:
+        keys: set[tuple[str, str, str, str]] = set()
+
+        # JobQueue protocol only supports filtering by one status at a time.
+        # Query each configured status and normalize to dedup keys.
+        for status in self._schedule.dedup_statuses:
+            jobs = await self._queue.list(status=status, limit=10000)
+            for job in jobs:
+                key = self._job_dedup_key(job)
+                if key is not None:
+                    keys.add(key)
+
+        return keys
+
+    @staticmethod
+    def _job_dedup_key(job) -> tuple[str, str, str, str] | None:
+        if getattr(job, "type", None) != "INCREMENTAL_PULL":
+            return None
+
+        try:
+            payload = json.loads(job.payload_json)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        project_id = payload.get("project_id")
+        source_type = payload.get("source_type")
+        source_name = payload.get("source")
+        if not all(
+            isinstance(v, str) and v.strip()
+            for v in (project_id, source_type, source_name)
+        ):
+            return None
+
+        return (
+            "INCREMENTAL_PULL",
+            project_id.strip(),
+            source_type.strip(),
+            source_name.strip(),
+        )

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/scheduler.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/scheduler.py
@@ -74,14 +74,16 @@ class IncrementalPullScheduler:
             if dedup_key in dedup_keys:
                 continue
 
-            payload = {
-                "project_id": project_id,
-                "source_type": source_type,
-                "source": source_name,
-                "source_lock": f"{project_id}:{source_type}:{source_name}",
-                "force": False,
-            }
-            payload.update(self._schedule.payload_defaults)
+            payload = dict(self._schedule.payload_defaults)
+            payload.update(
+                {
+                    "project_id": project_id,
+                    "source_type": source_type,
+                    "source": source_name,
+                    "source_lock": f"{project_id}:{source_type}:{source_name}",
+                    "force": False,
+                }
+            )
 
             await self._queue.enqueue("INCREMENTAL_PULL", payload)
             dedup_keys.add(dedup_key)

--- a/packages/qdrant-loader/tests/unit/config/test_workers_config.py
+++ b/packages/qdrant-loader/tests/unit/config/test_workers_config.py
@@ -40,3 +40,38 @@ def test_workers_config_defaults_incremental_pull_disabled():
     cfg = WorkersConfig()
     assert cfg.schedules.incremental_pull.enabled is False
     assert cfg.schedules.incremental_pull.interval_seconds == 300
+
+
+def test_payload_defaults_accepts_json_like_values():
+    cfg = IncrementalPullScheduleConfig(
+        enabled=True,
+        interval=300,
+        payload_defaults={
+            "force": False,
+            "attempt": 1,
+            "threshold": 0.5,
+            "tag": "nightly",
+            "extra": {"a": 1, "b": ["x", None, True]},
+        },
+    )
+
+    assert cfg.payload_defaults["force"] is False
+    assert cfg.payload_defaults["extra"]["b"][1] is None
+
+
+def test_payload_defaults_rejects_unsupported_types():
+    with pytest.raises(ValueError, match="unsupported type"):
+        IncrementalPullScheduleConfig(
+            enabled=True,
+            interval=300,
+            payload_defaults={"bad": object()},
+        )
+
+
+def test_payload_defaults_rejects_non_string_nested_dict_keys():
+    with pytest.raises(ValueError, match="keys must be strings"):
+        IncrementalPullScheduleConfig(
+            enabled=True,
+            interval=300,
+            payload_defaults={"bad": {1: "x"}},
+        )

--- a/packages/qdrant-loader/tests/unit/config/test_workers_config.py
+++ b/packages/qdrant-loader/tests/unit/config/test_workers_config.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+from qdrant_loader.config.workers import (
+    IncrementalPullScheduleConfig,
+    WorkersConfig,
+    parse_interval_seconds,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (300, 300),
+        ("300", 300),
+        ("30s", 30),
+        ("5m", 300),
+        ("2h", 7200),
+        ("1h30m", 5400),
+        ("PT5M", 300),
+        ("PT1H30M", 5400),
+    ],
+)
+def test_parse_interval_seconds_formats(raw, expected):
+    assert parse_interval_seconds(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [0, "", "0s", "PT0S", "abc", True])
+def test_parse_interval_seconds_invalid(raw):
+    with pytest.raises(ValueError):
+        parse_interval_seconds(raw)
+
+
+def test_schedule_config_accepts_alias_interval_formats():
+    cfg = IncrementalPullScheduleConfig(enabled=True, interval="5m")
+    assert cfg.interval_seconds == 300
+
+
+def test_workers_config_defaults_incremental_pull_disabled():
+    cfg = WorkersConfig()
+    assert cfg.schedules.incremental_pull.enabled is False
+    assert cfg.schedules.incremental_pull.interval_seconds == 300

--- a/packages/qdrant-loader/tests/unit/core/worker/test_scheduler.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_scheduler.py
@@ -106,3 +106,35 @@ async def test_scheduler_dedups_against_pending_and_running():
 
     assert created == 0
     assert queue.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_keeps_canonical_identity_over_payload_defaults():
+    queue = _FakeQueue()
+    schedule = IncrementalPullScheduleConfig(
+        enabled=True,
+        interval=300,
+        payload_defaults={
+            "project_id": "wrong",
+            "source_type": "wrong",
+            "source": "wrong",
+            "source_lock": "wrong:lock",
+            "force": True,
+            "custom": "ok",
+        },
+    )
+    scheduler = IncrementalPullScheduler(queue, _projects_config(), schedule)
+
+    created = await scheduler.run_once()
+
+    assert created == 2
+    first_payload = queue.enqueued[0][1]
+    assert first_payload["project_id"] == "demo"
+    assert first_payload["source_type"] in {"git", "jira"}
+    assert first_payload["source"] in {"repo-a", "jira-a"}
+    assert first_payload["source_lock"] in {
+        "demo:git:repo-a",
+        "demo:jira:jira-a",
+    }
+    assert first_payload["force"] is False
+    assert first_payload["custom"] == "ok"

--- a/packages/qdrant-loader/tests/unit/core/worker/test_scheduler.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_scheduler.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+from qdrant_loader.config.models import ProjectConfig, ProjectsConfig
+from qdrant_loader.config.sources import SourcesConfig
+from qdrant_loader.config.workers import IncrementalPullScheduleConfig
+from qdrant_loader.core.worker.scheduler import IncrementalPullScheduler
+
+
+@dataclass
+class _FakeJob:
+    type: str
+    payload_json: str
+    status: str
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.enqueued: list[tuple[str, dict]] = []
+        self.active_by_status: dict[str, list[_FakeJob]] = {}
+
+    async def enqueue(self, job_type: str, payload: dict):
+        self.enqueued.append((job_type, payload))
+        return _FakeJob(
+            type=job_type, payload_json=json.dumps(payload), status="pending"
+        )
+
+    async def list(self, status: str | None = None, limit: int = 100):
+        if status is None:
+            all_jobs = []
+            for items in self.active_by_status.values():
+                all_jobs.extend(items)
+            return all_jobs[:limit]
+        return self.active_by_status.get(status, [])[:limit]
+
+
+def _projects_config() -> ProjectsConfig:
+    sources = SourcesConfig()
+    sources.git = {"repo-a": object()}
+    sources.jira = {"jira-a": object()}
+    project = ProjectConfig(
+        project_id="demo",
+        display_name="Demo",
+        sources=sources,
+    )
+    return ProjectsConfig(projects={"demo": project})
+
+
+@pytest.mark.asyncio
+async def test_scheduler_enqueues_incremental_pull_for_all_sources():
+    queue = _FakeQueue()
+    schedule = IncrementalPullScheduleConfig(enabled=True, interval=300)
+    scheduler = IncrementalPullScheduler(queue, _projects_config(), schedule)
+
+    created = await scheduler.run_once()
+
+    assert created == 2
+    assert len(queue.enqueued) == 2
+    assert {payload["source"] for _, payload in queue.enqueued} == {"repo-a", "jira-a"}
+    assert all(job_type == "INCREMENTAL_PULL" for job_type, _ in queue.enqueued)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_dedups_against_pending_and_running():
+    queue = _FakeQueue()
+    queue.active_by_status = {
+        "pending": [
+            _FakeJob(
+                type="INCREMENTAL_PULL",
+                payload_json=json.dumps(
+                    {
+                        "project_id": "demo",
+                        "source_type": "git",
+                        "source": "repo-a",
+                    }
+                ),
+                status="pending",
+            )
+        ],
+        "running": [
+            _FakeJob(
+                type="INCREMENTAL_PULL",
+                payload_json=json.dumps(
+                    {
+                        "project_id": "demo",
+                        "source_type": "jira",
+                        "source": "jira-a",
+                    }
+                ),
+                status="running",
+            )
+        ],
+    }
+
+    schedule = IncrementalPullScheduleConfig(
+        enabled=True,
+        interval="5m",
+        dedup_statuses=["pending", "running"],
+    )
+    scheduler = IncrementalPullScheduler(queue, _projects_config(), schedule)
+
+    created = await scheduler.run_once()
+
+    assert created == 0
+    assert queue.enqueued == []

--- a/scripts/alembic_with_settings.py
+++ b/scripts/alembic_with_settings.py
@@ -123,12 +123,13 @@ def main() -> int:
 
     db_path = _resolve_state_db_path(args.workspace, args.config_path, args.env_path)
 
-    # Check if db_path comes from config or is default
-    config_source = (
-        "config file"
-        if any([args.workspace, args.config_path, args.env_path])
-        else "default (repo root)"
-    )
+    # Report invocation mode for DB path resolution.
+    if args.workspace:
+        config_source = "workspace"
+    elif args.config_path or args.env_path:
+        config_source = "config/env flags"
+    else:
+        config_source = "default (repo root)"
     print(f"[INFO] Using database path from {config_source}: {db_path}")
 
     child_env = os.environ.copy()


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Connectors / pipeline stages affected:
  - Scheduler adds periodic INCREMENTAL_PULL job creation across configured sources (git, confluence, jira, publicdocs, localfile) and integrates with the existing JobQueue/pipeline.

- Config schema changes (additive, non-breaking):
  - New WorkersConfig → WorkerSchedulesConfig → IncrementalPullScheduleConfig added to GlobalConfig.
  - IncrementalPullScheduleConfig fields: enabled (default False), interval_seconds (alias: interval, default 300s; accepts ints, "5m"/"1h30m" shorthand and ISO-8601 PT… formats), dedup_statuses (defaults ["pending","running"]), payload_defaults (validated JSON-like dict).

- Test coverage:
  - Unit tests cover interval parsing, payload_defaults validation, scheduler.run_once enqueuing for all sources, deduplication against pending+running jobs, and canonical payload behavior.

- Security / resource-safety:
  - Enforced positive/validated intervals, monotonic clock usage, payload type validation, dedup across active statuses, and stop_event-based shutdown mitigate risks of malformed jobs or queue flooding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->