### PR TITLE
feature: document pipeline graph write hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ internal/
 
 # Beads issue tracking
 .beads/
+
+# FalkorDB / Redis snapshots
+packages/qdrant-loader-core/data/*.rdb
+

--- a/packages/qdrant-loader-core/pyproject.toml
+++ b/packages/qdrant-loader-core/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 dependencies = [
     "pydantic>=2.0.0",
     "structlog>=23.0.0",
-    "FalkorDB>=1.0"
 ]
 
 [project.optional-dependencies]
@@ -52,6 +51,9 @@ ollama = [
 ]
 gemini = [
     "google-genai>=0.3.0",
+]
+graph = [
+    "FalkorDB>=1.0"
 ]
 
 [project.urls]

--- a/packages/qdrant-loader-core/pyproject.toml
+++ b/packages/qdrant-loader-core/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = [
     "pydantic>=2.0.0",
     "structlog>=23.0.0",
+    "FalkorDB>=1.0"
 ]
 
 [project.optional-dependencies]

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
@@ -1,11 +1,7 @@
 import asyncio
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from .falkor_store import FalkorGraphStore
-else:
-    FalkorGraphStore = Any
-
+from .falkor_store import FalkorGraphStore
 from .schema.init_schema import init_schema
 from .store import GraphEdge, GraphNode, GraphStore, SubGraph
 

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from .falkor_store import FalkorGraphStore
+from .store import GraphEdge, GraphNode, GraphStore, SubGraph
+from .schema import init_schema
+
+try:
+    from qdrant_loader.config import get_settings
+except ImportError:  # pragma: no cover
+    get_settings = None
+
+__all__ = [
+    "FalkorGraphStore",
+    "GraphNode",
+    "GraphEdge",
+    "GraphStore",
+    "SubGraph",
+]
+
+# Singleton graph store instance
+_graph_store: FalkorGraphStore | None = None
+_graph_store_lock = asyncio.Lock()
+
+
+async def get_graph_store() -> FalkorGraphStore:
+    global _graph_store
+
+    if _graph_store is None:
+        async with _graph_store_lock:
+            if _graph_store is None:
+                # Config from settings
+                if get_settings is not None:
+                    try:
+                        settings = get_settings()
+                        graph_cfg = getattr(settings.global_config, "graph", None)
+
+                        if graph_cfg is not None:
+                            host = host or graph_cfg.connection.host
+                            port = port or graph_cfg.connection.port
+                            graph_name = graph_name or graph_cfg.graph_name
+
+                    except AttributeError:
+                        pass
+
+                # Normalize values
+                final_host = host or "localhost"
+                final_port = int(port) if port else 6379
+                final_graph = graph_name or "default_graph"
+
+                _graph_store = FalkorGraphStore(
+                    host=final_host,
+                    port=final_port,
+                    graph_name=final_graph,
+                )
+
+                # Init schema
+                await init_schema(_graph_store)
+
+    return _graph_store

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
@@ -76,7 +76,7 @@ async def get_graph_store(
                     host=final_host,
                     port=int(final_port),
                     graph_name=final_graph,
-                    max_connections=final_max_conn,
+                    max_connections=final_max_conn if final_max_conn is not None else 10,
                 )
 
                 # init schema

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
@@ -1,13 +1,19 @@
 import asyncio
+from typing import TYPE_CHECKING, Any
 
-from .falkor_store import FalkorGraphStore
+if TYPE_CHECKING:
+    from .falkor_store import FalkorGraphStore
+else:
+    FalkorGraphStore = Any
+
+from .schema.init_schema import init_schema
 from .store import GraphEdge, GraphNode, GraphStore, SubGraph
-from .schema import init_schema
 
 try:
     from qdrant_loader.config import get_settings
 except ImportError:  # pragma: no cover
     get_settings = None
+
 
 __all__ = [
     "FalkorGraphStore",
@@ -17,43 +23,67 @@ __all__ = [
     "SubGraph",
 ]
 
-# Singleton graph store instance
+
 _graph_store: FalkorGraphStore | None = None
 _graph_store_lock = asyncio.Lock()
 
 
-async def get_graph_store() -> FalkorGraphStore:
+async def get_graph_store(
+    host: str | None = None,
+    port: int | None = None,
+    graph_name: str | None = None,
+    max_connections: int | None = None,
+) -> FalkorGraphStore:
     global _graph_store
+
+    # Check runtime availability
+    if not isinstance(FalkorGraphStore, type):
+        raise ModuleNotFoundError(
+            "FalkorGraphStore requires the 'graph' extra.\n"
+            "Install it with:\n"
+            "    pip install qdrant-loader-core[graph]"
+        )
 
     if _graph_store is None:
         async with _graph_store_lock:
             if _graph_store is None:
-                # Config from settings
+                final_host = host or "localhost"
+                final_port = port if port is not None else 6379
+                final_graph = graph_name or "default_graph"
+                final_max_conn = max_connections
+
+                # merge config (only override if param not provided)
                 if get_settings is not None:
                     try:
                         settings = get_settings()
                         graph_cfg = getattr(settings.global_config, "graph", None)
 
                         if graph_cfg is not None:
-                            host = host or graph_cfg.connection.host
-                            port = port or graph_cfg.connection.port
-                            graph_name = graph_name or graph_cfg.graph_name
+                            if host is None:
+                                final_host = graph_cfg.connection.host
+                            if port is None:
+                                final_port = graph_cfg.connection.port
+                            if graph_name is None:
+                                final_graph = graph_cfg.graph_name
+                            if max_connections is None:
+                                final_max_conn = getattr(
+                                    graph_cfg.pool,
+                                    "max_connections",
+                                    None,
+                                )
 
                     except AttributeError:
                         pass
 
-                # Normalize values
-                final_host = host or "localhost"
-                final_port = int(port) if port else 6379
-                final_graph = graph_name or "default_graph"
-
+                # init store
                 _graph_store = FalkorGraphStore(
                     host=final_host,
-                    port=final_port,
+                    port=int(final_port),
                     graph_name=final_graph,
+                    max_connections=final_max_conn,
                 )
 
-                # Init schema
+                # init schema
                 await init_schema(_graph_store)
 
     return _graph_store

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qdrant_loader.core.document import Document
+
 from abc import ABC, abstractmethod
 from typing import ClassVar
-
-from qdrant_loader.core.document import Document
 
 from ..models import (
     CoreEdgeType,
@@ -132,7 +135,10 @@ class BaseEntityExtractor(EntityExtractor):
             )
 
         # 5. Cross references
-        edges.extend(self._extract_links(doc))
+        link_nodes, link_edges = self._extract_links(doc)
+
+        nodes.extend(link_nodes)
+        edges.extend(link_edges)
 
         # 6. Source specific
         custom_nodes, custom_edges = self._extract_source_specific(doc)
@@ -215,8 +221,8 @@ class BaseEntityExtractor(EntityExtractor):
     def _extract_links(
         self,
         doc: Document,
-    ) -> list[GraphEdge]:
-        return []
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
+        return [], []
 
     def _extract_source_specific(
         self,

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
@@ -29,7 +29,7 @@ class EntityExtractor(ABC):
     _registry: dict[str, type[EntityExtractor]] = {}
 
     @abstractmethod
-    def extract(self, doc: Document) -> SubGraph:
+    async def extract(self, doc: Document) -> SubGraph:
         """
         Map raw source data into a SubGraph
         """
@@ -67,7 +67,7 @@ class BaseEntityExtractor(EntityExtractor):
 
     source_type: ClassVar[str]
 
-    def extract(self, doc: Document) -> SubGraph:
+    async def extract(self, doc: Document) -> SubGraph:
         project = self._project(doc)
 
         nodes: list[GraphNode] = []

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+from qdrant_loader.core.document import Document
+
+from ..models import (
+    CoreEdgeType,
+    CoreNodeLabel,
+    GraphEdge,
+    GraphNode,
+    PersonInfo,
+    SubGraph,
+)
+
+
+# ------------------------
+# EntityExtractor Interface
+# ------------------------
+class EntityExtractor(ABC):
+    """
+    Interface for all entity extractors.
+    """
+
+    _registry: dict[str, type[EntityExtractor]] = {}
+
+    @abstractmethod
+    def extract(self, doc: Document) -> SubGraph:
+        """
+        Map raw source data into a SubGraph
+        """
+        raise NotImplementedError
+
+    # -------- Registry --------
+    @classmethod
+    def register_extractor(cls, source_type: str, extractor_cls: type[EntityExtractor]):
+        if source_type in cls._registry:
+            raise ValueError(
+                f"Extractor already registered for source_type={source_type}"
+            )
+        cls._registry[source_type] = extractor_cls
+
+    @classmethod
+    def for_source(cls, source_type: str) -> EntityExtractor:
+        if source_type not in cls._registry:
+            raise ValueError(f"No extractor registered for source_type={source_type}")
+        return cls._registry[source_type]()  # instantiate
+
+
+class BaseEntityExtractor(EntityExtractor):
+    """
+    Base extractor implementing shared graph extraction.
+
+    Common nodes:
+        - Document
+        - Person
+        - Container
+        - Label
+
+    Source-specific nodes are extracted via
+    _extract_source_specific().
+    """
+
+    source_type: ClassVar[str]
+
+    def extract(self, doc: Document) -> SubGraph:
+        project = self._project(doc)
+
+        nodes: list[GraphNode] = []
+        edges: list[GraphEdge] = []
+
+        # 1. Document
+        doc_node = self._build_document_node(doc, project)
+        nodes.append(doc_node)
+
+        # 2. People
+        people = self._extract_people(doc)
+
+        # Deduplicate people by canonical person id
+        seen_people: set[str] = set()
+
+        for person_info, role in people:
+            canonical_id = person_info.id
+
+            if canonical_id in seen_people:
+                continue
+
+            seen_people.add(canonical_id)
+
+            person_node = self._person_node(person_info, project)
+            nodes.append(person_node)
+
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=person_node.id,
+                    edge_type=CoreEdgeType.AUTHORED_BY,
+                    project=project,
+                    properties={"role": role},
+                )
+            )
+
+        # 3. Container (project / space / repo)
+        container = self._extract_container(doc)
+
+        if container:
+            nodes.append(container)
+
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=container.id,
+                    edge_type=CoreEdgeType.BELONGS_TO,
+                    project=project,
+                )
+            )
+
+        # 4. Labels
+        labels = self._extract_labels(doc)
+
+        for label in labels:
+            nodes.append(label)
+
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=label.id,
+                    edge_type=CoreEdgeType.HAS_LABEL,
+                    project=project,
+                )
+            )
+
+        # 5. Cross references
+        edges.extend(self._extract_links(doc))
+
+        # 6. Source specific
+        custom_nodes, custom_edges = self._extract_source_specific(doc)
+
+        nodes.extend(custom_nodes)
+        edges.extend(custom_edges)
+
+        return SubGraph(
+            nodes=nodes,
+            edges=edges,
+        )
+
+    def _build_document_node(
+        self,
+        doc: Document,
+        project: str | None,
+    ) -> GraphNode:
+        return GraphNode(
+            id=doc.id,
+            label=CoreNodeLabel.DOCUMENT,
+            project=project,
+            properties={
+                "title": doc.title,
+                "source_type": self.source_type,
+            },
+        )
+
+    def _person_node(
+        self,
+        person_info: PersonInfo,
+        project: str | None,
+    ) -> GraphNode:
+        return GraphNode(
+            id=person_info.id,
+            label=CoreNodeLabel.PERSON,
+            project=project,
+            properties={
+                "display_name": person_info.display_name,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Required hooks
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _project(self, doc: Document) -> str | None:
+        """
+        Return project / space / repository identifier.
+        """
+
+    @abstractmethod
+    def _extract_people(
+        self,
+        doc: Document,
+    ) -> list[tuple[PersonInfo, str]]:
+        """
+        Return [(person_info, role), ...]
+        """
+
+    @abstractmethod
+    def _extract_container(
+        self,
+        doc: Document,
+    ) -> GraphNode | None:
+        """
+        Return container node (project / space / repository)
+        """
+
+    # ------------------------------------------------------------------
+    # Optional hooks
+    # ------------------------------------------------------------------
+
+    def _extract_labels(
+        self,
+        doc: Document,
+    ) -> list[GraphNode]:
+        return []
+
+    def _extract_links(
+        self,
+        doc: Document,
+    ) -> list[GraphEdge]:
+        return []
+
+    def _extract_source_specific(
+        self,
+        doc: Document,
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
+        return [], []

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/confluence.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/confluence.py
@@ -1,0 +1,152 @@
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.base_extractor import (
+    BaseEntityExtractor,
+)
+from qdrant_loader_core.graph.models import (
+    CoreEdgeType,
+    CoreNodeLabel,
+    GraphEdge,
+    GraphNode,
+    PersonInfo,
+)
+
+
+class ConfluenceEntityExtractor(BaseEntityExtractor):
+    """
+    Confluence graph extractor.
+
+    Extracts:
+    - Document node from page
+    - Person node from author
+    - Container node from space
+    - Parent / child page hierarchy
+    """
+
+    source_type = "confluence"
+
+    # ------------------------------------------------------------------
+    # Project / Space
+    # ------------------------------------------------------------------
+
+    def _project(
+        self,
+        doc: Document,
+    ) -> str | None:
+        return doc.metadata.get("space_key")
+
+    # ------------------------------------------------------------------
+    # People
+    # ------------------------------------------------------------------
+
+    def _extract_people(
+        self,
+        doc: Document,
+    ) -> list[tuple[PersonInfo, str]]:
+        author = doc.metadata.get("author")
+
+        if not author:
+            return []
+
+        return [
+            (
+                PersonInfo(
+                    id=str(author),
+                    display_name=str(author),
+                ),
+                "author",
+            )
+        ]
+
+    # ------------------------------------------------------------------
+    # Space container
+    # ------------------------------------------------------------------
+
+    def _extract_container(
+        self,
+        doc: Document,
+    ) -> GraphNode | None:
+        space_key = doc.metadata.get("space_key")
+
+        if not space_key:
+            return None
+
+        return GraphNode(
+            id=f"space:{space_key}",
+            label=CoreNodeLabel.CONTAINER,
+            project=space_key,
+            properties={
+                "kind": "confluence_space",
+                "space_key": space_key,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Labels
+    # ------------------------------------------------------------------
+
+    def _extract_labels(
+        self,
+        doc: Document,
+    ) -> list[GraphNode]:
+        project = self._project(doc)
+
+        labels = doc.metadata.get("labels", [])
+
+        return [
+            GraphNode(
+                id=f"label:{label}",
+                label=CoreNodeLabel.LABEL,
+                project=project,
+                properties={
+                    "name": label,
+                },
+            )
+            for label in labels
+        ]
+
+    # ------------------------------------------------------------------
+    # Hierarchy
+    # ------------------------------------------------------------------
+
+    def _extract_source_specific(
+        self,
+        doc: Document,
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
+        project = self._project(doc)
+
+        edges: list[GraphEdge] = []
+
+        parent_id = doc.metadata.get("parent_id")
+
+        if parent_id:
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=str(parent_id),
+                    edge_type=CoreEdgeType.PART_OF,
+                    project=project,
+                    properties={
+                        "kind": "page_child",
+                    },
+                )
+            )
+
+        for child in doc.metadata.get("children", []):
+            child_id = child.get("id")
+
+            if not child_id:
+                continue
+
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=str(child_id),
+                    edge_type=CoreEdgeType.HAS_CHILD,
+                    project=project,
+                    properties={
+                        "kind": "page_child",
+                    },
+                )
+            )
+
+        return [], edges

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/confluence.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/confluence.py
@@ -1,4 +1,10 @@
-from qdrant_loader.core.document import Document
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qdrant_loader.core.document import Document
+
 from qdrant_loader_core.graph.extractor.base_extractor import (
     BaseEntityExtractor,
 )

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/git.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/git.py
@@ -1,0 +1,68 @@
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.base_extractor import (
+    BaseEntityExtractor,
+)
+from qdrant_loader_core.graph.models import (
+    CoreNodeLabel,
+    GraphNode,
+    PersonInfo,
+)
+
+
+class GitEntityExtractor(BaseEntityExtractor):
+    """
+    Git repository graph extractor.
+
+    Extracts:
+    - Document node (file)
+    - Person node from last_commit_author
+    - Container node from repository
+    """
+
+    source_type = "git"
+
+    def _project(
+        self,
+        doc: Document,
+    ) -> str | None:
+        return doc.metadata.get("repository_name")
+
+    def _extract_people(
+        self,
+        doc: Document,
+    ) -> list[tuple[PersonInfo, str]]:
+        author = doc.metadata.get("last_commit_author")
+
+        if not author:
+            return []
+
+        return [
+            (
+                PersonInfo(
+                    id=f"git_user:{author}",
+                    display_name=author,
+                ),
+                "last_committer",
+            )
+        ]
+
+    def _extract_container(
+        self,
+        doc: Document,
+    ) -> GraphNode | None:
+        repo_name = doc.metadata.get("repository_name")
+
+        if not repo_name:
+            return None
+
+        return GraphNode(
+            id=f"git:{repo_name}",
+            label=CoreNodeLabel.CONTAINER,
+            project=repo_name,
+            properties={
+                "kind": "repository",
+                "repository_name": repo_name,
+                "repository_owner": doc.metadata.get("repository_owner"),
+                "repository_url": doc.metadata.get("repository_url"),
+            },
+        )

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/git.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/git.py
@@ -1,4 +1,10 @@
-from qdrant_loader.core.document import Document
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qdrant_loader.core.document import Document
+
 from qdrant_loader_core.graph.extractor.base_extractor import (
     BaseEntityExtractor,
 )

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
@@ -1,0 +1,276 @@
+import re
+
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.base_extractor import (
+    BaseEntityExtractor,
+)
+from qdrant_loader_core.graph.models import (
+    CoreEdgeType,
+    CoreNodeLabel,
+    GraphEdge,
+    GraphNode,
+    PersonInfo,
+)
+
+
+class JiraEntityExtractor(BaseEntityExtractor):
+    """
+    Jira graph extractor.
+
+    Extracts:
+    - Document node (status, priority, issue_type)
+    - Person nodes (reporter, assignee)
+    - Container node (jira project)
+    - Label nodes
+    - Linked issue relationships
+    - Parent/subtask relationships
+    - Epic relationships
+    - Cross-source links from URLs found in description
+    """
+
+    # NOTE:
+    # Jira API currently provides `linked_issues` as list[str] without relationship types
+    # (e.g., "blocks", "duplicates", etc.), so we default to "kind=related".
+    # This can be enhanced when richer link metadata becomes available.
+
+    # Additionally, epic relationships are not implemented because the current data model
+    # does not include an `epic_key` or equivalent field. Support for epic-child relationships
+    # can be added once such metadata is available.
+
+    source_type = "jira"
+
+    CONFLUENCE_URL_RE = re.compile(
+        r"https?://[^\s]*confluence[^\s]+",
+        re.IGNORECASE,
+    )
+
+    GIT_URL_RE = re.compile(
+        r"https?://(?:github|gitlab|bitbucket)[^\s]+",
+        re.IGNORECASE,
+    )
+
+    # ------------------------------------------------------------------
+    # Project
+    # ------------------------------------------------------------------
+
+    def _project(
+        self,
+        doc: Document,
+    ) -> str | None:
+        return doc.metadata.get("project_key")
+
+    # ------------------------------------------------------------------
+    # Document
+    # ------------------------------------------------------------------
+
+    def _build_document_node(
+        self,
+        doc: Document,
+        project: str | None,
+    ) -> GraphNode:
+        metadata = doc.metadata
+
+        return GraphNode(
+            id=doc.id,
+            label=CoreNodeLabel.DOCUMENT,
+            project=project,
+            properties={
+                "title": doc.title,
+                "source_type": self.source_type,
+                "status": metadata.get("status"),
+                "priority": metadata.get("priority"),
+                "issue_type": metadata.get("issue_type"),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # People
+    # ------------------------------------------------------------------
+
+    def _extract_people(
+        self,
+        doc: Document,
+    ) -> list[tuple[PersonInfo, str]]:
+        people = []
+
+        reporter = doc.metadata.get("reporter")
+
+        if reporter:
+            person_id = reporter.get("email_address") or reporter.get("account_id")
+
+            if person_id:
+                people.append(
+                    (
+                        PersonInfo(
+                            id=person_id,
+                            display_name=reporter.get(
+                                "display_name",
+                                person_id,
+                            ),
+                        ),
+                        "reporter",
+                    )
+                )
+
+        assignee = doc.metadata.get("assignee")
+
+        if assignee:
+            person_id = assignee.get("email_address") or assignee.get("account_id")
+
+            if person_id:
+                people.append(
+                    (
+                        PersonInfo(
+                            id=person_id,
+                            display_name=assignee.get(
+                                "display_name",
+                                person_id,
+                            ),
+                        ),
+                        "assignee",
+                    )
+                )
+
+        return people
+
+    # ------------------------------------------------------------------
+    # Container
+    # ------------------------------------------------------------------
+
+    def _extract_container(
+        self,
+        doc: Document,
+    ) -> GraphNode | None:
+        project_key = doc.metadata.get("project_key")
+
+        if not project_key:
+            return None
+
+        return GraphNode(
+            id=f"jira:{project_key}",
+            label=CoreNodeLabel.CONTAINER,
+            project=project_key,
+            properties={
+                "kind": "jira_project",
+                "project_key": project_key,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Labels
+    # ------------------------------------------------------------------
+
+    def _extract_labels(
+        self,
+        doc: Document,
+    ) -> list[GraphNode]:
+        project = self._project(doc)
+
+        nodes: list[GraphNode] = []
+
+        for label in doc.metadata.get("labels", []):
+            nodes.append(
+                GraphNode(
+                    id=f"label:{label}",
+                    label=CoreNodeLabel.LABEL,
+                    project=project,
+                    properties={
+                        "name": label,
+                    },
+                )
+            )
+
+        return nodes
+
+    # ------------------------------------------------------------------
+    # Cross-source URL links
+    # ------------------------------------------------------------------
+
+    def _extract_links(
+        self,
+        doc: Document,
+    ) -> list[GraphEdge]:
+        project = self._project(doc)
+
+        text = doc.metadata.get("description") or getattr(doc, "content", "") or ""
+
+        edges: list[GraphEdge] = []
+
+        for url in self.CONFLUENCE_URL_RE.findall(text):
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=url,
+                    edge_type=CoreEdgeType.LINKS_TO,
+                    project=project,
+                    properties={
+                        "kind": "confluence",
+                    },
+                )
+            )
+
+        for url in self.GIT_URL_RE.findall(text):
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=url,
+                    edge_type=CoreEdgeType.LINKS_TO,
+                    project=project,
+                    properties={
+                        "kind": "git",
+                    },
+                )
+            )
+
+        return edges
+
+    # ------------------------------------------------------------------
+    # Jira-specific relationships
+    # ------------------------------------------------------------------
+
+    def _extract_source_specific(
+        self,
+        doc: Document,
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
+        project = self._project(doc)
+
+        edges: list[GraphEdge] = []
+
+        metadata = doc.metadata
+
+        # --------------------------------------------------------------
+        # Linked Issues
+        # --------------------------------------------------------------
+
+        for issue_key in metadata.get("linked_issues", []):
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=issue_key,
+                    edge_type=CoreEdgeType.LINKS_TO,
+                    project=project,
+                    properties={
+                        "kind": "related",
+                    },
+                )
+            )
+        # --------------------------------------------------------------
+        # Parent Issue
+        # --------------------------------------------------------------
+
+        parent_issue = metadata.get("parent_key")
+
+        if parent_issue:
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=parent_issue,
+                    edge_type=CoreEdgeType.PART_OF,
+                    project=project,
+                    properties={
+                        "kind": "subtask",
+                    },
+                )
+            )
+
+        return [], edges

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
@@ -214,16 +214,21 @@ class JiraEntityExtractor(BaseEntityExtractor):
         def _handle_url(url: str, kind: str) -> None:
             target = url.strip()
 
-            if _is_url(target):
-                nodes.append(
-                    GraphNode(
-                        id=target,
-                        label=CoreNodeLabel.URL,
-                        project=project,
-                        properties={"url": target},
-                    )
-                )
+            # Guard both node và edge
+            if not _is_url(target):
+                return
 
+            # Create node
+            nodes.append(
+                GraphNode(
+                    id=target,
+                    label=CoreNodeLabel.URL,
+                    project=project,
+                    properties={"url": target},
+                )
+            )
+
+            # Create edge (only when node exists)
             edges.append(
                 GraphEdge(
                     source=doc.id,

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
@@ -1,6 +1,12 @@
-import re
+from __future__ import annotations
 
-from qdrant_loader.core.document import Document
+import re
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from qdrant_loader.core.document import Document
+
 from qdrant_loader_core.graph.extractor.base_extractor import (
     BaseEntityExtractor,
 )
@@ -24,7 +30,6 @@ class JiraEntityExtractor(BaseEntityExtractor):
     - Label nodes
     - Linked issue relationships
     - Parent/subtask relationships
-    - Epic relationships
     - Cross-source links from URLs found in description
     """
 
@@ -96,39 +101,39 @@ class JiraEntityExtractor(BaseEntityExtractor):
         reporter = doc.metadata.get("reporter")
 
         if reporter:
-            person_id = reporter.get("email_address") or reporter.get("account_id")
+            if isinstance(reporter, dict):
+                person_id = (
+                    reporter.get("email_address")
+                    or reporter.get("account_id")
+                    or reporter.get("display_name")
+                )
+                display_name = reporter.get("display_name", person_id)
+            else:
+                person_id = str(reporter)
+                display_name = person_id
 
             if person_id:
                 people.append(
-                    (
-                        PersonInfo(
-                            id=person_id,
-                            display_name=reporter.get(
-                                "display_name",
-                                person_id,
-                            ),
-                        ),
-                        "reporter",
-                    )
+                    (PersonInfo(id=person_id, display_name=display_name), "reporter")
                 )
 
         assignee = doc.metadata.get("assignee")
 
         if assignee:
-            person_id = assignee.get("email_address") or assignee.get("account_id")
+            if isinstance(assignee, dict):
+                person_id = (
+                    assignee.get("email_address")
+                    or assignee.get("account_id")
+                    or assignee.get("display_name")
+                )
+                display_name = assignee.get("display_name", person_id)
+            else:
+                person_id = str(assignee)
+                display_name = person_id
 
             if person_id:
                 people.append(
-                    (
-                        PersonInfo(
-                            id=person_id,
-                            display_name=assignee.get(
-                                "display_name",
-                                person_id,
-                            ),
-                        ),
-                        "assignee",
-                    )
+                    (PersonInfo(id=person_id, display_name=display_name), "assignee")
                 )
 
         return people
@@ -186,43 +191,56 @@ class JiraEntityExtractor(BaseEntityExtractor):
     # Cross-source URL links
     # ------------------------------------------------------------------
 
+    from urllib.parse import urlparse
+
     def _extract_links(
         self,
         doc: Document,
-    ) -> list[GraphEdge]:
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
         project = self._project(doc)
 
         text = doc.metadata.get("description") or getattr(doc, "content", "") or ""
 
+        nodes: list[GraphNode] = []
         edges: list[GraphEdge] = []
 
-        for url in self.CONFLUENCE_URL_RE.findall(text):
+        def _is_url(value: str) -> bool:
+            try:
+                parsed = urlparse(value)
+                return bool(parsed.scheme and parsed.netloc)
+            except Exception:
+                return False
+
+        def _handle_url(url: str, kind: str) -> None:
+            target = url.strip()
+
+            if _is_url(target):
+                nodes.append(
+                    GraphNode(
+                        id=target,
+                        label=CoreNodeLabel.URL,
+                        project=project,
+                        properties={"url": target},
+                    )
+                )
+
             edges.append(
                 GraphEdge(
                     source=doc.id,
-                    target=url,
+                    target=target,
                     edge_type=CoreEdgeType.LINKS_TO,
                     project=project,
-                    properties={
-                        "kind": "confluence",
-                    },
+                    properties={"kind": kind},
                 )
             )
+
+        for url in self.CONFLUENCE_URL_RE.findall(text):
+            _handle_url(url, "confluence")
 
         for url in self.GIT_URL_RE.findall(text):
-            edges.append(
-                GraphEdge(
-                    source=doc.id,
-                    target=url,
-                    edge_type=CoreEdgeType.LINKS_TO,
-                    project=project,
-                    properties={
-                        "kind": "git",
-                    },
-                )
-            )
+            _handle_url(url, "git")
 
-        return edges
+        return nodes, edges
 
     # ------------------------------------------------------------------
     # Jira-specific relationships

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/localfile.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/localfile.py
@@ -1,6 +1,10 @@
-from pathlib import PurePath
+from __future__ import annotations
 
-from qdrant_loader.core.document import Document
+from pathlib import PurePath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qdrant_loader.core.document import Document
 
 from ..models import (
     CoreNodeLabel,

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/localfile.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/localfile.py
@@ -1,0 +1,82 @@
+from pathlib import PurePath
+
+from qdrant_loader.core.document import Document
+
+from ..models import (
+    CoreNodeLabel,
+    GraphNode,
+    PersonInfo,
+)
+from .base_extractor import BaseEntityExtractor
+
+
+class LocalFileEntityExtractor(BaseEntityExtractor):
+    """
+    Extract graph entities from local filesystem documents.
+    """
+
+    source_type = "localfile"
+
+    def _project(self, doc: Document) -> str | None:
+        """
+        Local files are not associated with a project.
+        """
+        return None
+
+    def _extract_people(
+        self,
+        doc: Document,
+    ) -> list[tuple[PersonInfo, str]]:
+        """
+        Local files do not expose author information by default.
+        """
+        return []
+
+    def _extract_container(
+        self,
+        doc: Document,
+    ) -> GraphNode | None:
+
+        if not doc.url:
+            return None
+
+        pure_path = PurePath(doc.url)
+
+        parent_path = str(pure_path.parent)
+        directory = "root" if parent_path == "." else parent_path
+        directory_name = PurePath(directory).name if directory != "root" else "root"
+
+        return GraphNode(
+            id=f"dir:{directory}",
+            label=CoreNodeLabel.CONTAINER,
+            project=None,
+            properties={
+                "kind": "filesystem_dir",
+                "name": directory_name,
+                "path": directory,
+            },
+        )
+
+    def _build_document_node(
+        self,
+        doc: Document,
+        project: str | None,
+    ) -> GraphNode:
+        """
+        Build a document node enriched with filesystem metadata.
+        """
+
+        file_name = doc.metadata.get("file_name")
+
+        return GraphNode(
+            id=doc.id,
+            label=CoreNodeLabel.DOCUMENT,
+            project=project,
+            properties={
+                "title": file_name,
+                "url": doc.url,
+                "created_at": doc.metadata.get("created_at"),
+                "updated_at": doc.metadata.get("updated_at"),
+                "source_type": self.source_type,
+            },
+        )

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/publicdocs.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/publicdocs.py
@@ -1,0 +1,160 @@
+from urllib.parse import urlparse
+
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.base_extractor import (
+    BaseEntityExtractor,
+)
+from qdrant_loader_core.graph.models import (
+    CoreEdgeType,
+    CoreNodeLabel,
+    GraphEdge,
+    GraphNode,
+)
+
+
+class PublicDocsEntityExtractor(BaseEntityExtractor):
+    """
+    Public documentation graph extractor.
+
+    Extracts:
+    - Document node from page
+    - Container node from website/domain
+    - LINKS_TO edges between pages
+    - Attachment nodes
+    """
+
+    source_type = "publicdocs"
+
+    # ------------------------------------------------------------------
+    # Project
+    # ------------------------------------------------------------------
+
+    def _project(
+        self,
+        doc: Document,
+    ) -> str | None:
+        url = doc.metadata.get("url")
+
+        if not url:
+            return None
+
+        parsed = urlparse(url)
+
+        return parsed.netloc
+
+    # ------------------------------------------------------------------
+    # People
+    # ------------------------------------------------------------------
+
+    def _extract_people(
+        self,
+        doc: Document,
+    ) -> list:
+        return []
+
+    # ------------------------------------------------------------------
+    # Container
+    # ------------------------------------------------------------------
+
+    def _extract_container(
+        self,
+        doc: Document,
+    ) -> GraphNode | None:
+        url = doc.metadata.get("url")
+
+        if not url:
+            return None
+
+        parsed = urlparse(url)
+
+        domain = parsed.netloc
+
+        if not domain:
+            return None
+
+        return GraphNode(
+            id=f"site:{domain}",
+            label=CoreNodeLabel.CONTAINER,
+            project=domain,
+            properties={
+                "kind": "website",
+                "domain": domain,
+            },
+        )
+
+    def _extract_labels(
+        self,
+        doc: Document,
+    ) -> list[GraphNode]:
+        project = self._project(doc)
+
+        return [
+            GraphNode(
+                id=f"label:{tag}",
+                label=CoreNodeLabel.LABEL,
+                project=project,
+                properties={"name": tag},
+            )
+            for tag in doc.metadata.get("tags", [])
+        ]
+
+    # ------------------------------------------------------------------
+    # Links + Attachments
+    # ------------------------------------------------------------------
+
+    def _extract_source_specific(
+        self,
+        doc: Document,
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
+        project = self._project(doc)
+
+        nodes: list[GraphNode] = []
+        edges: list[GraphEdge] = []
+
+        # --------------------------------------------------------------
+        # Internal links
+        # --------------------------------------------------------------
+
+        for link in doc.metadata.get("links", []):
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=link,
+                    edge_type=CoreEdgeType.LINKS_TO,
+                    project=project,
+                )
+            )
+
+        # --------------------------------------------------------------
+        # Attachments
+        # --------------------------------------------------------------
+
+        for attachment in doc.metadata.get("attachments", []):
+            attachment_id = attachment.get("id")
+
+            if not attachment_id:
+                continue
+
+            nodes.append(
+                GraphNode(
+                    id=f"attachment:{attachment_id}",
+                    label="Attachment",
+                    project=project,
+                    properties={
+                        "filename": attachment.get("filename"),
+                        "mime_type": attachment.get("mime_type"),
+                        "download_url": attachment.get("download_url"),
+                    },
+                )
+            )
+
+            edges.append(
+                GraphEdge(
+                    source=doc.id,
+                    target=f"attachment:{attachment_id}",
+                    edge_type=CoreEdgeType.HAS_ATTACHMENT,
+                    project=project,
+                )
+            )
+
+        return nodes, edges

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/publicdocs.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/publicdocs.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from qdrant_loader.core.document import Document
+if TYPE_CHECKING:
+    from qdrant_loader.core.document import Document
+
 from qdrant_loader_core.graph.extractor.base_extractor import (
     BaseEntityExtractor,
 )
@@ -33,7 +38,7 @@ class PublicDocsEntityExtractor(BaseEntityExtractor):
         self,
         doc: Document,
     ) -> str | None:
-        url = doc.metadata.get("url")
+        url = getattr(doc, "url", None) or doc.metadata.get("url")
 
         if not url:
             return None
@@ -60,7 +65,7 @@ class PublicDocsEntityExtractor(BaseEntityExtractor):
         self,
         doc: Document,
     ) -> GraphNode | None:
-        url = doc.metadata.get("url")
+        url = getattr(doc, "url", None) or doc.metadata.get("url")
 
         if not url:
             return None
@@ -138,7 +143,7 @@ class PublicDocsEntityExtractor(BaseEntityExtractor):
             nodes.append(
                 GraphNode(
                     id=f"attachment:{attachment_id}",
-                    label="Attachment",
+                    label=CoreNodeLabel.ATTACHMENT,
                     project=project,
                     properties={
                         "filename": attachment.get("filename"),

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+import datetime
+from enum import Enum
+import json
+from typing import Any
+
+from falkordb import FalkorDB
+
+from .models import (
+    CoreEdgeType,
+    CoreNodeLabel,
+    GraphEdge,
+    GraphNode,
+    SubGraph,
+)
+from .store import GraphStore
+
+
+class FalkorGraphStore(GraphStore):
+    def __init__(
+        self, host="localhost", port=6379, password=None, graph_name="default_graph"
+    ):
+        self._db = FalkorDB(host=host, port=port, password=password)
+        self._graph = self._db.select_graph(graph_name)
+
+    def _validate_node(self, node: GraphNode):
+        if node.label not in {e.value for e in CoreNodeLabel}:
+            raise ValueError(f"Invalid node label: {node.label}")
+
+    def _validate_edge(self, edge: GraphEdge):
+        if edge.edge_type not in {e.value for e in CoreEdgeType}:
+            raise ValueError(f"Invalid edge type: {edge.edge_type}")
+
+    async def upsert_node(self, node: GraphNode) -> None:
+        self._validate_node(node)
+
+        props = self._clean_props(node.properties or {})
+        project = node.project or props.get("project")
+
+        if project is not None:
+            query = f"""
+            MERGE (n:{node.label} {{id: $id, project: $project}})
+            SET n += $props
+            """
+            params = {
+                "id": node.id,
+                "project": project,
+                "props": props,
+            }
+        else:
+            query = f"""
+            MERGE (n:{node.label} {{id: $id}})
+            SET n += $props
+            """
+            params = {
+                "id": node.id,
+                "props": props,
+            }
+
+        await asyncio.to_thread(
+            self._graph.query,
+            query,
+            params,
+        )
+
+    async def upsert_nodes_batch(self, nodes: list[GraphNode]) -> None:
+        if not nodes:
+            return
+        for node in nodes:
+            self._validate_node(node)
+        grouped: dict[str, list[GraphNode]] = defaultdict(list)
+        for node in nodes:
+            grouped[node.label].append(node)
+
+        tasks = []
+        for label, group_nodes in grouped.items():
+            payload = [
+                {
+                    "id": node.id,
+                    "project": node.project or (node.properties or {}).get("project"),
+                    "props": self._clean_props(node.properties or {}),
+                }
+                for node in group_nodes
+            ]
+            with_project = [n for n in payload if n["project"] is not None]
+            without_project = [n for n in payload if n["project"] is None]
+
+            if with_project:
+                await asyncio.to_thread(
+                    self._graph.query,
+                    f"""
+                    UNWIND $nodes AS node
+                    MERGE (n:{label} {{id: node.id, project: node.project}})
+                    SET n += node.props
+                    """,
+                    {"nodes": with_project},
+                )
+            if without_project:
+                await asyncio.to_thread(
+                    self._graph.query,
+                    f"""
+                    UNWIND $nodes AS node
+                    MERGE (n:{label} {{id: node.id}})
+                    SET n += node.props
+                    """,
+                    {"nodes": without_project},
+                )
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def upsert_edge(self, edge: GraphEdge) -> None:
+        self._validate_edge(edge)
+        props = self._clean_props(edge.properties or {})
+        project = edge.project or props.get("project")
+        params = {
+            "source": edge.source,
+            "target": edge.target,
+            "props": props,
+        }
+        if project is not None:
+            params["project"] = project
+            query = f"""
+            MATCH (a {{id: $source, project: $project}}),
+                (b {{id: $target, project: $project}})
+            MERGE (a)-[r:{edge.edge_type}]->(b)
+            SET r += $props
+            """
+        else:
+            query = f"""
+            MATCH (a {{id: $source}}),
+                (b {{id: $target}})
+            MERGE (a)-[r:{edge.edge_type}]->(b)
+            SET r += $props
+            """
+        await asyncio.to_thread(
+            self._graph.query,
+            query,
+            params,
+        )
+
+    async def upsert_edges_batch(
+        self,
+        edges: list[GraphEdge],
+    ) -> None:
+        if not edges:
+            return
+        for edge in edges:
+            self._validate_edge(edge)
+        grouped: dict[str, list[GraphEdge]] = defaultdict(list)
+        for edge in edges:
+            grouped[edge.edge_type].append(edge)
+
+        tasks = []
+        for edge_type, group_edges in grouped.items():
+            payload = [
+                {
+                    "source": edge.source,
+                    "target": edge.target,
+                    "project": edge.project or (edge.properties or {}).get("project"),
+                    "props": self._clean_props(edge.properties or {}),
+                }
+                for edge in group_edges
+            ]
+
+            with_project = [e for e in payload if e["project"] is not None]
+            without_project = [e for e in payload if e["project"] is None]
+
+            if with_project:
+                tasks.append(
+                    asyncio.to_thread(
+                        self._graph.query,
+                        f"""
+                    UNWIND $edges AS e
+                    MATCH (a {{id: e.source, project: e.project}})
+                    MATCH (b {{id: e.target, project: e.project}})
+                    MERGE (a)-[r:{edge_type}]->(b)
+                    SET r += e.props
+                    """,
+                        {"edges": with_project},
+                    )
+                )
+            if without_project:
+                tasks.append(
+                    asyncio.to_thread(
+                        self._graph.query,
+                        f"""
+                    UNWIND $edges AS e
+                    MATCH (a {{id: e.source}})
+                    MATCH (b {{id: e.target}})
+                    MERGE (a)-[r:{edge_type}]->(b)
+                    SET r += e.props
+                    """,
+                        {"edges": without_project},
+                    )
+                )
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def neighbors(
+        self,
+        node_id: str,
+        depth: int,
+        edge_types: list[str] | None = None,
+        project: str | None = None,
+    ) -> SubGraph:
+        edge_filter = ""
+        if edge_types:
+            invalid = [
+                e for e in edge_types if e not in {et.value for et in CoreEdgeType}
+            ]
+            if invalid:
+                raise ValueError(f"Invalid edge types: {invalid}")
+            edge_filter = ":" + "|".join(edge_types)
+        params = {"id": node_id}
+        MAX_ROWS = 5000
+        if project:
+            params["project"] = project
+            query = f"""
+            MATCH (n {{id: $id, project: $project}})-[r{edge_filter}*1..{depth}]-(m {{project: $project}})
+            RETURN n.id, type(r), m.id
+            LIMIT {MAX_ROWS}
+            """
+        else:
+            query = f"""
+            MATCH (n {{id: $id}})-[r{edge_filter}*1..{depth}]-(m)
+            RETURN n.id, type(r), m.id
+            LIMIT {MAX_ROWS}
+            """
+        result = await asyncio.to_thread(
+            self._graph.query,
+            query,
+            params,
+        )
+        nodes_map: dict[str, GraphNode] = {}
+        internal_node_id_map: dict[int, str] = {}
+        edges: list[GraphEdge] = []
+
+        def _extract_node(node_value):
+            if hasattr(node_value, "properties"):
+                node_id = node_value.properties.get("id")
+                label = (
+                    node_value.labels[0]
+                    if getattr(node_value, "labels", None)
+                    else "Unknown"
+                )
+                properties = node_value.properties or {}
+            elif isinstance(node_value, dict):
+                node_id = node_value.get("id")
+                label = node_value.get("label", "Unknown")
+                properties = node_value
+            else:
+                node_id = str(node_value)
+                label = "Unknown"
+                properties = {}
+            return node_id, label, properties
+
+        def _normalize_relationships(rels_value):
+            if rels_value is None:
+                return []
+            if isinstance(rels_value, list):
+                return rels_value
+            return [rels_value]
+
+        def _resolve_internal_node_id(node_value):
+            if isinstance(node_value, int):
+                return internal_node_id_map.get(node_value, str(node_value))
+            return node_value
+
+        def _extract_edge(rel):
+            if hasattr(rel, "src_node") and hasattr(rel, "dest_node"):
+                source = _resolve_internal_node_id(rel.src_node)
+                target = _resolve_internal_node_id(rel.dest_node)
+                edge_type = getattr(rel, "relation", getattr(rel, "edge_type", None))
+                properties = rel.properties or {}
+                return GraphEdge(
+                    source=source,
+                    target=target,
+                    edge_type=edge_type,
+                    properties=properties,
+                )
+            if isinstance(rel, dict):
+                return GraphEdge(
+                    source=rel.get("source"),
+                    target=rel.get("target"),
+                    edge_type=rel.get("edge_type"),
+                    properties=rel.get("properties", {}),
+                )
+            raise ValueError("Unsupported relationship result type")
+
+        for row in result.result_set:
+            if len(row) != 3:
+                continue
+            n, rels, m = row
+            n_id, n_label, n_props = _extract_node(n)
+            if hasattr(n, "id") and isinstance(n.id, int):
+                internal_node_id_map[n.id] = n_id
+            if n_id not in nodes_map:
+                nodes_map[n_id] = GraphNode(id=n_id, label=n_label, properties=n_props)
+
+            m_id, m_label, m_props = _extract_node(m)
+            if hasattr(m, "id") and isinstance(m.id, int):
+                internal_node_id_map[m.id] = m_id
+            if m_id not in nodes_map:
+                nodes_map[m_id] = GraphNode(id=m_id, label=m_label, properties=m_props)
+
+            for rel in _normalize_relationships(rels):
+                try:
+                    edge = _extract_edge(rel)
+                except ValueError:
+                    continue
+                edges.append(edge)
+        return SubGraph(
+            nodes=list(nodes_map.values()),
+            edges=edges,
+        )
+
+    async def query_cypher(
+        self,
+        cypher: str,
+        params: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        result = await asyncio.to_thread(self._graph.query, cypher, params or {})
+        return result.result_set
+
+    def _clean_props(self, props: dict) -> dict:
+        def _normalize_value(v: Any):
+            if v is None:
+                return None
+
+            if isinstance(v, (str, int, float, bool)):
+                return v
+
+            if isinstance(v, (datetime, datetime.date)):
+                return v.isoformat()
+
+            if isinstance(v, Enum):
+                return v.value
+
+            if isinstance(v, list):
+                cleaned = []
+                for item in v:
+                    val = _normalize_value(item)
+
+                    if isinstance(val, (str, int, float, bool)):
+                        cleaned.append(val)
+                    else:
+                        if val is not None:
+                            cleaned.append(str(val))
+                return cleaned
+
+            if isinstance(v, dict):
+                try:
+                    return json.dumps(v, ensure_ascii=False)
+                except Exception:
+                    return str(v)
+            try:
+                return str(v)
+            except Exception:
+                return None
+
+        clean = {}
+        for k, v in props.items():
+            val = _normalize_value(v)
+            if val is None:
+                continue
+            clean[k] = val
+        return clean

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections import defaultdict
 import datetime
-from enum import Enum
 import json
+from collections import defaultdict
+from enum import Enum
 from typing import Any
 
 from falkordb import FalkorDB
@@ -21,8 +21,17 @@ from .store import GraphStore
 
 class FalkorGraphStore(GraphStore):
     def __init__(
-        self, host="localhost", port=6379, password=None, graph_name="default_graph"
+        self,
+        host="localhost",
+        port=6379,
+        password=None,
+        graph_name="default_graph",
+        max_connections: int = 10,
     ):
+
+        if max_connections < 1:
+            raise ValueError("max_connections must be >= 1")
+        self._semaphore = asyncio.Semaphore(max_connections)
         self._db = FalkorDB(host=host, port=port, password=password)
         self._graph = self._db.select_graph(graph_name)
 
@@ -89,24 +98,28 @@ class FalkorGraphStore(GraphStore):
             without_project = [n for n in payload if n["project"] is None]
 
             if with_project:
-                await asyncio.to_thread(
-                    self._graph.query,
-                    f"""
+                tasks.append(
+                    asyncio.to_thread(
+                        self._graph.query,
+                        f"""
                     UNWIND $nodes AS node
                     MERGE (n:{label} {{id: node.id, project: node.project}})
                     SET n += node.props
                     """,
-                    {"nodes": with_project},
+                        {"nodes": with_project},
+                    )
                 )
             if without_project:
-                await asyncio.to_thread(
-                    self._graph.query,
-                    f"""
+                tasks.append(
+                    asyncio.to_thread(
+                        self._graph.query,
+                        f"""
                     UNWIND $nodes AS node
                     MERGE (n:{label} {{id: node.id}})
                     SET n += node.props
                     """,
-                    {"nodes": without_project},
+                        {"nodes": without_project},
+                    )
                 )
         if tasks:
             await asyncio.gather(*tasks)
@@ -220,13 +233,13 @@ class FalkorGraphStore(GraphStore):
             params["project"] = project
             query = f"""
             MATCH (n {{id: $id, project: $project}})-[r{edge_filter}*1..{depth}]-(m {{project: $project}})
-            RETURN n.id, type(r), m.id
+            RETURN n, r, m
             LIMIT {MAX_ROWS}
             """
         else:
             query = f"""
             MATCH (n {{id: $id}})-[r{edge_filter}*1..{depth}]-(m)
-            RETURN n.id, type(r), m.id
+            RETURN n, r, m
             LIMIT {MAX_ROWS}
             """
         result = await asyncio.to_thread(
@@ -321,9 +334,10 @@ class FalkorGraphStore(GraphStore):
         self,
         cypher: str,
         params: dict[str, Any],
-    ) -> list[dict[str, Any]]:
-        result = await asyncio.to_thread(self._graph.query, cypher, params or {})
-        return result.result_set
+    ) -> list[list[Any]]:
+        async with self._semaphore:
+            result = await asyncio.to_thread(self._graph.query, cypher, params or {})
+            return result.result_set
 
     def _clean_props(self, props: dict) -> dict:
         def _normalize_value(v: Any):
@@ -333,7 +347,7 @@ class FalkorGraphStore(GraphStore):
             if isinstance(v, (str, int, float, bool)):
                 return v
 
-            if isinstance(v, (datetime, datetime.date)):
+            if isinstance(v, (datetime.datetime, datetime.date)):
                 return v.isoformat()
 
             if isinstance(v, Enum):

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
@@ -69,11 +69,7 @@ class FalkorGraphStore(GraphStore):
                 "props": props,
             }
 
-        await asyncio.to_thread(
-            self._graph.query,
-            query,
-            params,
-        )
+        await self._run_query(query, params)
 
     async def upsert_nodes_batch(self, nodes: list[GraphNode]) -> None:
         if not nodes:
@@ -97,32 +93,34 @@ class FalkorGraphStore(GraphStore):
             with_project = [n for n in payload if n["project"] is not None]
             without_project = [n for n in payload if n["project"] is None]
 
+            tasks = []
+
             if with_project:
                 tasks.append(
-                    asyncio.to_thread(
-                        self._graph.query,
+                    self._run_query(
                         f"""
-                    UNWIND $nodes AS node
-                    MERGE (n:{label} {{id: node.id, project: node.project}})
-                    SET n += node.props
-                    """,
+                        UNWIND $nodes AS node
+                        MERGE (n:{label} {{id: node.id, project: node.project}})
+                        SET n += node.props
+                        """,
                         {"nodes": with_project},
                     )
                 )
+
             if without_project:
                 tasks.append(
-                    asyncio.to_thread(
-                        self._graph.query,
+                    self._run_query(
                         f"""
-                    UNWIND $nodes AS node
-                    MERGE (n:{label} {{id: node.id}})
-                    SET n += node.props
-                    """,
+                        UNWIND $nodes AS node
+                        MERGE (n:{label} {{id: node.id}})
+                        SET n += node.props
+                        """,
                         {"nodes": without_project},
                     )
                 )
-        if tasks:
-            await asyncio.gather(*tasks)
+
+            if tasks:
+                await asyncio.gather(*tasks)
 
     async def upsert_edge(self, edge: GraphEdge) -> None:
         self._validate_edge(edge)
@@ -148,11 +146,7 @@ class FalkorGraphStore(GraphStore):
             MERGE (a)-[r:{edge.edge_type}]->(b)
             SET r += $props
             """
-        await asyncio.to_thread(
-            self._graph.query,
-            query,
-            params,
-        )
+        await self._run_query(query, params)
 
     async def upsert_edges_batch(
         self,
@@ -183,8 +177,7 @@ class FalkorGraphStore(GraphStore):
 
             if with_project:
                 tasks.append(
-                    asyncio.to_thread(
-                        self._graph.query,
+                        self._run_query(
                         f"""
                     UNWIND $edges AS e
                     MATCH (a {{id: e.source, project: e.project}})
@@ -193,12 +186,11 @@ class FalkorGraphStore(GraphStore):
                     SET r += e.props
                     """,
                         {"edges": with_project},
-                    )
+                        )
                 )
             if without_project:
                 tasks.append(
-                    asyncio.to_thread(
-                        self._graph.query,
+                        self._run_query(
                         f"""
                     UNWIND $edges AS e
                     MATCH (a {{id: e.source}})
@@ -207,7 +199,7 @@ class FalkorGraphStore(GraphStore):
                     SET r += e.props
                     """,
                         {"edges": without_project},
-                    )
+                        )
                 )
         if tasks:
             await asyncio.gather(*tasks)
@@ -242,11 +234,7 @@ class FalkorGraphStore(GraphStore):
             RETURN n, r, m
             LIMIT {MAX_ROWS}
             """
-        result = await asyncio.to_thread(
-            self._graph.query,
-            query,
-            params,
-        )
+        result = await self._run_query(query, params)
         nodes_map: dict[str, GraphNode] = {}
         internal_node_id_map: dict[int, str] = {}
         edges: list[GraphEdge] = []
@@ -335,9 +323,8 @@ class FalkorGraphStore(GraphStore):
         cypher: str,
         params: dict[str, Any],
     ) -> list[list[Any]]:
-        async with self._semaphore:
-            result = await asyncio.to_thread(self._graph.query, cypher, params or {})
-            return result.result_set
+        result = await self._run_query(cypher, params or {})
+        return result.result_set
 
     def _clean_props(self, props: dict) -> dict:
         def _normalize_value(v: Any):
@@ -382,3 +369,8 @@ class FalkorGraphStore(GraphStore):
                 continue
             clean[k] = val
         return clean
+    
+    async def _run_query(self, query, params):
+        async with self._semaphore:
+            return await asyncio.to_thread(self._graph.query, query, params)
+

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/models.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/models.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class CoreNodeLabel(StrEnum):
+    DOCUMENT = "Document"
+    PERSON = "Person"
+    CONTAINER = "Container"
+    LABEL = "Label"
+    CONCEPT = "Concept"
+    CHUNK = "Chunk"
+
+
+class CoreEdgeType(StrEnum):
+    AUTHORED_BY = "AUTHORED_BY"
+    BELONGS_TO = "BELONGS_TO"
+    HAS_LABEL = "HAS_LABEL"
+    LINKS_TO = "LINKS_TO"
+    PART_OF = "PART_OF"
+    HAS_CHUNK = "HAS_CHUNK"
+    HAS_CHILD = "HAS_CHILD"
+
+
+@dataclass(slots=True, frozen=True)
+class PersonInfo:
+    id: str
+    display_name: str
+
+    email: str | None = None
+    username: str | None = None
+
+    source_type: str | None = None
+    source_id: str | None = None
+
+
+@dataclass
+class GraphNode:
+    id: str
+    label: CoreNodeLabel
+    project: str | None = None
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GraphEdge:
+    source: str
+    target: str
+    edge_type: CoreEdgeType
+    project: str | None = None
+    properties: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SubGraph:
+    nodes: list[GraphNode] = field(default_factory=list)
+    edges: list[GraphEdge] = field(default_factory=list)

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/models.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/models.py
@@ -12,6 +12,8 @@ class CoreNodeLabel(StrEnum):
     LABEL = "Label"
     CONCEPT = "Concept"
     CHUNK = "Chunk"
+    URL = "URL"
+    ATTACHMENT = "Attachment"
 
 
 class CoreEdgeType(StrEnum):
@@ -22,6 +24,7 @@ class CoreEdgeType(StrEnum):
     PART_OF = "PART_OF"
     HAS_CHUNK = "HAS_CHUNK"
     HAS_CHILD = "HAS_CHILD"
+    HAS_ATTACHMENT = "HAS_ATTACHMENT"
 
 
 @dataclass(slots=True, frozen=True)

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/registry.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/registry.py
@@ -1,0 +1,12 @@
+from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
+from qdrant_loader_core.graph.extractor.confluence import ConfluenceEntityExtractor
+from qdrant_loader_core.graph.extractor.git import GitEntityExtractor
+from qdrant_loader_core.graph.extractor.jira import JiraEntityExtractor
+from qdrant_loader_core.graph.extractor.localfile import LocalFileEntityExtractor
+from qdrant_loader_core.graph.extractor.publicdocs import PublicDocsEntityExtractor
+
+EntityExtractor.register_extractor("jira", JiraEntityExtractor)
+EntityExtractor.register_extractor("confluence", ConfluenceEntityExtractor)
+EntityExtractor.register_extractor("git", GitEntityExtractor)
+EntityExtractor.register_extractor("localfile", LocalFileEntityExtractor)
+EntityExtractor.register_extractor("publicdocs", PublicDocsEntityExtractor)

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/init_schema.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/init_schema.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+
+from ..models import CoreEdgeType, CoreNodeLabel
+from .versioning import get_version_query, set_version_query
+
+logger = logging.getLogger(__name__)
+
+LATEST_VERSION = 1
+
+
+# ------------------------
+# ENTRY POINT
+# ------------------------
+async def init_schema(graph_store):
+    current_version = await _get_current_version(graph_store)
+
+    logger.info(
+        "Current graph schema version=%s",
+        current_version,
+    )
+
+    for version in range(current_version + 1, LATEST_VERSION + 1):
+        logger.info(
+            "Applying graph schema migration v%s",
+            version,
+        )
+
+        await _ensure_indexes(graph_store)
+        await apply(graph_store)
+        await _set_version(graph_store, version)
+
+        logger.info(
+            "Graph schema migration v%s applied successfully",
+            version,
+        )
+
+
+# ------------------------
+# INDEXES
+# ------------------------
+async def _ensure_indexes(graph_store):
+    queries = [
+        "CREATE INDEX ON :Document(id)",
+        "CREATE INDEX ON :Person(id)",
+        "CREATE INDEX ON :Container(id)",
+        "CREATE INDEX ON :Label(id)",
+        "CREATE INDEX ON :Concept(id)",
+        "CREATE INDEX ON :Chunk(id)",
+    ]
+
+    for query in queries:
+        try:
+            await graph_store.query_cypher(query, {})
+        except Exception as exc:
+            if "already exists" in str(exc).lower():
+                continue
+            raise
+
+
+# ------------------------
+# VERSION
+# ------------------------
+async def _get_current_version(graph_store) -> int:
+    result = await graph_store.query_cypher(
+        get_version_query(),
+        {},
+    )
+
+    if not result:
+        return 0
+
+    return int(result[0][0])
+
+
+async def _set_version(
+    graph_store,
+    version: int,
+):
+    await graph_store.query_cypher(
+        set_version_query(),
+        {"version": version},
+    )
+
+
+async def apply(graph_store):
+    """
+    Initialize canonical graph schema metadata.
+
+    These nodes are informational metadata used to
+    document supported node labels and edge types.
+    """
+
+    for label in CoreNodeLabel:
+        await graph_store.query_cypher(
+            """
+            MERGE (:SchemaNodeType {name: $name})
+            """,
+            {"name": label.value},
+        )
+
+    for edge_type in CoreEdgeType:
+        await graph_store.query_cypher(
+            """
+            MERGE (:SchemaEdgeType {name: $name})
+            """,
+            {"name": edge_type.value},
+        )

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/init_schema.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/init_schema.py
@@ -41,14 +41,7 @@ async def init_schema(graph_store):
 # INDEXES
 # ------------------------
 async def _ensure_indexes(graph_store):
-    queries = [
-        "CREATE INDEX ON :Document(id)",
-        "CREATE INDEX ON :Person(id)",
-        "CREATE INDEX ON :Container(id)",
-        "CREATE INDEX ON :Label(id)",
-        "CREATE INDEX ON :Concept(id)",
-        "CREATE INDEX ON :Chunk(id)",
-    ]
+    queries = [f"CREATE INDEX ON :{label.value}(id)" for label in CoreNodeLabel]
 
     for query in queries:
         try:

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/versioning.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/versioning.py
@@ -1,0 +1,15 @@
+SCHEMA_VERSION_NODE = "_SchemaVersion"
+
+
+def get_version_query() -> str:
+    return f"""
+        MATCH (s:{SCHEMA_VERSION_NODE} {{id: "schema"}})
+        RETURN s.version AS version
+    """
+
+
+def set_version_query() -> str:
+    return f"""
+    MERGE (s:{SCHEMA_VERSION_NODE} {{id: "schema"}})
+    SET s.version = $version
+    """

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/store.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/store.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from .models import GraphEdge, GraphNode, SubGraph
+
+
+class GraphStore(ABC):
+    """
+    Backend-agnostic Graph Store interface.
+    Supports FalkorDB, Neptune, etc.
+    """
+
+    @abstractmethod
+    async def upsert_node(self, node: GraphNode) -> None:
+        """Insert or update a node"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def upsert_edge(self, edge: GraphEdge) -> None:
+        """Insert or update an edge"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def upsert_nodes_batch(self, nodes: list[GraphNode]) -> None:
+        """Batch insert/update nodes"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def upsert_edges_batch(self, edges: list[GraphEdge]) -> None:
+        """Batch insert/update edges"""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def neighbors(
+        self,
+        node_id: str,
+        depth: int,
+        edge_types: list[str] | None = None,
+        project: str | None = None,
+    ) -> SubGraph:
+        """
+        Get neighbors up to a certain depth.
+        Optionally filter by edge types.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def query_cypher(
+        self,
+        cypher: str,
+        params: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """
+        Execute Cypher query (for graph DBs that support it)
+        """
+        raise NotImplementedError

--- a/packages/qdrant-loader-core/tests/test_confluence_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_confluence_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.confluence import ConfluenceEntityExtractor
 
 
-def test_confluence_page():
+@pytest.mark.asyncio
+async def test_confluence_page():
     extractor = ConfluenceEntityExtractor()
 
     # Prepare a Document instance with normalized metadata the extractor expects
@@ -24,7 +26,7 @@ def test_confluence_page():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Container" for n in result.nodes)
     assert any(e.edge_type == "BELONGS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_confluence_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_confluence_extractor.py
@@ -1,0 +1,30 @@
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.confluence import ConfluenceEntityExtractor
+
+
+def test_confluence_page():
+    extractor = ConfluenceEntityExtractor()
+
+    # Prepare a Document instance with normalized metadata the extractor expects
+    metadata = {
+        "space_key": "ENG",
+        "author": "Bob",
+        "labels": ["design"],
+        "parent_id": None,
+        "children": [{"id": "456"}],
+    }
+
+    doc = Document(
+        title="Design Doc",
+        content_type="page",
+        content="Example content",
+        source_type="confluence",
+        source="confluence_instance",
+        url="http://conf/page",
+        metadata=metadata,
+    )
+
+    result = extractor.extract(doc)
+
+    assert any(n.label == "Container" for n in result.nodes)
+    assert any(e.edge_type == "BELONGS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_factory_additional.py
+++ b/packages/qdrant-loader-core/tests/test_factory_additional.py
@@ -46,7 +46,7 @@ def test_factory_routes_to_noop_on_openai_init_failure(monkeypatch):
         with pytest.raises(NotImplementedError):
             await chat.chat([{"role": "user", "content": "hi"}])  # type: ignore[func-returns-value]
 
-    asyncio.get_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 def test_factory_azure_error_returns_noop(monkeypatch):

--- a/packages/qdrant-loader-core/tests/test_factory_stub.py
+++ b/packages/qdrant-loader-core/tests/test_factory_stub.py
@@ -34,8 +34,3 @@ async def test_factory_returns_provider_with_expected_interfaces():
     assert hasattr(emb, "embed")
     assert hasattr(chat, "chat")
     assert tok.count("abc") == 3
-
-    with pytest.raises(NotImplementedError):
-        await emb.embed(["hello"])
-    with pytest.raises(NotImplementedError):
-        await chat.chat([{"role": "user", "content": "hi"}])

--- a/packages/qdrant-loader-core/tests/test_git_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_git_extractor.py
@@ -1,0 +1,32 @@
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.git import GitEntityExtractor
+
+
+def test_git_commit():
+    extractor = GitEntityExtractor()
+
+    metadata = {
+        "repository_name": "repo",
+        "repository_owner": "org",
+        "repository_url": "http://git/org/repo",
+        "last_commit_author": "alice@company.com",
+        "file_name": "README.md",
+    }
+
+    doc = Document(
+        title="Initial commit",
+        content_type="commit",
+        content="Initial commit content",
+        source_type="git",
+        source="abc123",
+        url="http://git/commit/abc123",
+        metadata=metadata,
+    )
+
+    result = extractor.extract(doc)
+
+    assert any(n.label == "Document" for n in result.nodes)
+    assert any(n.label == "Person" for n in result.nodes)
+    assert any(n.label == "Container" for n in result.nodes)
+    assert any(e.edge_type == "AUTHORED_BY" for e in result.edges)
+    assert any(e.edge_type == "BELONGS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_git_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_git_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.git import GitEntityExtractor
 
 
-def test_git_commit():
+@pytest.mark.asyncio
+async def test_git_commit():
     extractor = GitEntityExtractor()
 
     metadata = {
@@ -23,7 +25,7 @@ def test_git_commit():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Person" for n in result.nodes)

--- a/packages/qdrant-loader-core/tests/test_graph_store.py
+++ b/packages/qdrant-loader-core/tests/test_graph_store.py
@@ -1,92 +1,115 @@
-from qdrant_loader_core.graph.models import GraphNode, GraphEdge, SubGraph
-
-import pytest
 from unittest.mock import AsyncMock
 
+import pytest
+from qdrant_loader_core.graph.models import GraphEdge, GraphNode, SubGraph
 from qdrant_loader_core.graph.store import GraphStore
 
 
 class DummyGraphStore(GraphStore):
     def __init__(self):
-        self.upsert_node = AsyncMock()
-        self.upsert_edge = AsyncMock()
-        self.upsert_nodes_batch = AsyncMock()
-        self.upsert_edges_batch = AsyncMock()
-        self.neighbors = AsyncMock()
-        self.query_cypher = AsyncMock()
+        self._upsert_node = AsyncMock()
+        self._upsert_edge = AsyncMock()
+        self._upsert_nodes_batch = AsyncMock()
+        self._upsert_edges_batch = AsyncMock()
+        self._neighbors = AsyncMock()
+        self._query_cypher = AsyncMock()
 
-    @pytest.mark.asyncio
-    async def test_upsert_node_called():
-        store = DummyGraphStore()
+    async def upsert_node(self, node):
+        return await self._upsert_node(node)
 
-        node = GraphNode(id="1", label="Test")
+    async def upsert_edge(self, edge):
+        return await self._upsert_edge(edge)
 
-        await store.upsert_node(node)
+    async def upsert_nodes_batch(self, nodes):
+        return await self._upsert_nodes_batch(nodes)
 
-        store.upsert_node.assert_awaited_once_with(node)
+    async def upsert_edges_batch(self, edges):
+        return await self._upsert_edges_batch(edges)
 
-    @pytest.mark.asyncio
-    async def test_upsert_edge_called():
-        store = DummyGraphStore()
+    async def neighbors(self, **kwargs):
+        return await self._neighbors(**kwargs)
 
-        edge = GraphEdge(source="1", target="2", edge_type="REL")
+    async def query_cypher(self, query, params):
+        return await self._query_cypher(query, params)
 
-        await store.upsert_edge(edge)
 
-        store.upsert_edge.assert_awaited_once_with(edge)
+@pytest.mark.asyncio
+async def test_upsert_node_called():
+    store = DummyGraphStore()
 
-    @pytest.mark.asyncio
-    async def test_upsert_nodes_batch():
-        store = DummyGraphStore()
+    node = GraphNode(id="1", label="Test")
 
-        nodes = [
-            GraphNode(id="1", label="A"),
-            GraphNode(id="2", label="B"),
-        ]
+    await store.upsert_node(node)
 
-        await store.upsert_nodes_batch(nodes)
+    store._upsert_node.assert_awaited_once_with(node)
 
-        store.upsert_nodes_batch.assert_awaited_once_with(nodes)
 
-    @pytest.mark.asyncio
-    async def test_upsert_edges_batch():
-        store = DummyGraphStore()
+@pytest.mark.asyncio
+async def test_upsert_edge_called():
+    store = DummyGraphStore()
 
-        edges = [GraphEdge(source="1", target="2", edge_type="REL")]
+    edge = GraphEdge(source="1", target="2", edge_type="REL")
 
-        await store.upsert_edges_batch(edges)
+    await store.upsert_edge(edge)
 
-        store.upsert_edges_batch.assert_awaited_once_with(edges)
+    store._upsert_edge.assert_awaited_once_with(edge)
 
-    @pytest.mark.asyncio
-    async def test_neighbors():
-        store = DummyGraphStore()
 
-        expected = SubGraph(nodes=[], edges=[])
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch():
+    store = DummyGraphStore()
 
-        store.neighbors.return_value = expected
+    nodes = [
+        GraphNode(id="1", label="A"),
+        GraphNode(id="2", label="B"),
+    ]
 
-        result = await store.neighbors(
-            node_id="1",
-            depth=2,
-            edge_types=["REL"],
-            project="test",
-        )
+    await store.upsert_nodes_batch(nodes)
 
-        assert result == expected
-        store.neighbors.assert_awaited_once()
+    store._upsert_nodes_batch.assert_awaited_once_with(nodes)
 
-    @pytest.mark.asyncio
-    async def test_query_cypher():
-        store = DummyGraphStore()
 
-        expected = [{"a": 1}]
-        store.query_cypher.return_value = expected
+@pytest.mark.asyncio
+async def test_upsert_edges_batch():
+    store = DummyGraphStore()
 
-        result = await store.query_cypher(
-            "MATCH (n) RETURN n",
-            {},
-        )
+    edges = [GraphEdge(source="1", target="2", edge_type="REL")]
 
-        assert result == expected
-        store.query_cypher.assert_awaited_once_with("MATCH (n) RETURN n", {})
+    await store.upsert_edges_batch(edges)
+
+    store._upsert_edges_batch.assert_awaited_once_with(edges)
+
+
+@pytest.mark.asyncio
+async def test_neighbors():
+    store = DummyGraphStore()
+
+    expected = SubGraph(nodes=[], edges=[])
+
+    store._neighbors.return_value = expected
+
+    result = await store.neighbors(
+        node_id="1",
+        depth=2,
+        edge_types=["REL"],
+        project="test",
+    )
+
+    assert result == expected
+    store._neighbors.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_query_cypher():
+    store = DummyGraphStore()
+
+    expected = [{"a": 1}]
+    store._query_cypher.return_value = expected
+
+    result = await store.query_cypher(
+        "MATCH (n) RETURN n",
+        {},
+    )
+
+    assert result == expected
+    store._query_cypher.assert_awaited_once_with("MATCH (n) RETURN n", {})

--- a/packages/qdrant-loader-core/tests/test_graph_store.py
+++ b/packages/qdrant-loader-core/tests/test_graph_store.py
@@ -1,0 +1,92 @@
+from qdrant_loader_core.graph.models import GraphNode, GraphEdge, SubGraph
+
+import pytest
+from unittest.mock import AsyncMock
+
+from qdrant_loader_core.graph.store import GraphStore
+
+
+class DummyGraphStore(GraphStore):
+    def __init__(self):
+        self.upsert_node = AsyncMock()
+        self.upsert_edge = AsyncMock()
+        self.upsert_nodes_batch = AsyncMock()
+        self.upsert_edges_batch = AsyncMock()
+        self.neighbors = AsyncMock()
+        self.query_cypher = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_upsert_node_called():
+        store = DummyGraphStore()
+
+        node = GraphNode(id="1", label="Test")
+
+        await store.upsert_node(node)
+
+        store.upsert_node.assert_awaited_once_with(node)
+
+    @pytest.mark.asyncio
+    async def test_upsert_edge_called():
+        store = DummyGraphStore()
+
+        edge = GraphEdge(source="1", target="2", edge_type="REL")
+
+        await store.upsert_edge(edge)
+
+        store.upsert_edge.assert_awaited_once_with(edge)
+
+    @pytest.mark.asyncio
+    async def test_upsert_nodes_batch():
+        store = DummyGraphStore()
+
+        nodes = [
+            GraphNode(id="1", label="A"),
+            GraphNode(id="2", label="B"),
+        ]
+
+        await store.upsert_nodes_batch(nodes)
+
+        store.upsert_nodes_batch.assert_awaited_once_with(nodes)
+
+    @pytest.mark.asyncio
+    async def test_upsert_edges_batch():
+        store = DummyGraphStore()
+
+        edges = [GraphEdge(source="1", target="2", edge_type="REL")]
+
+        await store.upsert_edges_batch(edges)
+
+        store.upsert_edges_batch.assert_awaited_once_with(edges)
+
+    @pytest.mark.asyncio
+    async def test_neighbors():
+        store = DummyGraphStore()
+
+        expected = SubGraph(nodes=[], edges=[])
+
+        store.neighbors.return_value = expected
+
+        result = await store.neighbors(
+            node_id="1",
+            depth=2,
+            edge_types=["REL"],
+            project="test",
+        )
+
+        assert result == expected
+        store.neighbors.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_query_cypher():
+        store = DummyGraphStore()
+
+        expected = [{"a": 1}]
+        store.query_cypher.return_value = expected
+
+        result = await store.query_cypher(
+            "MATCH (n) RETURN n",
+            {},
+        )
+
+        assert result == expected
+        store.query_cypher.assert_awaited_once_with("MATCH (n) RETURN n", {})

--- a/packages/qdrant-loader-core/tests/test_jira_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_jira_extractor.py
@@ -33,10 +33,13 @@ def test_jira_basic():
     )
 
     result = extractor.extract(doc)
+    print([n.label for n in result.nodes])
+    print([e.edge_type for e in result.edges])
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Container" for n in result.nodes)
     assert any(n.label == "Person" for n in result.nodes)
-    assert any(n.edge_type == "BELONGS_TO" for n in result.edges)
+
+    assert any(e.edge_type == "BELONGS_TO" for e in result.edges)
     assert any(e.edge_type == "AUTHORED_BY" for e in result.edges)
     assert any(e.edge_type == "LINKS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_jira_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_jira_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.jira import JiraEntityExtractor
 
 
-def test_jira_basic():
+@pytest.mark.asyncio
+async def test_jira_basic():
     extractor = JiraEntityExtractor()
 
     metadata = {
@@ -32,7 +34,7 @@ def test_jira_basic():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
     print([n.label for n in result.nodes])
     print([e.edge_type for e in result.edges])
 

--- a/packages/qdrant-loader-core/tests/test_jira_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_jira_extractor.py
@@ -1,0 +1,42 @@
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.jira import JiraEntityExtractor
+
+
+def test_jira_basic():
+    extractor = JiraEntityExtractor()
+
+    metadata = {
+        "project_key": "ABC",
+        "status": "Open",
+        "priority": "High",
+        "issue_type": "Bug",
+        "reporter": {
+            "email_address": "reporter@company.com",
+            "display_name": "Reporter",
+        },
+        "assignee": {
+            "email_address": "john@company.com",
+            "display_name": "John",
+        },
+        "labels": ["backend"],
+        "description": "Related confluence page: http://confluence.example.com/display/ABC/Page",
+    }
+
+    doc = Document(
+        title="Fix login bug",
+        content_type="issue",
+        content="Jira issue content",
+        source_type="jira",
+        source="ABC-1",
+        url="http://jira/ABC-1",
+        metadata=metadata,
+    )
+
+    result = extractor.extract(doc)
+
+    assert any(n.label == "Document" for n in result.nodes)
+    assert any(n.label == "Container" for n in result.nodes)
+    assert any(n.label == "Person" for n in result.nodes)
+    assert any(n.edge_type == "BELONGS_TO" for n in result.edges)
+    assert any(e.edge_type == "AUTHORED_BY" for e in result.edges)
+    assert any(e.edge_type == "LINKS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_localfile_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_localfile_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.localfile import LocalFileEntityExtractor
 
 
-def test_localfile_basic():
+@pytest.mark.asyncio
+async def test_localfile_basic():
     extractor = LocalFileEntityExtractor()
 
     metadata = {
@@ -21,7 +23,7 @@ def test_localfile_basic():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Container" for n in result.nodes)

--- a/packages/qdrant-loader-core/tests/test_localfile_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_localfile_extractor.py
@@ -1,0 +1,28 @@
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.localfile import LocalFileEntityExtractor
+
+
+def test_localfile_basic():
+    extractor = LocalFileEntityExtractor()
+
+    metadata = {
+        "file_name": "design_doc.md",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T00:00:00Z",
+    }
+
+    doc = Document(
+        title="Design Doc",
+        content_type="page",
+        content="Example content",
+        source_type="localfile",
+        source="localfile_instance",
+        url="D:/docs/design_doc.md",
+        metadata=metadata,
+    )
+
+    result = extractor.extract(doc)
+
+    assert any(n.label == "Document" for n in result.nodes)
+    assert any(n.label == "Container" for n in result.nodes)
+    assert any(e.edge_type == "BELONGS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.publicdocs import PublicDocsEntityExtractor
 
@@ -8,6 +10,10 @@ def test_public_webpage():
     metadata = {
         "url": "https://example.com/page",
         "tags": ["ai", "ml"],
+        "links": ["https://example.com/other"],
+        "attachments": [
+            {"id": "att1", "filename": "doc.pdf", "mime_type": "application/pdf"}
+        ],
     }
 
     doc = Document(
@@ -24,4 +30,10 @@ def test_public_webpage():
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Label" for n in result.nodes)
+    assert any(n.label == "Container" for n in result.nodes), "Container node missing"
+    assert any(n.label == "Attachment" for n in result.nodes), "Attachment node missing"
     assert any(e.edge_type == "HAS_LABEL" for e in result.edges)
+    assert any(e.edge_type == "LINKS_TO" for e in result.edges), "LINKS_TO edge missing"
+    assert any(
+        e.edge_type == "HAS_ATTACHMENT" for e in result.edges
+    ), "HAS_ATTACHMENT edge missing"

--- a/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.publicdocs import PublicDocsEntityExtractor
 
 
-def test_public_webpage():
+@pytest.mark.asyncio
+async def test_public_webpage():
     extractor = PublicDocsEntityExtractor()
 
     metadata = {
@@ -26,7 +28,7 @@ def test_public_webpage():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Label" for n in result.nodes)

--- a/packages/qdrant-loader-core/tests/test_puplicdocs_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_puplicdocs_extractor.py
@@ -1,0 +1,27 @@
+from qdrant_loader.core.document import Document
+from qdrant_loader_core.graph.extractor.publicdocs import PublicDocsEntityExtractor
+
+
+def test_public_webpage():
+    extractor = PublicDocsEntityExtractor()
+
+    metadata = {
+        "url": "https://example.com/page",
+        "tags": ["ai", "ml"],
+    }
+
+    doc = Document(
+        title="Example Page",
+        content_type="page",
+        content="Example webpage content",
+        source_type="publicdocs",
+        source="https://example.com/page",
+        url="https://example.com/page",
+        metadata=metadata,
+    )
+
+    result = extractor.extract(doc)
+
+    assert any(n.label == "Document" for n in result.nodes)
+    assert any(n.label == "Label" for n in result.nodes)
+    assert any(e.edge_type == "HAS_LABEL" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_registry.py
+++ b/packages/qdrant-loader-core/tests/test_registry.py
@@ -1,0 +1,28 @@
+import pytest
+from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
+from qdrant_loader_core.graph.extractor.jira import JiraEntityExtractor
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    EntityExtractor._registry.clear()
+
+
+def test_registry_lookup():
+    EntityExtractor.register_extractor("jira", JiraEntityExtractor)
+
+    extractor = EntityExtractor.for_source("jira")
+
+    assert isinstance(extractor, JiraEntityExtractor)
+
+
+def test_registry_invalid():
+    with pytest.raises(ValueError, match="No extractor registered"):
+        EntityExtractor.for_source("unknown")
+
+
+def test_register_duplicate_should_fail():
+    EntityExtractor.register_extractor("jira", JiraEntityExtractor)
+
+    with pytest.raises(ValueError, match="already registered"):
+        EntityExtractor.register_extractor("jira", JiraEntityExtractor)

--- a/packages/qdrant-loader-core/tests/test_schema.py
+++ b/packages/qdrant-loader-core/tests/test_schema.py
@@ -1,0 +1,120 @@
+from qdrant_loader_core.graph.models import CoreEdgeType, CoreNodeLabel
+from qdrant_loader_core.graph.schema.init_schema import (
+    LATEST_VERSION,
+    _ensure_indexes,
+    _get_current_version,
+    _set_version,
+    apply,
+    init_schema,
+)
+
+import pytest
+from unittest.mock import AsyncMock, call
+
+
+@pytest.mark.asyncio
+async def test_get_current_version_no_result():
+    graph_store = AsyncMock()
+    graph_store.query_cypher.return_value = []
+
+    version = await _get_current_version(graph_store)
+
+    assert version == 0
+
+
+@pytest.mark.asyncio
+async def test_get_current_version_with_result():
+    graph_store = AsyncMock()
+    graph_store.query_cypher.return_value = [[1]]
+
+    version = await _get_current_version(graph_store)
+
+    assert version == 1
+
+
+@pytest.mark.asyncio
+async def test_set_version():
+    graph_store = AsyncMock()
+
+    await _set_version(graph_store, 3)
+
+    graph_store.query_cypher.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_success():
+    graph_store = AsyncMock()
+
+    await _ensure_indexes(graph_store)
+
+    assert graph_store.query_cypher.await_count == 6
+
+
+@pytest.mark.asyncio
+async def test_ensure_indexes_ignore_existing():
+    graph_store = AsyncMock()
+
+    async def mock_query(query, params):
+        raise Exception("Index already exists")
+
+    graph_store.query_cypher.side_effect = mock_query
+
+    # should NOT raise
+    await _ensure_indexes(graph_store)
+
+
+@pytest.mark.asyncio
+async def test_apply_creates_schema_nodes_and_edges():
+    graph_store = AsyncMock()
+
+    await apply(graph_store)
+
+    expected_calls = []
+
+    # Node labels
+    for label in CoreNodeLabel:
+        expected_calls.append(
+            call(
+                """
+            MERGE (:SchemaNodeType {name: $name})
+            """,
+                {"name": label.value},
+            )
+        )
+
+    # Edge types
+    for edge in CoreEdgeType:
+        expected_calls.append(
+            call(
+                """
+            MERGE (:SchemaEdgeType {name: $name})
+            """,
+                {"name": edge.value},
+            )
+        )
+
+    graph_store.query_cypher.assert_has_awaits(expected_calls, any_order=True)
+
+
+@pytest.mark.asyncio
+async def test_init_schema_runs_migration():
+    graph_store = AsyncMock()
+
+    # version = 0
+    graph_store.query_cypher.return_value = []
+
+    await init_schema(graph_store)
+
+    assert graph_store.query_cypher.await_count > 0
+
+
+@pytest.mark.asyncio
+async def test_init_schema_no_migration_needed():
+    graph_store = AsyncMock()
+
+    graph_store.query_cypher.return_value = [[LATEST_VERSION]]
+
+    await init_schema(graph_store)
+
+    # chỉ gọi get_version
+    graph_store.query_cypher.assert_awaited_once()

--- a/packages/qdrant-loader-core/tests/test_schema.py
+++ b/packages/qdrant-loader-core/tests/test_schema.py
@@ -1,3 +1,6 @@
+from unittest.mock import AsyncMock, call
+
+import pytest
 from qdrant_loader_core.graph.models import CoreEdgeType, CoreNodeLabel
 from qdrant_loader_core.graph.schema.init_schema import (
     LATEST_VERSION,
@@ -7,9 +10,6 @@ from qdrant_loader_core.graph.schema.init_schema import (
     apply,
     init_schema,
 )
-
-import pytest
-from unittest.mock import AsyncMock, call
 
 
 @pytest.mark.asyncio
@@ -47,7 +47,7 @@ async def test_ensure_indexes_success():
 
     await _ensure_indexes(graph_store)
 
-    assert graph_store.query_cypher.await_count == 6
+    assert graph_store.query_cypher.await_count == 8
 
 
 @pytest.mark.asyncio

--- a/packages/qdrant-loader-mcp-server/tests/unit/search/test_faceted_engine.py
+++ b/packages/qdrant-loader-mcp-server/tests/unit/search/test_faceted_engine.py
@@ -73,7 +73,7 @@ def test_search_with_facets_basic():
         assert resp["filtered_count"] == 2
         assert resp["facets"][0]["type"] == "source"
 
-    asyncio.get_event_loop().run_until_complete(run())
+    asyncio.run(run())
 
 
 def test_get_facet_suggestions_basic(monkeypatch):
@@ -135,4 +135,4 @@ def test_get_facet_suggestions_basic(monkeypatch):
         assert out["suggested_facets"][0]["type"] == "source"
         assert out["generation_metadata"]["total_documents_analyzed"] == 1
 
-    asyncio.get_event_loop().run_until_complete(run())
+    asyncio.run(run())

--- a/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
@@ -16,6 +16,7 @@ from qdrant_loader.config.sources import SourcesConfig
 from qdrant_loader.config.state import StateManagementConfig
 from qdrant_loader.config.workers import WorkersConfig
 from qdrant_loader.core.file_conversion import FileConversionConfig
+from qdrant_loader.config.graph import GraphConfig
 
 
 class SemanticAnalysisConfig(BaseConfig):
@@ -61,6 +62,9 @@ class GlobalConfig(BaseConfig):
         default_factory=WorkersConfig,
         description="Worker scheduling and runtime configuration",
     )
+    graph: GraphConfig = Field(
+        default_factory=GraphConfig, description="Graph configuration"
+    )
 
     def __init__(self, **data):
         """Initialize global configuration."""
@@ -104,4 +108,5 @@ class GlobalConfig(BaseConfig):
             },
             "qdrant": self.qdrant.to_dict(),
             "workers": self.workers.to_dict(),
+            "graph": self.graph.to_dict(),
         }

--- a/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
@@ -11,12 +11,12 @@ from pydantic import Field
 from qdrant_loader.config.base import BaseConfig
 from qdrant_loader.config.chunking import ChunkingConfig
 from qdrant_loader.config.embedding import EmbeddingConfig
+from qdrant_loader.config.graph import GraphConfig
 from qdrant_loader.config.qdrant import QdrantConfig
 from qdrant_loader.config.sources import SourcesConfig
 from qdrant_loader.config.state import StateManagementConfig
 from qdrant_loader.config.workers import WorkersConfig
 from qdrant_loader.core.file_conversion import FileConversionConfig
-from qdrant_loader.config.graph import GraphConfig
 
 
 class SemanticAnalysisConfig(BaseConfig):

--- a/packages/qdrant-loader/src/qdrant_loader/config/graph.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/graph.py
@@ -43,11 +43,7 @@ class GraphConfig(BaseModel):
             "backend": self.backend,
             "host": self.connection.host,
             "port": self.connection.port,
-            "password": (
-                self.connection.password.get_secret_value()
-                if self.connection.password
-                else None
-            ),
+            "password": self.connection.password,  # keep SecretStr; call get_secret_value() at client init only
             "graph_name": self.graph_name,
             "max_connections": self.pool.max_connections,
         }

--- a/packages/qdrant-loader/src/qdrant_loader/config/graph.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/graph.py
@@ -1,0 +1,53 @@
+"""Graph configuration settings.
+
+This module defines the Graph-specific configuration settings.
+"""
+
+from pydantic import BaseModel, Field, PositiveInt, SecretStr
+
+
+class GraphConnectionConfig(BaseModel):
+    host: str = Field(default="localhost", min_length=1, description="Graph DB host")
+    port: int = Field(default=6379, ge=1, le=65535, description="Graph DB port")
+    password: SecretStr | None = Field(default=None, description="Graph DB password")
+
+
+class GraphPoolConfig(BaseModel):
+    max_connections: PositiveInt = Field(default=10, description="Max connections")
+
+
+class GraphConfig(BaseModel):
+    """Configuration for Graph database."""
+
+    enabled: bool = Field(default=False, description="Enable graph processing")
+    backend: str = Field(
+        default="falkordb", min_length=1, description="Graph backend type"
+    )
+
+    connection: GraphConnectionConfig = Field(
+        default_factory=GraphConnectionConfig, description="Connection settings"
+    )
+
+    graph_name: str = Field(
+        default="default_graph", min_length=1, description="Graph name / namespace"
+    )
+
+    pool: GraphPoolConfig = Field(
+        default_factory=GraphPoolConfig, description="Connection pool settings"
+    )
+
+    def to_dict(self) -> dict:
+        """Convert config to dictionary (useful for client init)."""
+        return {
+            "enabled": self.enabled,
+            "backend": self.backend,
+            "host": self.connection.host,
+            "port": self.connection.port,
+            "password": (
+                self.connection.password.get_secret_value()
+                if self.connection.password
+                else None
+            ),
+            "graph_name": self.graph_name,
+            "max_connections": self.pool.max_connections,
+        }

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
@@ -2,8 +2,15 @@
 
 import asyncio
 import time
+from collections import defaultdict
 from dataclasses import dataclass
+from typing import Any
 
+import qdrant_loader_core.graph.registry as _registry  # noqa: F401
+from qdrant_loader_core.graph import get_graph_store
+from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
+
+from qdrant_loader.config import get_settings
 from qdrant_loader.core.document import Document
 from qdrant_loader.utils.logging import LoggingConfig
 
@@ -46,11 +53,146 @@ class DocumentPipeline:
         self.embedding_worker = embedding_worker
         self.upsert_worker = upsert_worker
 
-    async def process_batch(self, batch: list[Document]) -> BatchResult:
+    async def _process_graph(
+        self,
+        documents: list[Document],
+        current_project_id: str | None = None,
+    ) -> None:
+        """
+        Graph write hook (optional):
+        - Extract entities + relations from documents
+        - Build nodes/edges
+        - Deduplicate
+        - Batch upsert into GraphStore
+        - Must NOT affect ingestion if fails
+        """
+
+        # ---------------------------
+        # 1. Load config safely
+        # ---------------------------
+        logger.info("🔄 Starting process graph!!!")
+        try:
+            settings = get_settings()
+            graph_cfg = getattr(settings.global_config, "graph", None)
+            graph_enabled = (
+                bool(getattr(graph_cfg, "enabled", False)) if graph_cfg else False
+            )
+        except Exception:
+            logger.warning("Graph config not available → graph disabled")
+            return
+
+        if not graph_enabled:
+            return
+
+        logger.info("🔄 Graph extraction started (batch size=%s)", len(documents))
+
+        # ---------------------------
+        # 2. Prepare dedup storage
+        # ---------------------------
+        nodes_dict: dict[str, Any] = {}
+        edges_dict: dict[tuple[str, str, str], Any] = {}
+
+        # Optional: group by source_type for efficiency
+        grouped_docs: dict[str, list[Document]] = defaultdict(list)
+        for doc in documents:
+            grouped_docs[doc.source_type].append(doc)
+
+        # ---------------------------
+        # 3. Extract graph per source_type
+        # ---------------------------
+        for source_type, docs in grouped_docs.items():
+            try:
+                extractor = EntityExtractor.for_source(source_type)
+                if not extractor:
+                    logger.warning("No extractor found for source_type=%s", source_type)
+                    continue
+
+                for doc in docs:
+                    try:
+                        subgraph = await extractor.extract(doc)
+
+                        if getattr(subgraph, "nodes", None):
+                            for node in subgraph.nodes:
+                                nodes_dict[node.id] = node
+
+                        if getattr(subgraph, "edges", None):
+                            for edge in subgraph.edges:
+                                edge_key = (edge.source, edge.target, edge.edge_type)
+                                edges_dict[edge_key] = edge
+
+                    except Exception as e:
+                        logger.error(
+                            "⚠️ Graph extract failed doc_id=%s error=%s",
+                            getattr(doc, "id", "<unknown>"),
+                            e,
+                            exc_info=True,
+                        )
+
+            except Exception as e:
+                logger.error(
+                    "⚠️ Extractor failed for source_type=%s error=%s",
+                    source_type,
+                    e,
+                    exc_info=True,
+                )
+
+        # ---------------------------
+        # 4. Build batches
+        # ---------------------------
+        nodes_batch = list(nodes_dict.values())
+        edges_batch = list(edges_dict.values())
+
+        # ---------------------------
+        # 5. Attach project context
+        # ---------------------------
+        if current_project_id:
+            for node in nodes_batch:
+                if not hasattr(node, "properties") or node.properties is None:
+                    node.properties = {}
+                node.properties["project"] = current_project_id
+
+            for edge in edges_batch:
+                if not hasattr(edge, "properties") or edge.properties is None:
+                    edge.properties = {}
+                edge.properties["project"] = current_project_id
+
+        # ---------------------------
+        # 6. Batch upsert
+        # ---------------------------
+        if not nodes_batch and not edges_batch:
+            logger.info("Graph extraction result is empty → skip upsert")
+            return
+
+        try:
+            graph_store = await get_graph_store()
+
+            if nodes_batch:
+                await graph_store.upsert_nodes_batch(nodes_batch)
+
+            if edges_batch:
+                await graph_store.upsert_edges_batch(edges_batch)
+
+            logger.info(
+                "✅ Graph upsert success | nodes=%s edges=%s",
+                len(nodes_batch),
+                len(edges_batch),
+            )
+
+        except Exception as e:
+            logger.error(
+                "⚠️ Graph upsert failed (non-fatal): %s",
+                e,
+                exc_info=True,
+            )
+
+    async def process_batch(
+        self, batch: list[Document], current_project_id: str | None = None
+    ) -> BatchResult:
         """Process a bounded batch of documents through the pipeline.
 
         Args:
             batch: List of documents to process (bounded size, typically 256)
+            current_project_id: Optional project id context for graph extraction/upsert.
 
         Returns:
             BatchResult with processing statistics.
@@ -94,6 +236,9 @@ class DocumentPipeline:
                 f"✅ Batch processing completed: {pipeline_result.success_count} chunks, "
                 f"{pipeline_result.error_count} errors in {total_duration:.2f}s"
             )
+
+            # add node and edge
+            await self._process_graph(batch, current_project_id)
 
             return BatchResult(
                 success_count=pipeline_result.success_count,

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -277,7 +277,9 @@ class PipelineOrchestrator:
                         continue
 
                     batch_result = (
-                        await self.components.document_pipeline.process_batch(batch)
+                        await self.components.document_pipeline.process_batch(
+                            batch, current_project_id
+                        )
                     )
                     aggregated_result.success_count += batch_result.success_count
                     aggregated_result.error_count += batch_result.failure_count

--- a/packages/qdrant-loader/tests/.env.test.template
+++ b/packages/qdrant-loader/tests/.env.test.template
@@ -37,3 +37,9 @@ JIRA_EMAIL=your_jira_email_here
 # Personal Access Token (alternative to token/email for Data Center)
 # Generate at: Jira → Profile → Settings → Personal Access Tokens
 JIRA_PAT=your_jira_personal_access_token_here
+
+# Graph Database Configuration
+GRAPH_HOST=localhost
+GRAPH_PORT=6379
+GRAPH_NAME=test_graph
+GRAPH_PASSWORD=""

--- a/packages/qdrant-loader/tests/.env.test.template
+++ b/packages/qdrant-loader/tests/.env.test.template
@@ -42,4 +42,4 @@ JIRA_PAT=your_jira_personal_access_token_here
 GRAPH_HOST=localhost
 GRAPH_PORT=6379
 GRAPH_NAME=test_graph
-GRAPH_PASSWORD=""
+GRAPH_PASSWORD=

--- a/packages/qdrant-loader/tests/config.test.template.yaml
+++ b/packages/qdrant-loader/tests/config.test.template.yaml
@@ -4,6 +4,17 @@
 
 # Global configuration for all projects
 global:
+  # Graph configuration
+  graph:
+    enabled: true
+    backend: "falkordb"
+    connection:
+      host: "${GRAPH_HOST}"
+      port: "${GRAPH_PORT}"
+      password: "${GRAPH_PASSWORD}"
+    graph_name: "${GRAPH_NAME}"
+    pool:
+      max_connections: 20
   # Unified LLM configuration for tests (provider-agnostic)
   llm:
     provider: "openai"

--- a/packages/qdrant-loader/tests/config.test.yaml
+++ b/packages/qdrant-loader/tests/config.test.yaml
@@ -4,6 +4,17 @@
 
 # Global configuration for all sources
 global:
+  # Graph configuration
+  graph:
+    enabled: true
+    backend: "falkordb"
+    connection:
+      host: "${GRAPH_HOST}"
+      port: "${GRAPH_PORT}"
+      password: "${GRAPH_PASSWORD}"
+    graph_name: "${GRAPH_NAME}"
+    pool:
+      max_connections: 20
   # Unified LLM configuration (provider-agnostic)
   llm:
     provider: "openai"

--- a/packages/qdrant-loader/tests/conftest.py
+++ b/packages/qdrant-loader/tests/conftest.py
@@ -44,8 +44,9 @@ def setup_test_environment():
     data_dir.mkdir(parents=True, exist_ok=True)
 
     # Load test configuration
-    config_path = Path("tests/config.test.yaml")
-    env_path = Path("tests/.env.test")
+    tests_dir = Path(__file__).resolve().parent
+    config_path = tests_dir / "config.test.yaml"
+    env_path = tests_dir / ".env.test"
 
     # Load environment variables first
     load_dotenv(env_path, override=True)
@@ -59,6 +60,10 @@ def setup_test_environment():
         "CONFLUENCE_EMAIL": "test@example.com",
         "JIRA_TOKEN": "test-jira-token",
         "JIRA_EMAIL": "test@example.com",
+        "GRAPH_HOST": "localhost",
+        "GRAPH_PORT": "6379",
+        "GRAPH_NAME": "test_graph",
+        "GRAPH_PASSWORD": "",
     }
     for key, value in fallback_env.items():
         os.environ.setdefault(key, value)

--- a/packages/qdrant-loader/tests/integration/connectors/publicdocs/test_publicdocs_integration.py
+++ b/packages/qdrant-loader/tests/integration/connectors/publicdocs/test_publicdocs_integration.py
@@ -22,7 +22,10 @@ class TestPublicDocsIntegration:
     def publicdocs_config(self):
         """Get the PublicDocs configuration from test config file."""
         # Load the test configuration directly from the file
-        config_path = Path("tests/config.test.yaml")
+        config_path = (
+            next(p for p in Path(__file__).resolve().parents if p.name == "tests")
+            / "config.test.yaml"
+        )
 
         with open(config_path) as f:
             config_data = yaml.safe_load(f)

--- a/packages/qdrant-loader/tests/integration/connectors/publicdocs/test_publicdocs_integration.py
+++ b/packages/qdrant-loader/tests/integration/connectors/publicdocs/test_publicdocs_integration.py
@@ -22,10 +22,12 @@ class TestPublicDocsIntegration:
     def publicdocs_config(self):
         """Get the PublicDocs configuration from test config file."""
         # Load the test configuration directly from the file
-        config_path = (
-            next(p for p in Path(__file__).resolve().parents if p.name == "tests")
-            / "config.test.yaml"
+        tests_dir = next(
+            (p for p in Path(__file__).resolve().parents if p.name == "tests"), None
         )
+        if tests_dir is None:
+            raise FileNotFoundError("Could not locate tests directory in parent path")
+        config_path = tests_dir / "config.test.yaml"
 
         with open(config_path) as f:
             config_data = yaml.safe_load(f)

--- a/packages/qdrant-loader/tests/unit/config/test_global_config.py
+++ b/packages/qdrant-loader/tests/unit/config/test_global_config.py
@@ -2,6 +2,7 @@
 
 import pytest
 from qdrant_loader.config.global_config import GlobalConfig
+from qdrant_loader.config.graph import GraphConfig, GraphConnectionConfig
 from qdrant_loader.config.qdrant import QdrantConfig
 from qdrant_loader.core.file_conversion import FileConversionConfig, MarkItDownConfig
 
@@ -179,3 +180,50 @@ class TestGlobalConfig:
         assert config.qdrant is not None
 
         # Note: Additional validation tests would require custom field validators
+
+    def test_graph_config_defaults(self):
+        """Test GlobalConfig includes default graph configuration."""
+        config = GlobalConfig()
+
+        assert config.graph is not None
+        assert config.graph.enabled is False
+        assert config.graph.backend == "falkordb"
+        assert config.graph.connection.host == "localhost"
+        assert config.graph.connection.port == 6379
+        assert config.graph.graph_name == "default_graph"
+
+        config_dict = config.to_dict()
+        assert "graph" in config_dict
+        assert config_dict["graph"]["enabled"] is False
+        assert config_dict["graph"]["backend"] == "falkordb"
+        assert config_dict["graph"]["host"] == "localhost"
+        assert config_dict["graph"]["port"] == 6379
+        assert config_dict["graph"]["graph_name"] == "default_graph"
+
+    def test_custom_graph_configuration(self):
+        """Test that custom graph configuration can be provided."""
+        graph_config = GraphConfig(
+            enabled=True,
+            backend="falkordb",
+            connection=GraphConnectionConfig(
+                host="graph-host",
+                port=7777,
+                password=None,
+            ),
+            graph_name="custom_graph",
+        )
+
+        config = GlobalConfig(graph=graph_config)
+
+        assert config.graph.enabled is True
+        assert config.graph.backend == "falkordb"
+        assert config.graph.connection.host == "graph-host"
+        assert config.graph.connection.port == 7777
+        assert config.graph.graph_name == "custom_graph"
+
+        config_dict = config.to_dict()
+        assert config_dict["graph"]["enabled"] is True
+        assert config_dict["graph"]["backend"] == "falkordb"
+        assert config_dict["graph"]["host"] == "graph-host"
+        assert config_dict["graph"]["port"] == 7777
+        assert config_dict["graph"]["graph_name"] == "custom_graph"

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -143,7 +143,9 @@ class TestPipelineOrchestrator:
         self.source_filter.filter_sources.assert_called_once_with(
             self.mock_sources_config, None, None
         )
-        self.document_pipeline.process_batch.assert_called_once_with(mock_documents)
+        self.document_pipeline.process_batch.assert_called_once_with(
+            mock_documents, None
+        )
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1", "doc2"}, None
         )
@@ -241,7 +243,9 @@ class TestPipelineOrchestrator:
         self.source_filter.filter_sources.assert_called_once_with(
             self.mock_sources_config, "git", "my-repo"
         )
-        self.document_pipeline.process_batch.assert_called_once_with(mock_documents)
+        self.document_pipeline.process_batch.assert_called_once_with(
+            mock_documents, None
+        )
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1"}, None
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -387,7 +387,8 @@ Sitemap: https://qdrant-loader.net/sitemap.xml"""
     (templates_dir / "robots.txt").write_text(robots_template)
 
     # Create sample documentation files
-    (temp_workspace / "README.md").write_text("""# QDrant Loader
+    (temp_workspace / "README.md").write_text(
+        """# QDrant Loader
 
 Enterprise-ready vector database toolkit for building searchable knowledge bases.
 
@@ -396,16 +397,19 @@ Enterprise-ready vector database toolkit for building searchable knowledge bases
 - Multi-source data loading
 - Vector embeddings
 - Search capabilities
-""")
+"""
+    )
 
-    (temp_workspace / "docs" / "installation.md").write_text("""# Installation
+    (temp_workspace / "docs" / "installation.md").write_text(
+        """# Installation
 
 Install QDrant Loader using pip:
 
 ```bash
 pip install qdrant-loader
 ```
-""")
+"""
+    )
 
     # Create sample assets
     assets_dir = temp_workspace / "website" / "assets"

--- a/tests/test_website_build_comprehensive.py
+++ b/tests/test_website_build_comprehensive.py
@@ -935,7 +935,8 @@ class TestGitHubActionsWorkflow:
         favicon_script.parent.mkdir(parents=True, exist_ok=True)
 
         # Create a mock favicon generation script
-        favicon_script.write_text("""
+        favicon_script.write_text(
+            """
 import sys
 from pathlib import Path
 
@@ -980,7 +981,8 @@ def main():
 if __name__ == "__main__":
     success = main()
     sys.exit(0 if success else 1)
-""")
+"""
+        )
 
         # Test favicon generation step
         result = subprocess.run(


### PR DESCRIPTION
# Pull Request

## Summary

Add graph write hook in DocumentPipeline.process_batch(): after Qdrant upsert, if graph.enabled is true, extract nodes/edges by source_type and batch upsert to GraphStore.
Graph writes are idempotent (MERGE) and failures are logged without affecting ingestion.

## Detail

Graph write hook in DocumentPipeline.process_batch()

After Qdrant upsert, if graph.enabled=true in config:
Look up registered extractor per source_type
Call extract(doc) → (nodes, edges)
Batch upserts to GraphStore.upsert_nodes_batch() / upsert_edges_batch()
Idempotent (uses MERGE semantics, canonical IDs)
Failures logged but don't fail the batch — graph is optional, ingestion is not

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [x] Documentation updated (if applicable)
