### PR TITLE
feature: Graph write hook in DocumentPipeline.process_batch()

### DIFF
--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
@@ -84,7 +84,9 @@ async def get_graph_store(
                     host=final_host,
                     port=int(final_port),
                     graph_name=final_graph,
-                    max_connections=final_max_conn,
+                    max_connections=(
+                        final_max_conn if final_max_conn is not None else 10
+                    ),
                 )
 
                 await init_schema(_graph_store)

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/base_extractor.py
@@ -29,7 +29,7 @@ class EntityExtractor(ABC):
     _registry: dict[str, type[EntityExtractor]] = {}
 
     @abstractmethod
-    def extract(self, doc: Document) -> SubGraph:
+    async def extract(self, doc: Document) -> SubGraph:
         """
         Map raw source data into a SubGraph
         """
@@ -67,7 +67,7 @@ class BaseEntityExtractor(EntityExtractor):
 
     source_type: ClassVar[str]
 
-    def extract(self, doc: Document) -> SubGraph:
+    async def extract(self, doc: Document) -> SubGraph:
         project = self._project(doc)
 
         nodes: list[GraphNode] = []

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
@@ -211,17 +211,15 @@ class JiraEntityExtractor(BaseEntityExtractor):
         def _handle_url(url: str, kind: str) -> None:
             target = url.strip()
 
-            if not _is_url(target):
-                return
-
-            nodes.append(
-                GraphNode(
-                    id=target,
-                    label=CoreNodeLabel.URL,
-                    project=project,
-                    properties={"url": target},
+            if _is_url(target):
+                nodes.append(
+                    GraphNode(
+                        id=target,
+                        label=CoreNodeLabel.URL,
+                        project=project,
+                        properties={"url": target},
+                    )
                 )
-            )
 
             edges.append(
                 GraphEdge(

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/jira.py
@@ -190,9 +190,6 @@ class JiraEntityExtractor(BaseEntityExtractor):
     # ------------------------------------------------------------------
     # Cross-source URL links
     # ------------------------------------------------------------------
-
-    from urllib.parse import urlparse
-
     def _extract_links(
         self,
         doc: Document,
@@ -214,15 +211,17 @@ class JiraEntityExtractor(BaseEntityExtractor):
         def _handle_url(url: str, kind: str) -> None:
             target = url.strip()
 
-            if _is_url(target):
-                nodes.append(
-                    GraphNode(
-                        id=target,
-                        label=CoreNodeLabel.URL,
-                        project=project,
-                        properties={"url": target},
-                    )
+            if not _is_url(target):
+                return
+
+            nodes.append(
+                GraphNode(
+                    id=target,
+                    label=CoreNodeLabel.URL,
+                    project=project,
+                    properties={"url": target},
                 )
+            )
 
             edges.append(
                 GraphEdge(

--- a/packages/qdrant-loader-core/tests/test_confluence_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_confluence_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.confluence import ConfluenceEntityExtractor
 
 
-def test_confluence_page():
+@pytest.mark.asyncio
+async def test_confluence_page():
     extractor = ConfluenceEntityExtractor()
 
     # Prepare a Document instance with normalized metadata the extractor expects
@@ -24,7 +26,7 @@ def test_confluence_page():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Container" for n in result.nodes)
     assert any(e.edge_type == "BELONGS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_git_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_git_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.git import GitEntityExtractor
 
 
-def test_git_commit():
+@pytest.mark.asyncio
+async def test_git_commit():
     extractor = GitEntityExtractor()
 
     metadata = {
@@ -23,7 +25,7 @@ def test_git_commit():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Person" for n in result.nodes)

--- a/packages/qdrant-loader-core/tests/test_jira_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_jira_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.jira import JiraEntityExtractor
 
 
-def test_jira_basic():
+@pytest.mark.asyncio
+async def test_jira_basic():
     extractor = JiraEntityExtractor()
 
     metadata = {
@@ -32,7 +34,7 @@ def test_jira_basic():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
     print([n.label for n in result.nodes])
     print([e.edge_type for e in result.edges])
 

--- a/packages/qdrant-loader-core/tests/test_localfile_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_localfile_extractor.py
@@ -1,8 +1,10 @@
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.localfile import LocalFileEntityExtractor
 
 
-def test_localfile_basic():
+@pytest.mark.asyncio
+async def test_localfile_basic():
     extractor = LocalFileEntityExtractor()
 
     metadata = {
@@ -21,7 +23,7 @@ def test_localfile_basic():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Container" for n in result.nodes)

--- a/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import pytest
 from qdrant_loader.core.document import Document
 from qdrant_loader_core.graph.extractor.publicdocs import PublicDocsEntityExtractor
 
 
-def test_public_webpage():
+@pytest.mark.asyncio
+async def test_public_webpage():
     extractor = PublicDocsEntityExtractor()
 
     metadata = {
@@ -26,7 +28,7 @@ def test_public_webpage():
         metadata=metadata,
     )
 
-    result = extractor.extract(doc)
+    result = await extractor.extract(doc)
 
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Label" for n in result.nodes)

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
@@ -17,6 +17,12 @@ from qdrant_loader.utils.logging import LoggingConfig
 from .workers import ChunkingWorker, EmbeddingWorker, UpsertWorker
 from .workers.upsert_worker import PipelineResult
 
+# Sanity-check that at least one extractor was registered.
+assert EntityExtractor._registry, (
+    "No graph extractors registered — "
+    "ensure qdrant_loader_core.graph.registry was imported."
+)
+
 logger = LoggingConfig.get_logger(__name__)
 
 
@@ -237,7 +243,8 @@ class DocumentPipeline:
             )
 
             # add node and edge
-            await self._process_graph(batch, current_project_id)
+            if pipeline_result.success_count > 0:
+                await self._process_graph(batch, current_project_id)
 
             return BatchResult(
                 success_count=pipeline_result.success_count,

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
@@ -2,8 +2,15 @@
 
 import asyncio
 import time
+from collections import defaultdict
 from dataclasses import dataclass
+from typing import Any
 
+import qdrant_loader_core.graph.registry as _registry  # noqa: F401
+from qdrant_loader_core.graph import get_graph_store
+from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
+
+from qdrant_loader.config import get_settings
 from qdrant_loader.core.document import Document
 from qdrant_loader.utils.logging import LoggingConfig
 
@@ -46,11 +53,145 @@ class DocumentPipeline:
         self.embedding_worker = embedding_worker
         self.upsert_worker = upsert_worker
 
-    async def process_batch(self, batch: list[Document]) -> BatchResult:
+    async def _process_graph(
+        self,
+        documents: list[Document],
+        current_project_id: str | None = None,
+    ) -> None:
+        """
+        Graph write hook (optional):
+        - Extract entities + relations from documents
+        - Build nodes/edges
+        - Deduplicate
+        - Batch upsert into GraphStore
+        - Must NOT affect ingestion if fails
+        """
+
+        # ---------------------------
+        # 1. Load config safely
+        # ---------------------------
+        try:
+            settings = get_settings()
+            graph_cfg = getattr(settings.global_config, "graph", None)
+            graph_enabled = (
+                bool(getattr(graph_cfg, "enabled", False)) if graph_cfg else False
+            )
+        except Exception:
+            logger.warning("Graph config not available → graph disabled")
+            return
+
+        if not graph_enabled:
+            return
+
+        logger.info("🔄 Graph extraction started (batch size=%s)", len(documents))
+
+        # ---------------------------
+        # 2. Prepare dedup storage
+        # ---------------------------
+        nodes_dict: dict[str, Any] = {}
+        edges_dict: dict[tuple[str, str, str], Any] = {}
+
+        # Optional: group by source_type for efficiency
+        grouped_docs: dict[str, list[Document]] = defaultdict(list)
+        for doc in documents:
+            grouped_docs[doc.source_type].append(doc)
+
+        # ---------------------------
+        # 3. Extract graph per source_type
+        # ---------------------------
+        for source_type, docs in grouped_docs.items():
+            try:
+                extractor = EntityExtractor.for_source(source_type)
+                if not extractor:
+                    logger.warning("No extractor found for source_type=%s", source_type)
+                    continue
+
+                for doc in docs:
+                    try:
+                        subgraph = await extractor.extract(doc)
+
+                        if getattr(subgraph, "nodes", None):
+                            for node in subgraph.nodes:
+                                nodes_dict[node.id] = node
+
+                        if getattr(subgraph, "edges", None):
+                            for edge in subgraph.edges:
+                                edge_key = (edge.source, edge.target, edge.edge_type)
+                                edges_dict[edge_key] = edge
+
+                    except Exception as e:
+                        logger.error(
+                            "⚠️ Graph extract failed doc_id=%s error=%s",
+                            getattr(doc, "id", "<unknown>"),
+                            e,
+                            exc_info=True,
+                        )
+
+            except Exception as e:
+                logger.error(
+                    "⚠️ Extractor failed for source_type=%s error=%s",
+                    source_type,
+                    e,
+                    exc_info=True,
+                )
+
+        # ---------------------------
+        # 4. Build batches
+        # ---------------------------
+        nodes_batch = list(nodes_dict.values())
+        edges_batch = list(edges_dict.values())
+
+        # ---------------------------
+        # 5. Attach project context
+        # ---------------------------
+        if current_project_id:
+            for node in nodes_batch:
+                if not hasattr(node, "properties") or node.properties is None:
+                    node.properties = {}
+                node.properties["project"] = current_project_id
+
+            for edge in edges_batch:
+                if not hasattr(edge, "properties") or edge.properties is None:
+                    edge.properties = {}
+                edge.properties["project"] = current_project_id
+
+        # ---------------------------
+        # 6. Batch upsert
+        # ---------------------------
+        if not nodes_batch and not edges_batch:
+            logger.info("Graph extraction result is empty → skip upsert")
+            return
+
+        try:
+            graph_store = await get_graph_store()
+
+            if nodes_batch:
+                await graph_store.upsert_nodes_batch(nodes_batch)
+
+            if edges_batch:
+                await graph_store.upsert_edges_batch(edges_batch)
+
+            logger.info(
+                "✅ Graph upsert success | nodes=%s edges=%s",
+                len(nodes_batch),
+                len(edges_batch),
+            )
+
+        except Exception as e:
+            logger.error(
+                "⚠️ Graph upsert failed (non-fatal): %s",
+                e,
+                exc_info=True,
+            )
+
+    async def process_batch(
+        self, batch: list[Document], current_project_id: str | None = None
+    ) -> BatchResult:
         """Process a bounded batch of documents through the pipeline.
 
         Args:
             batch: List of documents to process (bounded size, typically 256)
+            current_project_id: Optional project id context for graph extraction/upsert.
 
         Returns:
             BatchResult with processing statistics.
@@ -94,6 +235,9 @@ class DocumentPipeline:
                 f"✅ Batch processing completed: {pipeline_result.success_count} chunks, "
                 f"{pipeline_result.error_count} errors in {total_duration:.2f}s"
             )
+
+            # add node and edge
+            await self._process_graph(batch, current_project_id)
 
             return BatchResult(
                 success_count=pipeline_result.success_count,

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
@@ -17,12 +17,6 @@ from qdrant_loader.utils.logging import LoggingConfig
 from .workers import ChunkingWorker, EmbeddingWorker, UpsertWorker
 from .workers.upsert_worker import PipelineResult
 
-# Sanity-check that at least one extractor was registered.
-assert EntityExtractor._registry, (
-    "No graph extractors registered — "
-    "ensure qdrant_loader_core.graph.registry was imported."
-)
-
 logger = LoggingConfig.get_logger(__name__)
 
 
@@ -243,8 +237,16 @@ class DocumentPipeline:
             )
 
             # add node and edge
-            if pipeline_result.success_count > 0:
-                await self._process_graph(batch, current_project_id)
+            if (
+                pipeline_result.successfully_processed_documents
+            ):  # get list of strings of successful Qdrant upsert docs
+                ok_docs = [
+                    doc
+                    for doc in batch
+                    if doc.id in pipeline_result.successfully_processed_documents
+                ]
+                if ok_docs:
+                    await self._process_graph(ok_docs, current_project_id)
 
             return BatchResult(
                 success_count=pipeline_result.success_count,

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -277,7 +277,9 @@ class PipelineOrchestrator:
                         continue
 
                     batch_result = (
-                        await self.components.document_pipeline.process_batch(batch)
+                        await self.components.document_pipeline.process_batch(
+                            batch, current_project_id
+                        )
                     )
                     aggregated_result.success_count += batch_result.success_count
                     aggregated_result.error_count += batch_result.failure_count

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -143,7 +143,9 @@ class TestPipelineOrchestrator:
         self.source_filter.filter_sources.assert_called_once_with(
             self.mock_sources_config, None, None
         )
-        self.document_pipeline.process_batch.assert_called_once_with(mock_documents)
+        self.document_pipeline.process_batch.assert_called_once_with(
+            mock_documents, None
+        )
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1", "doc2"}, None
         )
@@ -241,7 +243,9 @@ class TestPipelineOrchestrator:
         self.source_filter.filter_sources.assert_called_once_with(
             self.mock_sources_config, "git", "my-repo"
         )
-        self.document_pipeline.process_batch.assert_called_once_with(mock_documents)
+        self.document_pipeline.process_batch.assert_called_once_with(
+            mock_documents, None
+        )
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1"}, None
         )

--- a/packages/qdrant-loader/tests/unit/core/test_process_graph.py
+++ b/packages/qdrant-loader/tests/unit/core/test_process_graph.py
@@ -1,0 +1,210 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from qdrant_loader.core.pipeline.document_pipeline import DocumentPipeline
+from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
+
+
+@pytest.fixture
+def pipeline():
+    return DocumentPipeline(
+        chunking_worker=MagicMock(),
+        embedding_worker=MagicMock(),
+        upsert_worker=MagicMock(),
+    )
+
+
+@pytest.fixture
+def document():
+    return SimpleNamespace(
+        id="doc-1",
+        source_type="jira",
+    )
+
+
+def mock_settings(enabled: bool):
+    return SimpleNamespace(
+        global_config=SimpleNamespace(
+            graph=SimpleNamespace(enabled=enabled),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_graph_disabled_returns_early(
+    monkeypatch,
+    pipeline,
+    document,
+):
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_settings",
+        lambda: mock_settings(False),
+    )
+
+    get_graph_store = AsyncMock()
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_graph_store",
+        get_graph_store,
+    )
+
+    await pipeline._process_graph([document])
+
+    get_graph_store.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_graph_settings_failure_disables_graph(
+    monkeypatch,
+    pipeline,
+    document,
+):
+    def raise_settings():
+        raise RuntimeError("boom")
+
+    mock_logger = MagicMock()
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.logger",
+        mock_logger,
+    )
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_settings",
+        raise_settings,
+    )
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.EntityExtractor.for_source",
+        lambda _: None,
+    )
+
+    await pipeline._process_graph([document])
+
+    mock_logger.warning.assert_called_once_with(
+        "Graph config not available → graph disabled"
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_graph_missing_extractor_logs_warning(
+    monkeypatch,
+    pipeline,
+    document,
+):
+    mock_logger = MagicMock()
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.logger",
+        mock_logger,
+    )
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_settings",
+        lambda: mock_settings(True),
+    )
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.EntityExtractor.for_source",
+        lambda _: None,
+    )
+
+    await pipeline._process_graph([document])
+
+    mock_logger.warning.assert_called_once_with(
+        "No extractor found for source_type=%s",
+        "jira",
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_graph_writes_nodes_and_edges(
+    monkeypatch,
+    pipeline,
+    document,
+):
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_settings",
+        lambda: mock_settings(True),
+    )
+
+    node = SimpleNamespace(
+        id="node-1",
+        properties={},
+    )
+
+    edge = SimpleNamespace(
+        source="a",
+        target="b",
+        edge_type="RELATES_TO",
+        properties={},
+    )
+
+    subgraph = SimpleNamespace(
+        nodes=[node],
+        edges=[edge],
+    )
+
+    extractor = MagicMock()
+    extractor.extract = AsyncMock(return_value=subgraph)
+
+    monkeypatch.setattr(
+        EntityExtractor,
+        "for_source",
+        lambda _: extractor,
+    )
+
+    graph_store = AsyncMock()
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_graph_store",
+        AsyncMock(return_value=graph_store),
+    )
+
+    await pipeline._process_graph(
+        [document],
+        current_project_id="project-123",
+    )
+
+    graph_store.upsert_nodes_batch.assert_called_once()
+    graph_store.upsert_edges_batch.assert_called_once()
+
+    assert node.properties["project"] == "project-123"
+    assert edge.properties["project"] == "project-123"
+
+
+@pytest.mark.asyncio
+async def test_process_graph_empty_subgraph_skips_upsert(
+    monkeypatch,
+    pipeline,
+    document,
+):
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_settings",
+        lambda: mock_settings(True),
+    )
+
+    extractor = MagicMock()
+    extractor.extract = AsyncMock(
+        return_value=SimpleNamespace(
+            nodes=[],
+            edges=[],
+        )
+    )
+
+    monkeypatch.setattr(
+        EntityExtractor,
+        "for_source",
+        lambda _: None,
+    )
+
+    get_graph_store = AsyncMock()
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.pipeline.document_pipeline.get_graph_store",
+        get_graph_store,
+    )
+
+    await pipeline._process_graph([document])
+
+    get_graph_store.assert_not_called()


### PR DESCRIPTION
# Pull Request

## Summary

Add graph write hook in DocumentPipeline.process_batch(): after Qdrant upsert, if graph.enabled is true, extract nodes/edges by source_type and batch upsert to GraphStore.
Graph writes are idempotent (MERGE) and failures are logged without affecting ingestion.

## Detail
Graph write hook in DocumentPipeline.process_batch()

After Qdrant upsert, if graph.enabled=true in config:
- Look up registered extractor per source_type
- Call extract(doc) → (nodes, edges)
- Batch upserts to GraphStore.upsert_nodes_batch() / upsert_edges_batch()
- Idempotent (uses MERGE semantics, canonical IDs)
- Failures logged but don't fail the batch — graph is optional, ingestion is not
## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [x] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [x] Tests pass (`pytest -v`)
- [x] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)
