### PR TITLE
feature: streaming pipeline refactor

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/connectors/base.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/base.py
@@ -1,4 +1,7 @@
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from datetime import datetime
+import warnings
 
 from qdrant_loader.config.source_config import SourceConfig
 from qdrant_loader.core.document import Document
@@ -43,9 +46,46 @@ class BaseConnector(ABC):
         # Store on the instance so connectors that opt-in can access it.
         self._file_conversion_config = file_conversion_config
 
+    async def stream_documents(
+        self, since: datetime | None = None
+    ) -> AsyncIterator[Document]:
+        """Stream documents from the source (WS-1 connector contract).
+
+        This default implementation bridges legacy connectors by calling
+        :meth:`get_documents` and yielding documents from the returned list.
+
+        Args:
+            since: Optional datetime to fetch documents updated after this time.
+
+        Yields:
+            Document objects from the source.
+        """
+        if (
+            type(self).get_documents is BaseConnector.get_documents
+            and type(self).stream_documents is BaseConnector.stream_documents
+        ):
+            raise NotImplementedError(
+                f"{type(self).__name__} does not implement stream_documents or get_documents"
+            )
+
+        documents = await self.get_documents()
+        for document in documents:
+            yield document
+
     @abstractmethod
     async def get_documents(self) -> list[Document]:
-        """Get documents from the source."""
+        """Get documents from the source (DEPRECATED - use stream_documents)."""
+        warnings.warn(
+            "BaseConnector.get_documents is deprecated. Implement stream_documents() "
+            "or use connector.stream_documents() to avoid materializing the full "
+            "document list in memory.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        documents: list[Document] = []
+        async for document in self.stream_documents():
+            documents.append(document)
+        return documents
 
     async def fetch_by_id(self, entity_id: str) -> Document | None:
         """Fetch a single entity by ID (WS-1 connector contract).
@@ -56,11 +96,16 @@ class BaseConnector(ABC):
             f"{type(self).__name__} does not support fetch_by_id"
         )
 
-    async def list_entity_ids(self) -> list[str]:
-        """List all entity IDs for reconciliation (WS-1 connector contract).
+    async def list_entity_ids(self) -> AsyncIterator[str]:
+        """Stream all entity IDs for reconciliation (WS-1 connector contract).
 
-        Connectors that support single-event ingestion must override this method.
+        Yields:
+            Entity IDs from the source.
         """
+        # Make this an async generator so callers can use `async for` and
+        # receive a NotImplementedError during iteration rather than at call-time.
+        if False:  # pragma: no cover - makes this function an async generator
+            yield ""
         raise NotImplementedError(
             f"{type(self).__name__} does not support list_entity_ids"
         )

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
@@ -1,8 +1,9 @@
 """Jira connector implementation."""
 
 import asyncio
+import warnings
 from abc import abstractmethod
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
 from datetime import datetime
 from urllib.parse import urlparse  # noqa: F401 - may be used in URL handling
 
@@ -462,17 +463,30 @@ class BaseJiraConnector(BaseConnector):
         documents = await self._issues_to_documents([issue])
         return documents[0] if documents else None
 
-    async def list_entity_ids(self) -> list[str]:
-        """List all issue keys in the configured project."""
-        entity_ids: list[str] = []
+    async def list_entity_ids(self) -> AsyncIterator[str]:
+        """Stream all issue keys in the configured project."""
         async for issue in self.get_issues():
-            entity_ids.append(issue.key)
-        return entity_ids
+            yield issue.key
 
     async def _issues_to_documents(self, issues: list[JiraIssue]) -> list[Document]:
-        """Convert Jira issues to Document objects (including attachments)."""
-        documents: list[Document] = []
+        """Convert Jira issues to Document objects (including attachments).
 
+        .. deprecated:: WS-1
+            Use :meth:`_stream_issues_to_documents` for streaming.
+        """
+        documents: list[Document] = []
+        async for document in self._stream_issues_to_documents(issues):
+            documents.append(document)
+        return documents
+
+    async def _stream_issues_to_documents(
+        self, issues: list[JiraIssue]
+    ) -> AsyncGenerator[Document, None]:
+        """Stream Jira issues as Document objects, including attachments.
+
+        Yields documents one at a time, with attachments yielded immediately after
+        their parent issue document.
+        """
         for issue in issues:
             content_parts = [issue.summary]
             if issue.description:
@@ -546,7 +560,6 @@ class BaseJiraConnector(BaseConnector):
                 is_deleted=False,
                 metadata=metadata,
             )
-            documents.append(document)
             logger.debug(
                 "Jira document created",
                 document_id=document.id,
@@ -554,6 +567,7 @@ class BaseJiraConnector(BaseConnector):
                 source=document.source,
                 title=document.title,
             )
+            yield document
 
             if self.config.download_attachments and self.attachment_reader:
                 attachment_metadata = self._get_issue_attachments(issue)
@@ -569,7 +583,8 @@ class BaseJiraConnector(BaseConnector):
                             attachment_metadata, document
                         )
                     )
-                    documents.extend(attachment_documents)
+                    for attachment_document in attachment_documents:
+                        yield attachment_document
 
                     logger.debug(
                         "Processed attachments for JIRA issue",
@@ -577,15 +592,25 @@ class BaseJiraConnector(BaseConnector):
                         processed_count=len(attachment_documents),
                     )
 
-        return documents
+    async def stream_documents(
+        self, since: datetime | None = None
+    ) -> AsyncGenerator[Document, None]:
+        """Stream documents from Jira (WS-1 connector contract)."""
+        async for issue in self.get_issues(updated_after=since):
+            async for document in self._stream_issues_to_documents([issue]):
+                yield document
 
     async def get_documents(self) -> list[Document]:
-        """Fetch and process documents from Jira.
+        """Fetch and process documents from Jira (DEPRECATED - use stream_documents)."""
+        warnings.warn(
+            "BaseJiraConnector.get_documents is deprecated. Implement stream_documents() "
+            "or use connector.stream_documents() to avoid materializing the full "
+            "document list in memory.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        documents = []
+        async for document in self.stream_documents():
+            documents.append(document)
+        return documents
 
-        Returns:
-            List[Document]: List of processed documents
-        """
-        issues = []
-        async for issue in self.get_issues():
-            issues.append(issue)
-        return await self._issues_to_documents(issues)

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from dataclasses import dataclass
 
 from qdrant_loader.core.document import Document
 from qdrant_loader.utils.logging import LoggingConfig
@@ -10,6 +11,26 @@ from .workers import ChunkingWorker, EmbeddingWorker, UpsertWorker
 from .workers.upsert_worker import PipelineResult
 
 logger = LoggingConfig.get_logger(__name__)
+
+
+@dataclass
+class BatchResult:
+    """Result of processing a bounded batch of documents."""
+
+    success_count: int = 0
+    failure_count: int = 0
+    skipped_count: int = 0
+    successfully_processed_documents: set[str] | None = None
+    failed_document_ids: set[str] | None = None
+    errors: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.successfully_processed_documents is None:
+            self.successfully_processed_documents = set()
+        if self.failed_document_ids is None:
+            self.failed_document_ids = set()
+        if self.errors is None:
+            self.errors = []
 
 
 class DocumentPipeline:
@@ -25,6 +46,75 @@ class DocumentPipeline:
         self.embedding_worker = embedding_worker
         self.upsert_worker = upsert_worker
 
+    async def process_batch(self, batch: list[Document]) -> BatchResult:
+        """Process a bounded batch of documents through the pipeline.
+
+        Args:
+            batch: List of documents to process (bounded size, typically 256)
+
+        Returns:
+            BatchResult with processing statistics.
+        """
+        logger.info(f"⚙️ Processing batch of {len(batch)} documents through pipeline")
+        start_time = time.time()
+
+        try:
+            logger.debug("🔄 Starting chunking phase for batch...")
+            chunking_start = time.time()
+            chunks_iter = self.chunking_worker.process_documents(batch)
+
+            logger.debug("🔄 Chunking completed, transitioning to embedding phase...")
+            chunking_duration = time.time() - chunking_start
+            logger.debug(f"⏱️ Chunking phase took {chunking_duration:.2f} seconds")
+
+            embedding_start = time.time()
+            embedded_chunks_iter = self.embedding_worker.process_chunks(chunks_iter)
+
+            logger.debug("🔄 Embedding phase ready, starting upsert phase...")
+
+            try:
+                pipeline_result = await asyncio.wait_for(
+                    self.upsert_worker.process_embedded_chunks(embedded_chunks_iter),
+                    timeout=600.0,  # 10 minute timeout per batch
+                )
+            except TimeoutError:
+                logger.error("❌ Batch processing timed out after 10 minutes")
+                return BatchResult(
+                    failure_count=len(batch),
+                    errors=["Batch processing timed out after 10 minutes"],
+                )
+
+            total_duration = time.time() - start_time
+            embedding_duration = time.time() - embedding_start
+
+            logger.debug(
+                f"⏱️ Embedding + Upsert phase took {embedding_duration:.2f} seconds"
+            )
+            logger.info(
+                f"✅ Batch processing completed: {pipeline_result.success_count} chunks, "
+                f"{pipeline_result.error_count} errors in {total_duration:.2f}s"
+            )
+
+            return BatchResult(
+                success_count=pipeline_result.success_count,
+                failure_count=pipeline_result.error_count,
+                skipped_count=0,
+                successfully_processed_documents=pipeline_result.successfully_processed_documents,
+                failed_document_ids=pipeline_result.failed_document_ids,
+                errors=pipeline_result.errors,
+            )
+
+        except Exception as e:
+            total_duration = time.time() - start_time
+            logger.error(
+                f"❌ Batch processing failed after {total_duration:.2f} seconds: {e}",
+                exc_info=True,
+            )
+            return BatchResult(
+                failure_count=len(batch),
+                errors=[f"Batch processing failed: {e}"],
+            )
+
     async def process_documents(self, documents: list[Document]) -> PipelineResult:
         """Process documents through the pipeline.
 
@@ -38,12 +128,10 @@ class DocumentPipeline:
         start_time = time.time()
 
         try:
-            # Step 1: Chunk documents
             logger.info("🔄 Starting chunking phase...")
             chunking_start = time.time()
             chunks_iter = self.chunking_worker.process_documents(documents)
 
-            # Step 2: Generate embeddings
             logger.info("🔄 Chunking completed, transitioning to embedding phase...")
             chunking_duration = time.time() - chunking_start
             logger.info(f"⏱️ Chunking phase took {chunking_duration:.2f} seconds")
@@ -51,10 +139,8 @@ class DocumentPipeline:
             embedding_start = time.time()
             embedded_chunks_iter = self.embedding_worker.process_chunks(chunks_iter)
 
-            # Step 3: Upsert to Qdrant
             logger.info("🔄 Embedding phase ready, starting upsert phase...")
 
-            # Add timeout for the entire pipeline to prevent indefinite hanging
             try:
                 result = await asyncio.wait_for(
                     self.upsert_worker.process_embedded_chunks(embedded_chunks_iter),
@@ -87,7 +173,6 @@ class DocumentPipeline:
                 f"❌ Document pipeline failed after {total_duration:.2f} seconds: {e}",
                 exc_info=True,
             )
-            # Return a result with error information
             result = PipelineResult()
             result.error_count = len(documents)
             result.errors = [f"Pipeline failed: {e}"]

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -148,6 +148,7 @@ class PipelineOrchestrator:
         source: str | None = None,
         project_id: str | None = None,
         force: bool = False,
+        since: datetime | None = None,
     ) -> list[Document]:
         """Main entry point for document processing.
 
@@ -157,6 +158,9 @@ class PipelineOrchestrator:
             source: Filter by specific source name
             project_id: Process documents for a specific project
             force: Force processing of all documents, bypassing change detection
+            since: Only stream documents updated after this timestamp (connector-level
+                filtering). Connectors that do not yet support time-based filtering will
+                fall back to full fetch with hash-based change detection.
 
         Returns:
             List of processed documents
@@ -204,7 +208,7 @@ class PipelineOrchestrator:
                     )
 
                 logger.debug("Processing all projects")
-                return await self._process_all_projects(source_type, source, force)
+                return await self._process_all_projects(source_type, source, force, since)
 
             # Check if filtered config is empty
             if source_type and not any(
@@ -233,11 +237,6 @@ class PipelineOrchestrator:
                 change_detector = await StateChangeDetector(
                     self.components.state_manager
                 ).__aenter__()
-
-            # `since` indicates the snapshot timestamp to stream changes from.
-            # It may be provided by callers in future; default to `None` for
-            # now to preserve backward compatibility and satisfy tests.
-            since: datetime | None = None
 
             seen_uris: set[str] = set()
             try:
@@ -349,6 +348,7 @@ class PipelineOrchestrator:
         source_type: str | None = None,
         source: str | None = None,
         force: bool = False,
+        since: datetime | None = None,
     ) -> list[Document]:
         """Process documents from all configured projects."""
         if not self.project_manager:
@@ -369,6 +369,7 @@ class PipelineOrchestrator:
                     source_type=source_type,
                     source=source,
                     force=force,
+                    since=since,
                 )
                 project_result = self.last_pipeline_result
                 all_documents.extend(project_documents)

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -234,6 +234,11 @@ class PipelineOrchestrator:
                     self.components.state_manager
                 ).__aenter__()
 
+            # `since` indicates the snapshot timestamp to stream changes from.
+            # It may be provided by callers in future; default to `None` for
+            # now to preserve backward compatibility and satisfy tests.
+            since: datetime | None = None
+
             seen_uris: set[str] = set()
             try:
                 # Prefer calling the new signature but fall back to the

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -308,7 +308,14 @@ class PipelineOrchestrator:
                     return []
 
                 if not force and not processed_documents:
-                    logger.info("✅ No new or updated documents to process")
+                    self.last_pipeline_result = aggregated_result
+                    if aggregated_result.error_count > 0:
+                        logger.error(
+                            "No documents were successfully processed",
+                            error_count=aggregated_result.error_count,
+                        )
+                    else:
+                        logger.info("No new or updated documents to process")
                     return []
 
                     # Deletion detection / reconciliation note:

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -1,6 +1,7 @@
 """Main orchestrator for the ingestion pipeline."""
 
 import traceback
+from collections.abc import AsyncIterator
 from datetime import datetime
 
 from qdrant_loader.config import Settings, SourcesConfig
@@ -53,6 +54,92 @@ class PipelineOrchestrator:
         self.components = components
         self.project_manager = project_manager
         self.last_pipeline_result = None
+
+    async def _stream_batches_from_sources(
+        self,
+        filtered_config: SourcesConfig,
+        batch_size: int = 256,
+        since: datetime | None = None,
+        project_id: str | None = None,
+        seen_uris: set[str] | None = None,
+    ) -> AsyncIterator[list[Document]]:
+        """Stream source documents in bounded micro-batches.
+
+        This helper collects documents from each source type and yields
+        batches of a fixed size, keeping memory usage bounded.
+        """
+        batch: list[Document] = []
+
+        # Note: previous implementation contained vestigial async inner
+        # helpers `_flush_batch` and `_append_document` which attempted to
+        # yield from inside non-generator contexts. These were dead code
+        # and confusing. Batching is handled inline in `_process_source_type`.
+
+        async def _process_source_type(source_type_name: str, source_configs):
+            if not source_configs:
+                return
+
+            async for document in self.components.source_processor.stream_source_documents(
+                source_configs,
+                get_connector_instance,
+                source_type_name,
+                since=since,
+            ):
+                # Inject project metadata when running with project context
+                if project_id and self.project_manager:
+                    try:
+                        document.metadata = self.project_manager.inject_project_metadata(
+                            project_id, document.metadata
+                        )
+                    except Exception:
+                        # Don't let metadata injection break streaming; log and continue
+                        logger.debug(
+                            "Project metadata injection failed for document",
+                            document_id=document.id,
+                            project_id=project_id,
+                        )
+
+                # Track seen URIs for potential post-stream reconciliation
+                if seen_uris is not None:
+                    try:
+                        uri = f"{document.source_type}:{document.source}:{document.url.rstrip('/') }"
+                        seen_uris.add(uri)
+                    except Exception:
+                        pass
+
+                batch.append(document)
+                if len(batch) >= batch_size:
+                    yield batch.copy()
+                    batch.clear()
+
+        if filtered_config.confluence:
+            async for yielded_batch in _process_source_type(
+                "Confluence", filtered_config.confluence
+            ):
+                yield yielded_batch
+
+        if filtered_config.git:
+            async for yielded_batch in _process_source_type("Git", filtered_config.git):
+                yield yielded_batch
+
+        if filtered_config.jira:
+            async for yielded_batch in _process_source_type("Jira", filtered_config.jira):
+                yield yielded_batch
+
+        if filtered_config.publicdocs:
+            async for yielded_batch in _process_source_type(
+                "PublicDocs", filtered_config.publicdocs
+            ):
+                yield yielded_batch
+
+        if filtered_config.localfile:
+            async for yielded_batch in _process_source_type(
+                "LocalFile", filtered_config.localfile
+            ):
+                yield yielded_batch
+
+        if batch:
+            yield batch
 
     async def process_documents(
         self,
@@ -138,71 +225,118 @@ class PipelineOrchestrator:
             ):
                 raise ValueError(f"No sources found for type '{source_type}'")
 
-            # Collect documents from all sources
-            documents = await self._collect_documents_from_sources(
-                filtered_config, current_project_id, since
-            )
+            # Stream documents in bounded micro-batches and process each batch
+            total_documents = 0
+            processed_documents: list[Document] = []
+            aggregated_result = PipelineResult()
+            batch_count = 0
 
-            # SAFETY CHECK: Empty-snapshot deletion protection (WS-3 territory)
-            #
-            # In force mode we bypass change detection entirely,
-            # so an empty snapshot means there is nothing to process.
-            #
-            # In normal mode we MUST continue into change detection,
-            # because an empty snapshot may indicate that previously
-            # indexed documents were deleted from the source.
-            #
-            # HOWEVER: Without an explicit signal from the connector that the
-            # snapshot is complete (vs. partial failure / API outage), an empty
-            # list could trigger mass deletion. Example: Jira API outage returns []
-            # → change detection classifies all 115k indexed docs as deleted.
-            #
-            # TEMPORARY FIX: Log a warning if snapshot is empty and we're about to
-            # proceed to change detection. This is safe but noisy.
-            #
-            # PERMANENT FIX (WS-3): Require connector contract to include
-            # `snapshot_is_complete: bool` or add per-source `enable_deletion_detection` flag.
-            if not documents and not force:
-                logger.warning(
-                    "⚠️ EMPTY SNAPSHOT in non-force mode. About to enter change detection "
-                    "which may classify existing corpus as deleted if source API returned partial/null results. "
-                    "This is a known risk (WS-3: add explicit snapshot_is_complete signal or per-source enable_deletion_detection). "
-                    "Proceeding carefully."
-                )
+            if not force and not self.components.state_manager._initialized:
+                logger.debug("Initializing state manager for change detection")
+                await self.components.state_manager.initialize()
 
-            if not documents and force:
-                logger.info("✅ No documents found from sources")
-                return []
+            change_detector = None
+            if not force:
+                change_detector = await StateChangeDetector(
+                    self.components.state_manager
+                ).__aenter__()
 
-            # Detect changes in documents (bypass if force=True)
-            if force:
-                logger.warning(
-                    f"🔄 Force mode enabled: bypassing change detection, processing all {len(documents)} documents"
-                )
-            else:
-                documents = await self._detect_document_changes(
-                    documents, filtered_config, current_project_id
-                )
+            seen_uris: set[str] = set()
+            try:
+                # Prefer calling the new signature but fall back to the
+                # legacy 3-arg signature for backwards compatibility / tests.
+                try:
+                    stream_iter = self._stream_batches_from_sources(
+                        filtered_config,
+                        256,
+                        since,
+                        project_id=current_project_id,
+                        seen_uris=seen_uris,
+                    )
+                except TypeError:
+                    # Callable likely expects the old signature
+                    stream_iter = self._stream_batches_from_sources(
+                        filtered_config, 256, since
+                    )
 
-                if not documents:
+                async for batch in stream_iter:
+                    total_documents += len(batch)
+                    batch_count += 1
+
+                    if not force and change_detector is not None:
+                        batch = await change_detector.classify_batch(
+                            batch, filtered_config, current_project_id
+                        )
+
+                    if not batch:
+                        continue
+
+                    batch_result = await self.components.document_pipeline.process_batch(
+                        batch
+                    )
+                    aggregated_result.success_count += batch_result.success_count
+                    aggregated_result.error_count += batch_result.failure_count
+                    aggregated_result.errors.extend(batch_result.errors)
+                    aggregated_result.successfully_processed_documents.update(
+                        batch_result.successfully_processed_documents
+                    )
+                    aggregated_result.failed_document_ids.update(
+                        batch_result.failed_document_ids
+                    )
+
+                    if batch_result.successfully_processed_documents:
+                        await self._update_document_states(
+                            batch,
+                            batch_result.successfully_processed_documents,
+                            current_project_id,
+                        )
+                        processed_documents.extend(
+                            [
+                                doc
+                                for doc in batch
+                                if doc.id in batch_result.successfully_processed_documents
+                            ]
+                        )
+
+                if total_documents == 0 and not force:
+                    logger.warning(
+                        "⚠️ EMPTY SNAPSHOT in non-force mode. About to enter change detection "
+                        "which may classify existing corpus as deleted if source API returned partial/null results. "
+                        "This is a known risk (WS-3: add explicit snapshot_is_complete signal or per-source enable_deletion_detection). "
+                        "Proceeding carefully."
+                    )
+
+                if total_documents == 0 and force:
+                    logger.info("✅ No documents found from sources")
+                    return []
+
+                if not force and not processed_documents:
                     logger.info("✅ No new or updated documents to process")
                     return []
 
-            # Process documents through the pipeline
-            result = await self.components.document_pipeline.process_documents(
-                documents
-            )
-            self.last_pipeline_result = result
+                    # Deletion detection / reconciliation note:
+                    # Streaming classification only detects new/updated documents
+                    # per-batch. Full deletion detection (documents present in the
+                    # state DB but absent from the current snapshot across all
+                    # batches) requires a post-stream reconciliation (WS-3).
+                    # For now we only log that reconciliation is possible and
+                    # record the set of seen URIs; implementors can enable a
+                    # reconciliation pass that compares previous state URIs to
+                    # `seen_uris` and call `_process_deleted_documents`.
+                    if not force:
+                        logger.debug(
+                            "Post-stream reconciliation not enabled. Seen URIs collected for potential WS-3 reconciliation",
+                            seen_count=len(seen_uris),
+                        )
 
-            # Update document states for successfully processed documents
-            await self._update_document_states(
-                documents, result.successfully_processed_documents, current_project_id
-            )
-
-            logger.info(
-                f"✅ Ingestion completed: {result.success_count} chunks processed successfully"
-            )
-            return documents
+                self.last_pipeline_result = aggregated_result
+                logger.info(
+                    f"✅ Ingestion completed: {aggregated_result.success_count} chunks processed successfully"
+                )
+                return processed_documents
+            finally:
+                if change_detector is not None:
+                    await change_detector.__aexit__(None, None, None)
 
         except Exception as e:
             logger.error(

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/source_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/source_processor.py
@@ -1,7 +1,8 @@
 """Source processor for handling different source types."""
 
 import asyncio
-from collections.abc import Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
+from datetime import datetime
 
 from qdrant_loader.config.source_config import SourceConfig
 from qdrant_loader.connectors.base import BaseConnector, ConnectorConfigurationError
@@ -71,8 +72,15 @@ class SourceProcessor:
 
                 # Use the connector as an async context manager to ensure proper initialization
                 async with connector:
-                    # Get documents from this source
-                    documents = await connector.get_documents()
+                    documents = []
+                    if isinstance(connector, BaseConnector):
+                        try:
+                            async for document in connector.stream_documents():
+                                documents.append(document)
+                        except (TypeError, NotImplementedError, AttributeError):
+                            documents = await connector.get_documents()
+                    else:
+                        documents = await connector.get_documents()
 
                     logger.debug(
                         f"Retrieved {len(documents)} documents from {source_type} source: {source_name}"
@@ -98,3 +106,64 @@ class SourceProcessor:
                 f"📥 {source_type}: {len(all_documents)} documents from {len(source_configs)} sources"
             )
         return all_documents
+
+    async def stream_source_documents(
+        self,
+        source_configs: Mapping[str, SourceConfig],
+        connector_factory: Callable[[SourceConfig], BaseConnector],
+        source_type: str,
+        since: datetime | None = None,
+    ) -> AsyncIterator[Document]:
+        """Stream documents from a specific source type (WS-1).
+
+        Yields documents one at a time as they are fetched from the source.
+        """
+        logger.debug(f"Streaming {source_type} sources: {list(source_configs.keys())}")
+
+        for source_name, source_config in source_configs.items():
+            if self.shutdown_event.is_set():
+                logger.info(
+                    f"Shutdown requested, skipping {source_type} source: {source_name}"
+                )
+                break
+
+            try:
+                logger.debug(f"Streaming {source_type} source: {source_name}")
+
+                connector = connector_factory(source_config)
+
+                if (
+                    self.file_conversion_config
+                    and hasattr(connector, "set_file_conversion_config")
+                    and hasattr(source_config, "enable_file_conversion")
+                    and source_config.enable_file_conversion
+                ):
+                    logger.debug(
+                        f"Setting file conversion config for {source_type} source: {source_name}"
+                    )
+                    connector.set_file_conversion_config(self.file_conversion_config)
+
+                async with connector:
+                    document_count = 0
+                    async for document in connector.stream_documents(since=since):
+                        yield document
+                        document_count += 1
+                        if document_count % 100 == 0:
+                            logger.debug(
+                                f"Streamed {document_count} documents from {source_type} source: {source_name}"
+                            )
+
+                    if document_count > 0:
+                        logger.info(
+                            f"✅ Streamed {document_count} documents from {source_type} source: {source_name}"
+                        )
+
+            except ConnectorConfigurationError:
+                raise
+            except Exception as e:
+                safe_error = sanitize_exception_message(e)
+                logger.error(
+                    f"Failed to stream {source_type} source {source_name}: {safe_error}",
+                    error_type=type(e).__name__,
+                )
+                continue

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/source_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/source_processor.py
@@ -77,7 +77,8 @@ class SourceProcessor:
                         try:
                             async for document in connector.stream_documents():
                                 documents.append(document)
-                        except (TypeError, NotImplementedError, AttributeError):
+                        except NotImplementedError:
+                            # Connector does not implement streaming; fall back to eager fetch
                             documents = await connector.get_documents()
                     else:
                         documents = await connector.get_documents()

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/state_change_detector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/state_change_detector.py
@@ -135,7 +135,7 @@ class StateChangeDetector:
         )
 
         current_states = [self._get_document_state(doc) for doc in documents]
-        previous_states_dict: dict[str, DocumentState] = {}
+        previous_states_by_id: dict[str, DocumentState] = {}
 
         # Group documents by source to perform bulk DB lookups per source
         groups: dict[tuple[str, str], list[Document]] = {}
@@ -153,7 +153,7 @@ class StateChangeDetector:
                     uri = self._generate_uri(
                         record.url, record.source, record.source_type, record.document_id  # type: ignore
                     )
-                    previous_states_dict[uri] = DocumentState(
+                    previous_states_by_id[record.document_id] = DocumentState(
                         document_id=record.document_id,  # type: ignore
                         uri=uri,
                         content_hash=record.content_hash,  # type: ignore
@@ -169,12 +169,15 @@ class StateChangeDetector:
                 )
                 raise
 
-        changed_documents = [
-            doc
-            for state, doc in zip(current_states, documents, strict=False)
-            if state.uri not in previous_states_dict
-            or self._is_document_updated(state, previous_states_dict[state.uri])
-        ]
+        changed_documents: list[Document] = []
+        for state, doc in zip(current_states, documents, strict=False):
+            previous = previous_states_by_id.get(doc.id)
+            if (
+                previous is None
+                or state.uri != previous.uri
+                or self._is_document_updated(state, previous)
+            ):
+                changed_documents.append(doc)
 
         self.logger.info(
             "Batch classification completed",

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/state_change_detector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/state_change_detector.py
@@ -113,6 +113,77 @@ class StateChangeDetector:
 
         return changes
 
+    async def classify_batch(
+        self,
+        documents: list[Document],
+        filtered_config: SourcesConfig,
+        project_id: str | None = None,
+    ) -> list[Document]:
+        """Classify a bounded batch of documents by comparing against state records.
+
+        This method performs targeted state lookups per document URI and returns
+        only new or updated documents for processing.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "StateChangeDetector not initialized. Use as async context manager."
+            )
+
+        self.logger.info(
+            "Classifying document batch for inline change detection",
+            document_count=len(documents),
+        )
+
+        current_states = [self._get_document_state(doc) for doc in documents]
+        previous_states_dict: dict[str, DocumentState] = {}
+
+        # Group documents by source to perform bulk DB lookups per source
+        groups: dict[tuple[str, str], list[Document]] = {}
+        for doc in documents:
+            key = (doc.source_type, doc.source)
+            groups.setdefault(key, []).append(doc)
+
+        for (source_type, source), docs in groups.items():
+            try:
+                ids = [d.id for d in docs]
+                records = await self.state_manager.get_document_state_records_by_ids(
+                    source_type, source, ids, project_id
+                )
+                for record in records:
+                    uri = self._generate_uri(
+                        record.url, record.source, record.source_type, record.document_id  # type: ignore
+                    )
+                    previous_states_dict[uri] = DocumentState(
+                        document_id=record.document_id,  # type: ignore
+                        uri=uri,
+                        content_hash=record.content_hash,  # type: ignore
+                        updated_at=record.updated_at,  # type: ignore
+                    )
+            except Exception as e:
+                self.logger.error(
+                    "Error loading existing document state for batch classification",
+                    source_type=source_type,
+                    source=source,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+                raise
+
+        changed_documents = [
+            doc
+            for state, doc in zip(current_states, documents, strict=False)
+            if state.uri not in previous_states_dict
+            or self._is_document_updated(state, previous_states_dict[state.uri])
+        ]
+
+        self.logger.info(
+            "Batch classification completed",
+            new_or_updated_count=len(changed_documents),
+            total_documents=len(documents),
+        )
+
+        return changed_documents
+
     def _get_document_state(self, document: Document) -> DocumentState:
         """Get the standardized state of a document."""
         try:

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
@@ -379,6 +379,32 @@ class StateManager:
             )
             raise
 
+    async def get_document_state_records_by_ids(
+        self,
+        source_type: str,
+        source: str,
+        document_ids: list[str],
+        project_id: str | None = None,
+    ) -> list[DocumentStateRecord]:
+        """Get multiple document state records for a given source in a single query."""
+        self.logger.debug(
+            f"Getting document state records for {source_type}:{source} (batch of {len(document_ids)})"
+        )
+        try:
+            return await _transitions.get_document_state_records_by_ids(
+                self._session_factory,  # type: ignore[arg-type]
+                source_type=source_type,
+                source=source,
+                document_ids=document_ids,
+                project_id=project_id,
+            )
+        except Exception as e:
+            self.logger.error(
+                f"Error getting document state records by ids for {source_type}:{source}: {str(e)}",
+                exc_info=True,
+            )
+            raise
+
     async def get_document_state_records(
         self, source_config: SourceConfig, since: datetime | None = None
     ) -> list[DocumentStateRecord]:

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
@@ -144,6 +144,29 @@ async def get_document_state_records(
         return list(result.scalars().all())
 
 
+    async def get_document_state_records_by_ids(
+        session_factory: AsyncSessionFactory,
+        *,
+        source_type: str,
+        source: str,
+        document_ids: list[str],
+        project_id: str | None = None,
+    ) -> list[DocumentStateRecord]:
+        """Fetch a set of DocumentStateRecord rows for a given source and list of document IDs in one query."""
+        if not document_ids:
+            return []
+        async with session_factory() as session:  # type: ignore
+            query = select(DocumentStateRecord).filter(
+                DocumentStateRecord.source_type == source_type,
+                DocumentStateRecord.source == source,
+                DocumentStateRecord.document_id.in_(document_ids),
+            )
+            if project_id is not None:
+                query = query.filter(DocumentStateRecord.project_id == project_id)
+            result = await session.execute(query)
+            return list(result.scalars().all())
+
+
 async def update_document_state(
     session_factory: AsyncSessionFactory,
     *,

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
@@ -160,6 +160,7 @@ async def get_document_state_records_by_ids(
             DocumentStateRecord.source_type == source_type,
             DocumentStateRecord.source == source,
             DocumentStateRecord.document_id.in_(document_ids),
+            DocumentStateRecord.is_deleted.is_(False),
         )
         if project_id is not None:
             query = query.filter(DocumentStateRecord.project_id == project_id)

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
@@ -131,9 +131,9 @@ async def get_document_state_records(
     since: datetime | None,
 ) -> list[DocumentStateRecord]:
     async with session_factory() as session:  # type: ignore
-        query = select(DocumentStateRecord).filter(
-            DocumentStateRecord.source_type == source,
-        )
+        # Select records for the given source_type and source; the previous
+        # duplicate assignment filtered on the wrong field and was overridden
+        # immediately — remove the erroneous assignment.
         query = select(DocumentStateRecord).filter(
             DocumentStateRecord.source_type == source_type,
             DocumentStateRecord.source == source,
@@ -144,27 +144,27 @@ async def get_document_state_records(
         return list(result.scalars().all())
 
 
-    async def get_document_state_records_by_ids(
-        session_factory: AsyncSessionFactory,
-        *,
-        source_type: str,
-        source: str,
-        document_ids: list[str],
-        project_id: str | None = None,
-    ) -> list[DocumentStateRecord]:
-        """Fetch a set of DocumentStateRecord rows for a given source and list of document IDs in one query."""
-        if not document_ids:
-            return []
-        async with session_factory() as session:  # type: ignore
-            query = select(DocumentStateRecord).filter(
-                DocumentStateRecord.source_type == source_type,
-                DocumentStateRecord.source == source,
-                DocumentStateRecord.document_id.in_(document_ids),
-            )
-            if project_id is not None:
-                query = query.filter(DocumentStateRecord.project_id == project_id)
-            result = await session.execute(query)
-            return list(result.scalars().all())
+async def get_document_state_records_by_ids(
+    session_factory: AsyncSessionFactory,
+    *,
+    source_type: str,
+    source: str,
+    document_ids: list[str],
+    project_id: str | None = None,
+) -> list[DocumentStateRecord]:
+    """Fetch a set of DocumentStateRecord rows for a given source and list of document IDs in one query."""
+    if not document_ids:
+        return []
+    async with session_factory() as session:  # type: ignore
+        query = select(DocumentStateRecord).filter(
+            DocumentStateRecord.source_type == source_type,
+            DocumentStateRecord.source == source,
+            DocumentStateRecord.document_id.in_(document_ids),
+        )
+        if project_id is not None:
+            query = query.filter(DocumentStateRecord.project_id == project_id)
+        result = await session.execute(query)
+        return list(result.scalars().all())
 
 
 async def update_document_state(

--- a/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
+++ b/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
@@ -104,4 +104,4 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
     )
 
     assert recorded_calls, "_stream_batches_from_sources was not called"
-    assert recorded_calls[0]["since"] is not None
+    assert recorded_calls[0]["since"] == history.last_successful_ingestion

--- a/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
+++ b/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
@@ -104,4 +104,6 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
     )
 
     assert recorded_calls, "_stream_batches_from_sources was not called"
-    assert recorded_calls[0]["since"] == history.last_successful_ingestion
+    assert recorded_calls[0]["since"] == datetime(
+        2026, 5, 20, 9, 55, 0, tzinfo=UTC
+    )

--- a/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
+++ b/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
@@ -58,8 +58,29 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
         project_manager=MagicMock(),
     )
     # Stub deep enough so orchestrator.process_documents reaches
-    # _collect_documents_from_sources without needing real DB/Qdrant.
-    orchestrator._collect_documents_from_sources = AsyncMock(return_value=[])
+    # _stream_batches_from_sources without needing real DB/Qdrant.
+    recorded_calls: list[dict[str, object]] = []
+
+    async def fake_stream_batches(
+        filtered_config,
+        batch_size=256,
+        since=None,
+        project_id=None,
+        seen_uris=None,
+    ):
+        recorded_calls.append(
+            {
+                "filtered_config": filtered_config,
+                "batch_size": batch_size,
+                "since": since,
+                "project_id": project_id,
+                "seen_uris": seen_uris,
+            }
+        )
+        if False:
+            yield
+
+    orchestrator._stream_batches_from_sources = fake_stream_batches
 
     history = MagicMock()
     history.last_successful_ingestion = datetime(2026, 5, 20, 10, 0, 0, tzinfo=UTC)
@@ -82,12 +103,5 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
         }
     )
 
-    # Confirm orchestrator was called with since != None
-    call_kwargs = orchestrator._collect_documents_from_sources.call_args
-    assert call_kwargs is not None, "_collect_documents_from_sources was not called"
-    passed_since = call_kwargs.kwargs.get("since") or (
-        call_kwargs.args[2] if len(call_kwargs.args) > 2 else None
-    )
-    assert (
-        passed_since is not None
-    ), "since was not forwarded to _collect_documents_from_sources"
+    assert recorded_calls, "_stream_batches_from_sources was not called"
+    assert recorded_calls[0]["since"] is not None

--- a/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
+++ b/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
@@ -1136,6 +1136,6 @@ class TestFetchById:
             patch.object(connector, "get_issues", fake_get_issues),
         ):
             async with connector:
-                entity_ids = await connector.list_entity_ids()
+                entity_ids = [entity_id async for entity_id in connector.list_entity_ids()]
 
         assert entity_ids == ["TEST-1"]

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -113,34 +113,42 @@ class TestPipelineOrchestrator:
 
         # Configure mocks
         self.source_filter.filter_sources.return_value = filtered_config
-        self.orchestrator._collect_documents_from_sources = AsyncMock(
-            return_value=mock_documents
-        )
-        self.orchestrator._detect_document_changes = AsyncMock(
-            return_value=mock_documents
-        )
-        self.document_pipeline.process_documents.return_value = mock_result
         self.orchestrator._update_document_states = AsyncMock()
 
-        # Execute - pass sources_config parameter
-        result = await self.orchestrator.process_documents(
-            sources_config=self.mock_sources_config
-        )
+        async def fake_stream_batches(filtered_config_arg, batch_size=256, since=None):
+            assert filtered_config_arg is filtered_config
+            yield mock_documents
 
-        # Verify
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = mock_documents
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            mock_result.failure_count = 0
+            mock_result.errors = []
+            mock_result.failed_document_ids = set()
+            self.document_pipeline.process_batch.return_value = mock_result
+            result = await self.orchestrator.process_documents(
+                sources_config=self.mock_sources_config
+            )
+
         assert result == mock_documents
         self.source_filter.filter_sources.assert_called_once_with(
             self.mock_sources_config, None, None
         )
-        self.orchestrator._collect_documents_from_sources.assert_called_once_with(
-            filtered_config, None, None
-        )
-        self.orchestrator._detect_document_changes.assert_called_once_with(
-            mock_documents, filtered_config, None
-        )
-        self.document_pipeline.process_documents.assert_called_once_with(mock_documents)
+        self.document_pipeline.process_batch.assert_called_once_with(mock_documents)
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1", "doc2"}, None
+        )
+        mock_change_detector.classify_batch.assert_called_once_with(
+            mock_documents, filtered_config, None
         )
 
     @pytest.mark.asyncio
@@ -150,27 +158,36 @@ class TestPipelineOrchestrator:
         filtered_config = Mock(spec=SourcesConfig)
         mock_documents = [Mock(spec=Document, id="doc1")]
 
-        # Setup mocks
         self.source_filter.filter_sources.return_value = filtered_config
-        self.orchestrator._collect_documents_from_sources = AsyncMock(
-            return_value=mock_documents
-        )
-        self.orchestrator._detect_document_changes = AsyncMock(
-            return_value=mock_documents
-        )
-
-        mock_result = Mock()
-        mock_result.successfully_processed_documents = {"doc1"}
-        mock_result.success_count = 1
-        self.document_pipeline.process_documents.return_value = mock_result
         self.orchestrator._update_document_states = AsyncMock()
 
-        # Execute
-        result = await self.orchestrator.process_documents(
-            sources_config=custom_sources_config
-        )
+        async def fake_stream_batches(filtered_config_arg, batch_size=256, since=None):
+            assert filtered_config_arg is filtered_config
+            yield mock_documents
 
-        # Verify
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = mock_documents
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            mock_result = Mock()
+            mock_result.successfully_processed_documents = {"doc1"}
+            mock_result.success_count = 1
+            mock_result.failure_count = 0
+            mock_result.errors = []
+            mock_result.failed_document_ids = set()
+            self.document_pipeline.process_batch.return_value = mock_result
+            result = await self.orchestrator.process_documents(
+                sources_config=custom_sources_config
+            )
+
         assert result == mock_documents
         self.source_filter.filter_sources.assert_called_once_with(
             custom_sources_config, None, None
@@ -188,40 +205,46 @@ class TestPipelineOrchestrator:
 
         mock_documents = [Mock(spec=Document, id="doc1")]
 
-        # Setup mocks
         self.source_filter.filter_sources.return_value = filtered_config
-        self.orchestrator._collect_documents_from_sources = AsyncMock(
-            return_value=mock_documents
-        )
-        self.orchestrator._detect_document_changes = AsyncMock(
-            return_value=mock_documents
-        )
-
-        mock_result = Mock()
-        mock_result.successfully_processed_documents = {"doc1"}
-        mock_result.success_count = 1
-        self.document_pipeline.process_documents.return_value = mock_result
         self.orchestrator._update_document_states = AsyncMock()
 
-        # Execute - pass sources_config parameter
-        result = await self.orchestrator.process_documents(
-            sources_config=self.mock_sources_config, source_type="git", source="my-repo"
-        )
+        async def fake_stream_batches(filtered_config_arg, batch_size=256, since=None):
+            assert filtered_config_arg is filtered_config
+            yield mock_documents
 
-        # Verify
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = mock_documents
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            mock_result = Mock()
+            mock_result.successfully_processed_documents = {"doc1"}
+            mock_result.success_count = 1
+            mock_result.failure_count = 0
+            mock_result.errors = []
+            mock_result.failed_document_ids = set()
+            self.document_pipeline.process_batch.return_value = mock_result
+            result = await self.orchestrator.process_documents(
+                sources_config=self.mock_sources_config, source_type="git", source="my-repo"
+            )
+
         assert result == mock_documents
         self.source_filter.filter_sources.assert_called_once_with(
             self.mock_sources_config, "git", "my-repo"
         )
-        self.orchestrator._collect_documents_from_sources.assert_called_once_with(
-            filtered_config, None, None
-        )
-        self.orchestrator._detect_document_changes.assert_called_once_with(
-            mock_documents, filtered_config, None
-        )
-        self.document_pipeline.process_documents.assert_called_once_with(mock_documents)
+        self.document_pipeline.process_batch.assert_called_once_with(mock_documents)
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1"}, None
+        )
+        mock_change_detector.classify_batch.assert_called_once_with(
+            mock_documents, filtered_config, None
         )
 
     @pytest.mark.asyncio
@@ -255,21 +278,28 @@ class TestPipelineOrchestrator:
         filtered_config.publicdocs = None
         filtered_config.localfile = None
 
-        # Setup mocks
         self.source_filter.filter_sources.return_value = filtered_config
-        self.orchestrator._collect_documents_from_sources = AsyncMock(return_value=[])
-        self.orchestrator._detect_document_changes = AsyncMock(return_value=[])
 
-        # Execute
-        result = await self.orchestrator.process_documents(
-            sources_config=self.mock_sources_config
-        )
+        async def fake_stream_batches(filtered_config_arg, batch_size=256, since=None):
+            if False:
+                yield []
 
-        # Verify
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            result = await self.orchestrator.process_documents(
+                sources_config=self.mock_sources_config
+            )
+
         assert result == []
-        self.orchestrator._collect_documents_from_sources.assert_called_once_with(
-            filtered_config, None, None
-        )
 
     @pytest.mark.asyncio
     async def test_process_documents_no_changes_detected(self):
@@ -277,21 +307,31 @@ class TestPipelineOrchestrator:
         mock_documents = [Mock(spec=Document, id="doc1")]
         filtered_config = Mock(spec=SourcesConfig)
 
-        # Setup mocks
         self.source_filter.filter_sources.return_value = filtered_config
-        self.orchestrator._collect_documents_from_sources = AsyncMock(
-            return_value=mock_documents
-        )
-        self.orchestrator._detect_document_changes = AsyncMock(return_value=[])
+        self.orchestrator._update_document_states = AsyncMock()
 
-        # Execute
-        result = await self.orchestrator.process_documents(
-            sources_config=self.mock_sources_config
-        )
+        async def fake_stream_batches(filtered_config_arg, batch_size=256, since=None):
+            assert filtered_config_arg is filtered_config
+            yield mock_documents
 
-        # Verify
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = []
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            result = await self.orchestrator.process_documents(
+                sources_config=self.mock_sources_config
+            )
+
         assert result == []
-        self.orchestrator._detect_document_changes.assert_called_once_with(
+        mock_change_detector.classify_batch.assert_called_once_with(
             mock_documents, filtered_config, None
         )
 
@@ -300,9 +340,12 @@ class TestPipelineOrchestrator:
         """Test document processing exception handling."""
         filtered_config = make_rich_compatible_mock(spec=SourcesConfig)
         self.source_filter.filter_sources.return_value = filtered_config
-        self.orchestrator._collect_documents_from_sources = AsyncMock(
-            side_effect=Exception("Collection failed")
-        )
+        async def failing_stream_batches(*args, **kwargs):
+            if False:
+                yield []
+            raise Exception("Collection failed")
+
+        self.orchestrator._stream_batches_from_sources = failing_stream_batches
 
         # Patch the logger to prevent Rich formatting issues during exception logging
         with patch("qdrant_loader.core.pipeline.orchestrator.logger"):
@@ -861,27 +904,34 @@ class TestPipelineOrchestrator:
         filtered_config.publicdocs = None
         filtered_config.localfile = None
 
-        # Setup mocks
         self.source_filter.filter_sources.return_value = filtered_config
-        self.orchestrator._collect_documents_from_sources = AsyncMock(return_value=[])
-        
-        # Mock change detection to simulate what would happen with empty docs
-        self.orchestrator._detect_document_changes = AsyncMock(return_value=[])
+        self.orchestrator._update_document_states = AsyncMock()
 
-        with patch("qdrant_loader.core.pipeline.orchestrator.logger") as mock_logger:
-            # Execute
+        async def fake_stream_batches(filtered_config_arg, batch_size=256, since=None):
+            if False:
+                yield []
+
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = []
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ), patch("qdrant_loader.core.pipeline.orchestrator.logger") as mock_logger:
             result = await self.orchestrator.process_documents(
                 sources_config=self.mock_sources_config
             )
 
-            # Verify warning was logged about empty snapshot
-            mock_logger.warning.assert_called()
-            warning_calls = [call for call in mock_logger.warning.call_args_list 
-                            if "EMPTY SNAPSHOT" in str(call)]
-            assert len(warning_calls) > 0, "Expected warning about empty snapshot"
-            
-            # Verify that change detection was still called (not skipped)
-            self.orchestrator._detect_document_changes.assert_called_once()
-            
-            # Verify empty result
-            assert result == []
+        mock_logger.warning.assert_called()
+        warning_calls = [
+            call
+            for call in mock_logger.warning.call_args_list
+            if "EMPTY SNAPSHOT" in str(call)
+        ]
+        assert len(warning_calls) > 0, "Expected warning about empty snapshot"
+        assert result == []


### PR DESCRIPTION
# Pull Request

## Summary

Streaming pipeline refactor

## Type of change

- [X] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")


## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Affected Connectors & Pipeline Stages

**Connectors:** BaseConnector adds streaming interface with `stream_documents(since)` and changes `list_entity_ids()` return type to `AsyncIterator[str]`. Jira connector refactored to streaming-first with new `fetch_by_id` method.

**Pipeline stages:** DocumentPipeline gains batched processing with `process_batch()` (10-minute upsert timeout). PipelineOrchestrator refactored to batch-streaming via `_stream_batches_from_sources`. SourceProcessor adds `stream_source_documents()`. StateChangeDetector gains batch classification. StateManager gains atomic deletion and batch lookup methods.

## Config Schema Changes

Breaking: `list_entity_ids()` return type changed from `list[str]` → `AsyncIterator[str]`. `PipelineComponents.__init__` now requires `qdrant_manager` parameter (previously implicit). Additive: `process_documents()` gains optional `since: datetime | None` for time-based filtering.

## Test Coverage

Integration and unit tests updated to verify batching flow, `StateChangeDetector.classify_batch` invocation, and `since` parameter forwarding.

## Safety Concerns

Resource-safe: async batching reduces memory vs. full materialization; 10-minute timeout guards upsert hangs. Consistency risk: two-phase deletion (DB mark, then Qdrant delete) may leave inconsistent state if Qdrant deletion fails post-commit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/martin-papy/qdrant-loader/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->