### PR TITLE
chore(workflow): add release notification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,12 +64,14 @@ jobs:
           uv build --out-dir dist/
           
       - name: Publish loader package to PyPI
+        id: publish_loader
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/qdrant-loader/dist/
 
       - name: Notify teams on success
-        if: success()
+        if: ${{ steps.publish_loader.conclusion == 'success' }}
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -93,7 +95,7 @@ jobs:
                   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                   version: "1.4",
                   body: [
-                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "QDrant Loader package published to PyPI successfully", "color": "Good" },
+                    { type: "TextBlock", weight: "Bolder", size: "Medium", text: "QDrant Loader package published to PyPI successfully", color: "Good" },
                     { type: "FactSet", facts: [
                       { title: "Tag name", value: $tag_name },
                       { title: "Triggered by", value: $actor },
@@ -106,7 +108,8 @@ jobs:
           curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
 
       - name: Notify teams on failure
-        if: failure()
+        if: ${{ always() && steps.publish_loader.conclusion == 'failure' }}
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -130,7 +133,7 @@ jobs:
                   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                   version: "1.4",
                   body: [
-                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "QDrant Loader package published to PyPI FAILED", color: "Attention" },
+                    { type: "TextBlock", weight: "Bolder", size: "Medium", text: "QDrant Loader package published to PyPI FAILED", color: "Attention" },
                     { type: "FactSet", facts: [
                       { title: "Tag name", value: $tag_name },
                       { title: "Triggered by", value: $actor },
@@ -140,7 +143,8 @@ jobs:
                 }
               }]
             }')
-          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+          curl --fail --silent --show-error --max-time 30 \
+            -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
 
   publish-mcp-server:
     name: Publish MCP Server to PyPI
@@ -166,12 +170,14 @@ jobs:
           uv build --out-dir dist/
           
       - name: Publish MCP server package to PyPI
+        id: publish_mcp_server
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/qdrant-loader-mcp-server/dist/
 
       - name: Notify teams on success
-        if: success()
+        if: ${{ steps.publish_mcp_server.conclusion == 'success' }}
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -195,7 +201,7 @@ jobs:
                   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                   version: "1.4",
                   body: [
-                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "MCP Server package published to PyPI successfully", "color": "Good" },
+                    { type: "TextBlock", weight: "Bolder", size: "Medium", text: "MCP Server package published to PyPI successfully", color: "Good" },
                     { type: "FactSet", facts: [
                       { title: "Tag name", value: $tag_name },
                       { title: "Triggered by", value: $actor },
@@ -208,7 +214,8 @@ jobs:
           curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
 
       - name: Notify teams on failure
-        if: failure()
+        if: ${{ always() && steps.publish_mcp_server.conclusion == 'failure' }}
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -232,7 +239,7 @@ jobs:
                   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                   version: "1.4",
                   body: [
-                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "MCP Server package published to PyPI FAILED", color: "Attention" },
+                    { type: "TextBlock", weight: "Bolder", size: "Medium", text: "MCP Server package published to PyPI FAILED", color: "Attention" },
                     { type: "FactSet", facts: [
                       { title: "Tag name", value: $tag_name },
                       { title: "Triggered by", value: $actor },
@@ -242,7 +249,8 @@ jobs:
                 }
               }]
             }')
-          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+          curl --fail --silent --show-error --max-time 30 \
+            -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
 
   publish-core:
     name: Publish qdrant-loader-core to PyPI
@@ -268,12 +276,14 @@ jobs:
           uv build --out-dir dist/
 
       - name: Publish core package to PyPI
+        id: publish_core
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/qdrant-loader-core/dist/
 
       - name: Notify teams on success
-        if: success()
+        if: ${{ steps.publish_core.conclusion == 'success' }}
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -297,7 +307,7 @@ jobs:
                   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                   version: "1.4",
                   body: [
-                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "Core Library package published to PyPI successfully", "color": "Good"},
+                    { type: "TextBlock", weight: "Bolder", size: "Medium", text: "Core Library package published to PyPI successfully", color: "Good"},
                     { type: "FactSet", facts: [
                       { title: "Tag name", value: $tag_name },
                       { title: "Triggered by", value: $actor },
@@ -310,7 +320,8 @@ jobs:
           curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
 
       - name: Notify teams on failure
-        if: failure()
+        if: ${{ always() && steps.publish_core.conclusion == 'failure' }}
+        continue-on-error: true
         env:
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -334,7 +345,7 @@ jobs:
                   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                   version: "1.4",
                   body: [
-                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "Core Library package published to PyPI FAILED", color: "Attention" },
+                    { type: "TextBlock", weight: "Bolder", size: "Medium", text: "Core Library package published to PyPI FAILED", color: "Attention" },
                     { type: "FactSet", facts: [
                       { title: "Tag name", value: $tag_name },
                       { title: "Triggered by", value: $actor },
@@ -344,4 +355,5 @@ jobs:
                 }
               }]
             }')
-          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+          curl --fail --silent --show-error --max-time 30 \
+            -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,80 @@ jobs:
         with:
           packages-dir: packages/qdrant-loader/dist/
 
+      - name: Notify teams on success
+        if: success()
+        env:
+          WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          URL: https://pypi.org/p/qdrant-loader
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "TEAMS_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          PAYLOAD=$(jq -n \
+            --arg tag_name "$TAG_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$URL" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  type: "AdaptiveCard",
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  version: "1.4",
+                  body: [
+                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "QDrant Loader package published to PyPI successfully", "color": "Good" },
+                    { type: "FactSet", facts: [
+                      { title: "Tag name", value: $tag_name },
+                      { title: "Triggered by", value: $actor },
+                      { title: "URL", value: $url }
+                    ]}
+                  ]
+                }
+              }]
+            }')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+
+      - name: Notify teams on failure
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "TEAMS_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          PAYLOAD=$(jq -n \
+            --arg tag_name "$TAG_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$RUN_URL" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  type: "AdaptiveCard",
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  version: "1.4",
+                  body: [
+                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "QDrant Loader package published to PyPI FAILED", color: "Attention" },
+                    { type: "FactSet", facts: [
+                      { title: "Tag name", value: $tag_name },
+                      { title: "Triggered by", value: $actor },
+                      { title: "Logs", value: $url }
+                    ]}
+                  ]
+                }
+              }]
+            }')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+
   publish-mcp-server:
     name: Publish MCP Server to PyPI
     runs-on: ubuntu-latest
@@ -96,6 +170,80 @@ jobs:
         with:
           packages-dir: packages/qdrant-loader-mcp-server/dist/
 
+      - name: Notify teams on success
+        if: success()
+        env:
+          WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          URL: https://pypi.org/p/qdrant-loader-mcp-server
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "TEAMS_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          PAYLOAD=$(jq -n \
+            --arg tag_name "$TAG_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$URL" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  type: "AdaptiveCard",
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  version: "1.4",
+                  body: [
+                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "MCP Server package published to PyPI successfully", "color": "Good" },
+                    { type: "FactSet", facts: [
+                      { title: "Tag name", value: $tag_name },
+                      { title: "Triggered by", value: $actor },
+                      { title: "URL", value: $url }
+                    ]}
+                  ]
+                }
+              }]
+            }')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+
+      - name: Notify teams on failure
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "TEAMS_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          PAYLOAD=$(jq -n \
+            --arg tag_name "$TAG_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$RUN_URL" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  type: "AdaptiveCard",
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  version: "1.4",
+                  body: [
+                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "MCP Server package published to PyPI FAILED", color: "Attention" },
+                    { type: "FactSet", facts: [
+                      { title: "Tag name", value: $tag_name },
+                      { title: "Triggered by", value: $actor },
+                      { title: "Logs", value: $url }
+                    ]}
+                  ]
+                }
+              }]
+            }')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+
   publish-core:
     name: Publish qdrant-loader-core to PyPI
     runs-on: ubuntu-latest
@@ -123,3 +271,77 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/qdrant-loader-core/dist/
+
+      - name: Notify teams on success
+        if: success()
+        env:
+          WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          URL: https://pypi.org/p/qdrant-loader-core
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "TEAMS_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          PAYLOAD=$(jq -n \
+            --arg tag_name "$TAG_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$URL" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  type: "AdaptiveCard",
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  version: "1.4",
+                  body: [
+                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "Core Library package published to PyPI successfully", "color": "Good"},
+                    { type: "FactSet", facts: [
+                      { title: "Tag name", value: $tag_name },
+                      { title: "Triggered by", value: $actor },
+                      { title: "URL", value: $url }
+                    ]}
+                  ]
+                }
+              }]
+            }')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"
+
+      - name: Notify teams on failure
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "TEAMS_WEBHOOK_URL not set, skipping notification"
+            exit 0
+          fi
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          PAYLOAD=$(jq -n \
+            --arg tag_name "$TAG_NAME" \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg url "$RUN_URL" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  type: "AdaptiveCard",
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  version: "1.4",
+                  body: [
+                    { type: "TextBlock", weight: "Bolder", size: "Large", text: "Core Library package published to PyPI FAILED", color: "Attention" },
+                    { type: "FactSet", facts: [
+                      { title: "Tag name", value: $tag_name },
+                      { title: "Triggered by", value: $actor },
+                      { title: "Logs", value: $url }
+                    ]}
+                  ]
+                }
+              }]
+            }')
+          curl -fsS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$WEBHOOK"


### PR DESCRIPTION
# Pull Request

## Summary

Add Teams notifications for release events, including success and failure status

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [x] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Affected Pipeline Stages: CI/CD publish workflow — release-triggered publish jobs for qdrant-loader, qdrant-loader-mcp-server, and qdrant-loader-core. No runtime connectors or application pipeline code touched.

Configuration Changes: Additive only — per-job Teams notification steps (success and failure) using secrets.TEAMS_WEBHOOK_URL; no breaking config or schema changes.

Test Coverage: None provided — workflow changes run only on release events; no unit/integration tests included and CI checkboxes remain unchecked.

Security & Resource Safety: Reasonable precautions — webhook URL read from secrets with graceful no-op when unset; payloads constructed via jq --arg to avoid injection; workflow permissions are minimal (contents: read; id-token: write for publish jobs); notifications include only non-sensitive fields (tag, actor, package/run URLs); curl uses fail-fast flags. No obvious resource or security risks identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->