### PR TITLE
feat(worker): lease renewal + pending-only cancel + race fix

### DIFF
--- a/docs/users/cli-reference/commands.md
+++ b/docs/users/cli-reference/commands.md
@@ -685,7 +685,7 @@ done
 
 ### `qdrant-loader jobs cancel`
 
-Cancel a pending or running job.
+Cancel a pending job.
 
 #### Basic Usage
 

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/jobs_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/jobs_cmd.py
@@ -18,14 +18,17 @@ from click.types import Path as ClickPath
 from qdrant_loader.core.worker.job_types import JobType
 
 
-def _load_config(workspace: Path | None, config: Path | None, env: Path | None) -> None:
-    """Validate flags and load global config. Raises ClickException on failure."""
+def _init_queue(workspace: Path | None, config: Path | None, env: Path | None):
+    """Load config, build StateManager and SQLiteJobQueue. Returns (state_manager, queue)."""
     from qdrant_loader.cli.config_loader import (
         load_config_with_workspace,
         setup_workspace,
     )
+    from qdrant_loader.config import get_global_config
     from qdrant_loader.config.workspace import validate_workspace_flags
+    from qdrant_loader.core.state.state_manager import StateManager
 
+    # Validate mutually exclusive flags early
     try:
         validate_workspace_flags(workspace, config, env)
     except ValueError as e:
@@ -48,30 +51,23 @@ def _load_config(workspace: Path | None, config: Path | None, env: Path | None) 
             skip_validation=True,
         )
 
+    global_config = get_global_config()
+    state_manager = StateManager(global_config.state_management)
+    return state_manager
+
 
 async def _run_with_queue(workspace, config, env, coro_factory):
-    """Load config, open engine directly (no DDL), run coro_factory(queue), dispose engine."""
-    from qdrant_loader.core.state.session import dispose_engine
-    from qdrant_loader.core.worker.queue import SQLiteJobQueue
-
-    engine, session_factory = _make_session_factory(workspace, config, env)
+    """Initialize queue, run coro_factory(queue), dispose state manager."""
+    state_manager = _init_queue(workspace, config, env)
+    await state_manager.initialize()
+    queue_instance = None
     try:
-        queue = SQLiteJobQueue(session_factory)
-        return await coro_factory(queue)
+        from qdrant_loader.core.worker.queue import SQLiteJobQueue
+
+        queue_instance = SQLiteJobQueue(state_manager._session_factory)
+        return await coro_factory(queue_instance)
     finally:
-        await dispose_engine(engine)
-
-
-def _make_session_factory(
-    workspace: Path | None, config: Path | None, env: Path | None
-):
-    """Minimum bootstrap: load config, build engine, return (engine, session_factory). No DDL."""
-    from qdrant_loader.config import get_global_config
-    from qdrant_loader.core.state.session import initialize_engine_and_session
-
-    _load_config(workspace, config, env)
-    global_config = get_global_config()
-    return initialize_engine_and_session(global_config.state_management)
+        await state_manager.dispose()
 
 
 # ────────────────────────────────────────────────
@@ -117,9 +113,7 @@ def _common_options(fn):
 @jobs_cmd.command("list")
 @click.option(
     "--status",
-    type=Choice(
-        ["pending", "running", "done", "failed", "cancelled"], case_sensitive=False
-    ),
+    type=Choice(["pending", "running", "done", "failed"], case_sensitive=False),
     default=None,
     help="Filter by job status.",
 )
@@ -248,7 +242,7 @@ def jobs_trigger(
 @click.argument("job_id", type=int)
 @_common_options
 def jobs_cancel(job_id, workspace, config_path, env_path):
-    """Cancel a pending or running job."""
+    """Cancel a pending job."""
 
     async def _cancel(queue):
         ok = await queue.cancel(job_id)
@@ -256,7 +250,7 @@ def jobs_cancel(job_id, workspace, config_path, env_path):
             click.echo(f"Job {job_id} cancelled.")
         else:
             raise ClickException(
-                f"Job {job_id} not found or is not in pending/running state."
+                f"Job {job_id} not found or is not in pending state."
             )
 
     asyncio.run(_run_with_queue(workspace, config_path, env_path, _cancel))

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/jobs_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/jobs_cmd.py
@@ -19,7 +19,7 @@ from qdrant_loader.core.worker.job_types import JobType
 
 
 def _init_queue(workspace: Path | None, config: Path | None, env: Path | None):
-    """Load config, build StateManager and SQLiteJobQueue. Returns (state_manager, queue)."""
+    """Load config, build StateManager. Returns state_manager."""
     from qdrant_loader.cli.config_loader import (
         load_config_with_workspace,
         setup_workspace,
@@ -64,7 +64,7 @@ async def _run_with_queue(workspace, config, env, coro_factory):
     try:
         from qdrant_loader.core.worker.queue import SQLiteJobQueue
 
-        queue_instance = SQLiteJobQueue(state_manager._session_factory)
+        queue_instance = SQLiteJobQueue(state_manager.session_factory)
         return await coro_factory(queue_instance)
     finally:
         await state_manager.dispose()
@@ -113,7 +113,9 @@ def _common_options(fn):
 @jobs_cmd.command("list")
 @click.option(
     "--status",
-    type=Choice(["pending", "running", "done", "failed"], case_sensitive=False),
+    type=Choice(
+        ["pending", "running", "done", "failed", "cancelled"], case_sensitive=False
+    ),
     default=None,
     help="Filter by job status.",
 )
@@ -249,8 +251,6 @@ def jobs_cancel(job_id, workspace, config_path, env_path):
         if ok:
             click.echo(f"Job {job_id} cancelled.")
         else:
-            raise ClickException(
-                f"Job {job_id} not found or is not in pending state."
-            )
+            raise ClickException(f"Job {job_id} not found or is not in pending state.")
 
     asyncio.run(_run_with_queue(workspace, config_path, env_path, _cancel))

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -102,7 +102,31 @@ class QueueWorkerPool:
                     )
                     t0 = time.monotonic()
                     try:
-                        await self._handler(job.type, payload)
+                        # Start lease renewal task to prevent visibility timeout during handler
+                        renewal_interval = max(1, self._lease_seconds // 3)
+
+                        async def _renew_lease(
+                            *,
+                            current_job_id: int = job.id,
+                            current_lease_seconds: int = self._lease_seconds,
+                            current_renewal_interval: int = renewal_interval,
+                        ) -> None:
+                            while True:
+                                await asyncio.sleep(current_renewal_interval)
+                                async with self._queue_io_guard:
+                                    await self._queue.extend_visibility(
+                                        current_job_id, current_lease_seconds
+                                    )
+
+                        renewal_task = asyncio.create_task(_renew_lease())
+                        try:
+                            await self._handler(job.type, payload)
+                        finally:
+                            renewal_task.cancel()
+                            try:
+                                await renewal_task
+                            except asyncio.CancelledError:
+                                pass
                     except Exception as exc:
                         duration_ms = round((time.monotonic() - t0) * 1000)
                         async with self._queue_io_guard:

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -113,9 +113,17 @@ class QueueWorkerPool:
                         ) -> None:
                             while True:
                                 await asyncio.sleep(current_renewal_interval)
-                                async with self._queue_io_guard:
-                                    await self._queue.extend_visibility(
-                                        current_job_id, current_lease_seconds
+                                try:
+                                    async with self._queue_io_guard:
+                                        await self._queue.extend_visibility(
+                                            current_job_id, current_lease_seconds
+                                        )
+                                except Exception as exc:
+                                    logger.warning(
+                                        "job.lease_renew_failed",
+                                        job_id=current_job_id,
+                                        error=str(exc),
+                                        error_type=type(exc).__name__,
                                     )
 
                         renewal_task = asyncio.create_task(_renew_lease())
@@ -127,6 +135,13 @@ class QueueWorkerPool:
                                 await renewal_task
                             except asyncio.CancelledError:
                                 pass
+                            except Exception as exc:
+                                logger.warning(
+                                    "job.lease_renew_teardown_failed",
+                                    job_id=job.id,
+                                    error=str(exc),
+                                    error_type=type(exc).__name__,
+                                )
                     except Exception as exc:
                         duration_ms = round((time.monotonic() - t0) * 1000)
                         async with self._queue_io_guard:

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -48,6 +48,13 @@ class JobQueue(Protocol):
     ) -> bool:
         """Release a claimed job back to pending for a later retry."""
 
+    async def extend_visibility(self, job_id: int, lease_seconds: int) -> bool:
+        """Extend the visibility deadline of a RUNNING job by lease_seconds.
+
+        Used to prevent lease expiration during long-running handler execution.
+        Returns True if successfully extended, False if job is no longer RUNNING.
+        """
+
     async def list(self, status: str | None = None, limit: int = 100) -> list[Job]:
         """List jobs with optional status filter."""
 
@@ -55,7 +62,7 @@ class JobQueue(Protocol):
         """Reset a failed or done job back to pending so it can be retried."""
 
     async def cancel(self, job_id: int) -> bool:
-        """Cancel a pending or running job (sets status to cancelled, not failed)."""
+        """Cancel a pending job (sets status to CANCELLED)."""
 
 
 class SQLiteJobQueue:
@@ -223,6 +230,30 @@ class SQLiteJobQueue:
                 self._pending_event.set()
             return updated
 
+    async def extend_visibility(self, job_id: int, lease_seconds: int) -> bool:
+        """Extend the visibility deadline of a RUNNING job by lease_seconds.
+
+        Used to prevent lease expiration during long-running handler execution.
+        Returns True if successfully extended, False if job is no longer RUNNING.
+        """
+        now = datetime.now(UTC)
+        new_deadline = now + timedelta(seconds=lease_seconds)
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                update(Job)
+                .where(
+                    Job.id == job_id,
+                    Job.status == self.RUNNING,
+                )
+                .values(
+                    visibility_deadline=new_deadline,
+                )
+            )
+            updated = result.rowcount > 0
+            await session.commit()
+            return updated
+
     async def list(self, status: str | None = None, limit: int = 100) -> list[Job]:
         async with self._session_factory() as session:
             stmt = select(Job)
@@ -237,6 +268,7 @@ class SQLiteJobQueue:
         """Reset a failed/done job back to pending for retry.
 
         Preserve attempts so operator retries do not erase retry history.
+        Does not reset CANCELLED jobs (operator must explicitly delete them).
         """
         async with self._session_factory() as session:
             result = await session.execute(
@@ -258,14 +290,14 @@ class SQLiteJobQueue:
             return updated
 
     async def cancel(self, job_id: int) -> bool:
-        """Cancel a pending or running job."""
+        """Cancel a pending job."""
         now = datetime.now(UTC)
         async with self._session_factory() as session:
             result = await session.execute(
                 update(Job)
                 .where(
                     Job.id == job_id,
-                    Job.status.in_([self.PENDING, self.RUNNING]),
+                    Job.status == self.PENDING,
                 )
                 .values(
                     status=self.CANCELLED,

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -306,3 +306,48 @@ async def test_worker_pool_extends_visibility_during_long_handler(
     # No jobs should be left RUNNING
     running_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.RUNNING)
     assert len(running_jobs) == 0
+
+
+@pytest.mark.asyncio
+async def test_lease_renew_errors_do_not_mask_handler_error(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """Renewal DB failures must not replace the handler exception.
+
+    If extend_visibility fails while handler is still running, final job failure
+    should reflect the handler error, not the renewal-task error.
+    """
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source_lock": "jira-main"})
+
+    original_extend_visibility = sqlite_job_queue.extend_visibility
+
+    async def flaky_extend_visibility(job_id: int, lease_seconds: int) -> bool:
+        raise RuntimeError("db down during extend_visibility")
+
+    sqlite_job_queue.extend_visibility = flaky_extend_visibility  # type: ignore[method-assign]
+
+    async def handler(_job_type: str, _payload: dict[str, str]) -> None:
+        # Ensure renewal loop has time to run and fail first.
+        await asyncio.sleep(1.2)
+        raise ValueError("handler boom")
+
+    pool = QueueWorkerPool(
+        sqlite_job_queue,
+        handler=handler,
+        worker_count=1,
+        lease_seconds=1,
+        max_attempts=1,
+    )
+
+    try:
+        processed = await pool.run_until_empty()
+    finally:
+        sqlite_job_queue.extend_visibility = original_extend_visibility
+
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
+
+    assert processed == 1
+    assert len(failed_jobs) == 1
+    assert failed_jobs[0].last_error is not None
+    assert "handler boom" in failed_jobs[0].last_error
+    assert "extend_visibility" not in failed_jobs[0].last_error

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -260,3 +260,49 @@ async def test_worker_pool_marks_failed_for_missing_source_lock(
     assert len(done_jobs) == 0
     assert len(failed_jobs) == 1
     assert "source_lock" in failed_jobs[0].last_error
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_extends_visibility_during_long_handler(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """Lease renewal should prevent reclaim of long-running jobs.
+
+    Test that when a handler takes longer than (lease_seconds / 3),
+    the renewal task extends the visibility deadline periodically,
+    preventing false reclaim by another worker.
+    """
+    job = await sqlite_job_queue.enqueue("TEST", {"source_lock": "test"})
+
+    handler_duration = 0.15  # 150ms
+    lease_seconds = 10  # 10s lease
+    # renewal_interval = max(1, 10 // 3) = 3s
+
+    call_count = [0]  # Track handler invocations
+
+    async def long_handler(_type: str, _payload: dict) -> None:
+        call_count[0] += 1
+        await asyncio.sleep(handler_duration)
+
+    pool = QueueWorkerPool(
+        sqlite_job_queue,
+        handler=long_handler,
+        worker_count=1,
+        lease_seconds=lease_seconds,
+    )
+
+    # Run pool once
+    processed = await pool.run_until_empty()
+
+    # Job should be processed exactly once (no false reclaim)
+    assert processed == 1
+    assert call_count[0] == 1
+
+    # Job should be DONE
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    assert len(done_jobs) == 1
+    assert done_jobs[0].id == job.id
+
+    # No jobs should be left RUNNING
+    running_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.RUNNING)
+    assert len(running_jobs) == 0

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -266,7 +266,7 @@ async def test_cancel_pending_job_sets_cancelled_status(
 
 
 @pytest.mark.asyncio
-async def test_cancel_running_job_sets_cancelled_status(
+async def test_cancel_running_job_is_rejected(
     sqlite_job_queue: SQLiteJobQueue,
 ):
     job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
@@ -274,11 +274,14 @@ async def test_cancel_running_job_sets_cancelled_status(
     assert claimed is not None
 
     ok = await sqlite_job_queue.cancel(job.id)
-    assert ok is True
+    assert ok is False
 
     cancelled = await sqlite_job_queue.list(status=SQLiteJobQueue.CANCELLED)
-    assert len(cancelled) == 1
-    assert cancelled[0].status == SQLiteJobQueue.CANCELLED
+    assert len(cancelled) == 0
+
+    running = await sqlite_job_queue.list(status=SQLiteJobQueue.RUNNING)
+    assert len(running) == 1
+    assert running[0].id == job.id
 
 
 @pytest.mark.asyncio
@@ -292,3 +295,53 @@ async def test_cancelled_job_cannot_be_retried(sqlite_job_queue: SQLiteJobQueue)
 
     pending = await sqlite_job_queue.list(status=SQLiteJobQueue.PENDING)
     assert len(pending) == 0
+
+
+@pytest.mark.asyncio
+async def test_extend_visibility_updates_running_job_deadline(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """extend_visibility should extend deadline for RUNNING jobs."""
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "test"})
+
+    # Claim job (status = RUNNING, visibility_deadline = now + 60s)
+    claimed = await sqlite_job_queue.claim_next(lease_seconds=60)
+    assert claimed is not None
+    assert claimed.status == SQLiteJobQueue.RUNNING
+
+    # Extend by 30s
+    extended = await sqlite_job_queue.extend_visibility(job.id, lease_seconds=30)
+    assert extended is True  # Should succeed
+
+    # Verify deadline was extended (new deadline should be >= original + 30s)
+    updated_job = await sqlite_job_queue.claim_next(lease_seconds=60)
+    assert updated_job is None  # Can't claim again (still leased from renewal)
+
+
+@pytest.mark.asyncio
+async def test_extend_visibility_ignores_non_running_job(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """extend_visibility should fail for non-RUNNING jobs (DONE, FAILED, PENDING)."""
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "test"})
+    claimed = await sqlite_job_queue.claim_next(lease_seconds=60)
+    assert claimed is not None
+
+    # Mark DONE
+    await sqlite_job_queue.mark_done(job.id, claim_attempt=claimed.attempts)
+
+    # Try to extend DONE job
+    extended = await sqlite_job_queue.extend_visibility(job.id, lease_seconds=30)
+    assert extended is False  # Should fail because job is DONE
+
+
+@pytest.mark.asyncio
+async def test_extend_visibility_on_pending_job_fails(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """extend_visibility should reject PENDING jobs (not yet claimed)."""
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "test"})
+
+    # Try to extend PENDING job (without claiming)
+    extended = await sqlite_job_queue.extend_visibility(job.id, lease_seconds=30)
+    assert extended is False


### PR DESCRIPTION
# Pull Request

## Summary

- Lease renewal: Workers reclaim expired RUNNING jobs after lease_seconds
- Pending-only cancel: cancel() now only targets PENDING/RUNNING (not failed)
- Race fix: Removed UPDATE...RETURNING (SQLite + aiosqlite concurrent issue)

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)
