### PR TITLE
feat: add worker activity tracking and enhanced initialization logs

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
@@ -147,8 +147,14 @@ async def _serve_main(
         session_factory=session_factory,
     )
 
-    logger.info("serve.pool_init")
     worker_runtime = config_obj.workers.runtime
+    logger.info(
+        "serve.pool_init",
+        worker_count=worker_runtime.worker_count,
+        lease_seconds=worker_runtime.lease_seconds,
+        max_attempts=worker_runtime.max_attempts,
+        retry_backoff_base_seconds=worker_runtime.retry_backoff_base_seconds,
+    )
     worker_pool = QueueWorkerPool(
         queue=job_queue,
         handler=job_handler,

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/chunk_enricher.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/chunk_enricher.py
@@ -26,7 +26,7 @@ def _empty() -> dict[str, Any]:
 class ChunkEnricher:
     """Owns a ``SemanticAnalyzer`` and maps ``(content, doc_id)`` to chunk metadata."""
 
-    def __init__(self, settings: "Settings") -> None:
+    def __init__(self, settings: Settings) -> None:
         chunking = settings.global_config.chunking
         self._enhanced = bool(chunking.enable_enhanced_semantic_analysis)
         self._analyzer: SemanticAnalyzer | None = None

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -150,6 +150,7 @@ class QueueWorkerPool:
                         current_claim_attempt: int = job.attempts,
                         current_lease_seconds: int = self._lease_seconds,
                         current_renewal_interval: int = renewal_interval,
+                        holder: list[asyncio.Task | None] = _handler_task_holder,
                     ) -> None:
                         nonlocal claim_lost
                         while True:
@@ -169,8 +170,8 @@ class QueueWorkerPool:
                                         job_id=current_job_id,
                                     )
                                     claim_lost = True
-                                    if _handler_task_holder[0] is not None:
-                                        _handler_task_holder[0].cancel()
+                                    if holder[0] is not None:
+                                        holder[0].cancel()
                                     return
                             except Exception as exc:
                                 logger.warning(

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -50,8 +50,18 @@ class QueueWorkerPool:
         """Drain the queue once and return number of attempted jobs."""
         processed_count = 0
         processed_count_guard = asyncio.Lock()
+        active_workers: set[int] = set()
+        active_workers_guard = asyncio.Lock()
 
-        async def worker() -> None:
+        async def _set_worker_activity(worker_id: int, is_active: bool) -> int:
+            async with active_workers_guard:
+                if is_active:
+                    active_workers.add(worker_id)
+                else:
+                    active_workers.discard(worker_id)
+                return len(active_workers)
+
+        async def worker(worker_id: int) -> None:
             nonlocal processed_count
 
             while True:
@@ -62,25 +72,45 @@ class QueueWorkerPool:
                 if job is None:
                     return
 
+                current_active_workers = await _set_worker_activity(worker_id, True)
+
                 payload, error_message = self._decode_payload(job.payload_json)
                 if error_message is not None:
                     async with self._queue_io_guard:
-                        await self._queue.mark_failed(
+                        updated = await self._queue.mark_failed(
                             job.id, error_message, claim_attempt=job.attempts
+                        )
+                    if not updated:
+                        logger.warning(
+                            "job.claim_lost_on_terminal_transition",
+                            job_id=job.id,
+                            worker_id=worker_id,
+                            active_workers=current_active_workers,
+                            worker_count=self._worker_count,
                         )
                     async with processed_count_guard:
                         processed_count += 1
+                    await _set_worker_activity(worker_id, False)
                     continue
 
                 try:
                     source_key = self._extract_source_key(payload)
                 except KeyError as exc:
                     async with self._queue_io_guard:
-                        await self._queue.mark_failed(
+                        updated = await self._queue.mark_failed(
                             job.id, str(exc), claim_attempt=job.attempts
+                        )
+                    if not updated:
+                        logger.warning(
+                            "job.claim_lost_on_terminal_transition",
+                            job_id=job.id,
+                            worker_id=worker_id,
+                            active_workers=current_active_workers,
+                            worker_count=self._worker_count,
                         )
                     async with processed_count_guard:
                         processed_count += 1
+                    await _set_worker_activity(worker_id, False)
                     continue
                 source_lock = await self._get_source_lock(source_key)
 
@@ -90,6 +120,9 @@ class QueueWorkerPool:
                     job_type=job.type,
                     source_key=source_key,
                     attempt=job.attempts,
+                    worker_id=worker_id,
+                    active_workers=current_active_workers,
+                    worker_count=self._worker_count,
                 )
 
                 async with source_lock:
@@ -99,77 +132,129 @@ class QueueWorkerPool:
                         job_type=job.type,
                         source_key=source_key,
                         attempt=job.attempts,
+                        worker_id=worker_id,
+                        active_workers=current_active_workers,
+                        worker_count=self._worker_count,
                     )
                     t0 = time.monotonic()
-                    try:
-                        # Start lease renewal task to prevent visibility timeout during handler
-                        renewal_interval = max(1, self._lease_seconds // 3)
-                        lease_lost = asyncio.Event()
+                    claim_lost = False
+                    renewal_interval = max(1, self._lease_seconds // 3)
+                    # Mutable holder so _renew_lease closure can reference handler_task
+                    # after it is created (asyncio is single-threaded; the first
+                    # renewal sleep guarantees the holder is populated before use).
+                    _handler_task_holder: list[asyncio.Task | None] = [None]
 
-                        async def _renew_lease(
-                            *,
-                            current_job_id: int = job.id,
-                            current_claim_attempt: int = job.attempts,
-                            current_lease_seconds: int = self._lease_seconds,
-                            current_renewal_interval: int = renewal_interval,
-                            lease_lost_event: asyncio.Event = lease_lost,
-                        ) -> None:
-                            while True:
-                                await asyncio.sleep(current_renewal_interval)
-                                try:
-                                    async with self._queue_io_guard:
-                                        extended = await self._queue.extend_visibility(
-                                            current_job_id,
-                                            current_lease_seconds,
-                                            claim_attempt=current_claim_attempt,
-                                        )
-                                    if not extended:
-                                        lease_lost_event.set()
-                                        return
-                                except Exception as exc:
-                                    logger.warning(
-                                        "job.lease_renew_failed",
-                                        job_id=current_job_id,
-                                        error=str(exc),
-                                        error_type=type(exc).__name__,
-                                    )
-
-                        renewal_task = asyncio.create_task(_renew_lease())
-                        try:
-                            await self._handler(job.type, payload)
-                            if lease_lost.is_set():
-                                raise RuntimeError(
-                                    f"Lost lease for job {job.id} while handler was running"
-                                )
-                        finally:
-                            renewal_task.cancel()
+                    async def _renew_lease(
+                        *,
+                        current_job_id: int = job.id,
+                        current_claim_attempt: int = job.attempts,
+                        current_lease_seconds: int = self._lease_seconds,
+                        current_renewal_interval: int = renewal_interval,
+                    ) -> None:
+                        nonlocal claim_lost
+                        while True:
+                            await asyncio.sleep(current_renewal_interval)
                             try:
-                                await renewal_task
-                            except asyncio.CancelledError:
-                                pass
+                                async with self._queue_io_guard:
+                                    renewed = await self._queue.extend_visibility(
+                                        current_job_id,
+                                        current_lease_seconds,
+                                        claim_attempt=current_claim_attempt,
+                                    )
+                                if not renewed:
+                                    # Claim was silently lost (job reclaimed or cancelled
+                                    # externally). Cancel the handler to abort side-effects.
+                                    logger.warning(
+                                        "job.claim_lost_on_renewal",
+                                        job_id=current_job_id,
+                                    )
+                                    claim_lost = True
+                                    if _handler_task_holder[0] is not None:
+                                        _handler_task_holder[0].cancel()
+                                    return
                             except Exception as exc:
                                 logger.warning(
-                                    "job.lease_renew_teardown_failed",
-                                    job_id=job.id,
+                                    "job.lease_renew_failed",
+                                    job_id=current_job_id,
                                     error=str(exc),
                                     error_type=type(exc).__name__,
                                 )
+
+                    # Run handler as a task so the renewal loop can cancel it on claim loss.
+                    handler_task = asyncio.create_task(self._handler(job.type, payload))
+                    _handler_task_holder[0] = handler_task
+                    renewal_task = asyncio.create_task(_renew_lease())
+
+                    handler_exc: Exception | None = None
+                    _external_cancelled = False
+
+                    try:
+                        await handler_task
+                    except asyncio.CancelledError:
+                        if not claim_lost:
+                            # True external cancellation (not from claim-loss path).
+                            # Ensure handler_task is stopped, then re-raise.
+                            _external_cancelled = True
+                            handler_task.cancel()
+                            try:
+                                await handler_task
+                            except (asyncio.CancelledError, Exception):
+                                pass
+                        # If claim_lost: expected cancellation triggered by renewal;
+                        # fall through to cleanup without re-raising.
                     except Exception as exc:
+                        handler_exc = exc
+                    finally:
+                        renewal_task.cancel()
+                        try:
+                            await renewal_task
+                        except asyncio.CancelledError:
+                            pass
+                        except Exception as exc:
+                            logger.warning(
+                                "job.lease_renew_teardown_failed",
+                                job_id=job.id,
+                                error=str(exc),
+                                error_type=type(exc).__name__,
+                            )
+
+                    if _external_cancelled:
+                        raise asyncio.CancelledError()
+
+                    if claim_lost:
+                        # Job was reclaimed by another worker; skip all status mutations
+                        # to avoid overwriting the new owner's state.
+                        logger.warning(
+                            "job.claim_lost_skipping_update",
+                            job_id=job.id,
+                            job_type=job.type,
+                            source_key=source_key,
+                            attempt=job.attempts,
+                        )
+                    elif handler_exc is not None:
                         duration_ms = round((time.monotonic() - t0) * 1000)
+                        is_retry = job.attempts < self._max_attempts
+                        retry_after_seconds = 0
+                        if is_retry and self._retry_backoff_base_seconds > 0:
+                            retry_after_seconds = self._retry_backoff_base_seconds * (
+                                2 ** (job.attempts - 1)
+                            )
                         async with self._queue_io_guard:
-                            if job.attempts < self._max_attempts:
-                                retry_after_seconds = 0
-                                if self._retry_backoff_base_seconds > 0:
-                                    retry_after_seconds = (
-                                        self._retry_backoff_base_seconds
-                                        * (2 ** (job.attempts - 1))
-                                    )
-                                await self._queue.release_for_retry(
+                            if is_retry:
+                                updated = await self._queue.release_for_retry(
                                     job.id,
-                                    str(exc),
+                                    str(handler_exc),
                                     claim_attempt=job.attempts,
                                     retry_after_seconds=retry_after_seconds,
                                 )
+                            else:
+                                updated = await self._queue.mark_failed(
+                                    job.id,
+                                    str(handler_exc),
+                                    claim_attempt=job.attempts,
+                                )
+                        if updated:
+                            if is_retry:
                                 logger.info(
                                     "job.retry_scheduled",
                                     job_id=job.id,
@@ -179,12 +264,12 @@ class QueueWorkerPool:
                                     max_attempts=self._max_attempts,
                                     retry_after_seconds=retry_after_seconds,
                                     duration_ms=duration_ms,
-                                    error=str(exc),
+                                    error=str(handler_exc),
+                                    worker_id=worker_id,
+                                    active_workers=current_active_workers,
+                                    worker_count=self._worker_count,
                                 )
                             else:
-                                await self._queue.mark_failed(
-                                    job.id, str(exc), claim_attempt=job.attempts
-                                )
                                 logger.info(
                                     "job.failed",
                                     job_id=job.id,
@@ -193,27 +278,59 @@ class QueueWorkerPool:
                                     attempt=job.attempts,
                                     max_attempts=self._max_attempts,
                                     duration_ms=duration_ms,
-                                    error=str(exc),
+                                    error=str(handler_exc),
+                                    worker_id=worker_id,
+                                    active_workers=current_active_workers,
+                                    worker_count=self._worker_count,
                                 )
+                        else:
+                            logger.warning(
+                                "job.claim_lost_on_terminal_transition",
+                                job_id=job.id,
+                                job_type=job.type,
+                                source_key=source_key,
+                                attempt=job.attempts,
+                                worker_id=worker_id,
+                                active_workers=current_active_workers,
+                                worker_count=self._worker_count,
+                            )
                     else:
                         duration_ms = round((time.monotonic() - t0) * 1000)
                         async with self._queue_io_guard:
-                            await self._queue.mark_done(
+                            updated = await self._queue.mark_done(
                                 job.id, claim_attempt=job.attempts
                             )
-                        logger.info(
-                            "job.done",
-                            job_id=job.id,
-                            job_type=job.type,
-                            source_key=source_key,
-                            attempt=job.attempts,
-                            duration_ms=duration_ms,
-                        )
+                        if updated:
+                            logger.info(
+                                "job.done",
+                                job_id=job.id,
+                                job_type=job.type,
+                                source_key=source_key,
+                                attempt=job.attempts,
+                                duration_ms=duration_ms,
+                                worker_id=worker_id,
+                                active_workers=current_active_workers,
+                                worker_count=self._worker_count,
+                            )
+                        else:
+                            logger.warning(
+                                "job.claim_lost_on_terminal_transition",
+                                job_id=job.id,
+                                job_type=job.type,
+                                source_key=source_key,
+                                attempt=job.attempts,
+                                worker_id=worker_id,
+                                active_workers=current_active_workers,
+                                worker_count=self._worker_count,
+                            )
 
                 async with processed_count_guard:
                     processed_count += 1
+                await _set_worker_activity(worker_id, False)
 
-        await asyncio.gather(*(worker() for _ in range(self._worker_count)))
+        await asyncio.gather(
+            *(worker(worker_id) for worker_id in range(1, self._worker_count + 1))
+        )
         return processed_count
 
     async def _get_source_lock(self, source_key: str) -> asyncio.Lock:

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -54,7 +54,7 @@ class JobQueue(Protocol):
         """Extend the visibility deadline of a RUNNING job by lease_seconds.
 
         Used to prevent lease expiration during long-running handler execution.
-        Returns True if successfully extended, False if job is no longer RUNNING.
+        Returns True if successfully extended, False if claim ownership changed.
         """
 
     async def list(
@@ -249,7 +249,7 @@ class SQLiteJobQueue:
         """Extend the visibility deadline of a RUNNING job by lease_seconds.
 
         Used to prevent lease expiration during long-running handler execution.
-        Returns True if successfully extended, False if job is no longer RUNNING.
+        Returns True if successfully extended, False if claim ownership changed.
         """
         now = datetime.now(UTC)
         new_deadline = now + timedelta(seconds=lease_seconds)

--- a/packages/qdrant-loader/tests/unit/core/conversion/test_service.py
+++ b/packages/qdrant-loader/tests/unit/core/conversion/test_service.py
@@ -11,6 +11,9 @@ running real docling over a fixture.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
 from qdrant_loader.core.conversion.outcome import (
     ConversionOutcome,
     ConversionStatus,
@@ -18,6 +21,17 @@ from qdrant_loader.core.conversion.outcome import (
 from qdrant_loader.core.conversion.service import ConversionService, ConvertedFile
 from qdrant_loader.core.file_conversion.conversion_config import FileConversionConfig
 from qdrant_loader.core.file_conversion.exceptions import FileConversionError
+
+try:
+    import docling as _docling  # noqa: F401
+    _docling_available = True
+except ModuleNotFoundError:
+    _docling_available = False
+
+_skip_no_docling = pytest.mark.skipif(
+    not _docling_available,
+    reason="docling optional dependency is not installed",
+)
 
 
 class _StubConvertedDocument:
@@ -103,30 +117,34 @@ def test_markitdown_failure_uses_fallback_document_and_fallback_method():
 
 
 # -- docling path: PARTIAL is usable but must be flagged -------------------------
-def test_docling_success_returns_docling_content_without_warning(caplog):
+def test_docling_success_returns_docling_content_without_warning():
+    import qdrant_loader.core.conversion.service as conv_module
+
     doc = _StubConvertedDocument("# Full document\n\nall content present")
     outcome = ConversionOutcome(status=ConversionStatus.SUCCESS, document=doc)
     service = _docling_service(outcome)
 
-    with caplog.at_level("WARNING"):
+    with patch.object(conv_module, "logger") as mock_logger:
         result = service.convert("/docs/report.pdf")
 
     assert result.content == "# Full document\n\nall content present"
     assert result.conversion_method == "docling"
     assert result.conversion_failed is False
     assert result.converted_document is doc
-    assert caplog.records == []  # a clean SUCCESS must not warn
+    assert mock_logger.warning.call_count == 0  # a clean SUCCESS must not warn
 
 
-def test_docling_partial_logs_warning_but_still_returns_usable_content(caplog):
+def test_docling_partial_logs_warning_but_still_returns_usable_content():
     """A PARTIAL outcome (e.g. document_timeout mid-document -> truncated content) is
     still usable, so we index it as docling content — but it must NOT pass silently:
     a distinct warning naming the file + that content is truncated/partial fires."""
+    import qdrant_loader.core.conversion.service as conv_module
+
     doc = _StubConvertedDocument("# Truncated document\n\npartial content")
     outcome = ConversionOutcome(status=ConversionStatus.PARTIAL, document=doc)
     service = _docling_service(outcome)
 
-    with caplog.at_level("WARNING"):
+    with patch.object(conv_module, "logger") as mock_logger:
         result = service.convert("/docs/huge.pdf")
 
     # content is still usable docling output, indexed as a real (not fallback) doc
@@ -136,11 +154,11 @@ def test_docling_partial_logs_warning_but_still_returns_usable_content(caplog):
     assert result.converted_document is doc
 
     # but a distinct warning must have fired, naming the file
-    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert len(warnings) == 1
-    message = warnings[0].getMessage().lower()
-    assert "/docs/huge.pdf" in warnings[0].getMessage()
-    assert "partial" in message or "truncat" in message
+    assert mock_logger.warning.call_count == 1
+    call_args = mock_logger.warning.call_args
+    event_msg = call_args[0][0]  # first positional arg is the event string
+    assert "/docs/huge.pdf" in str(call_args)
+    assert "partial" in event_msg.lower() or "truncat" in event_msg.lower()
 
 
 def test_docling_failure_uses_canonical_fallback_document():
@@ -209,6 +227,7 @@ def test_markitdown_is_supported_delegates_to_file_detector(tmp_path):
     assert service.is_supported(str(md)) is False
 
 
+@_skip_no_docling
 def test_docling_is_supported_true_for_pdf_within_policy(tmp_path):
     """For docling, a PDF is supported: FileDetector says convertible AND it falls
     within docling's FormatPolicy."""
@@ -229,6 +248,7 @@ def test_docling_is_supported_false_when_file_detector_rejects(tmp_path):
     assert service.is_supported(str(md)) is False
 
 
+@_skip_no_docling
 def test_docling_is_supported_false_when_outside_format_policy(tmp_path):
     """A file the FileDetector accepts but whose format is NOT in docling's
     FormatPolicy (e.g. epub — MarkItDown-supported, not a docling enabled format)
@@ -243,6 +263,7 @@ def test_docling_is_supported_false_when_outside_format_policy(tmp_path):
     assert service.is_supported(str(epub)) is False
 
 
+@_skip_no_docling
 def test_docling_is_supported_false_when_over_size_limit(tmp_path):
     """A convertible, in-policy file that exceeds docling's max_file_size is rejected."""
     big = tmp_path / "huge.pdf"

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -309,6 +309,67 @@ async def test_worker_pool_extends_visibility_during_long_handler(
 
 
 @pytest.mark.asyncio
+async def test_worker_pool_cancels_handler_and_skips_update_on_claim_loss(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """extend_visibility returning False must cancel the handler and skip status update.
+
+    If the job's claim was silently lost (reclaimed by another worker or cancelled
+    externally), the renewal task detects it via extend_visibility → False, cancels
+    the handler to abort side-effects, and the pool must NOT call mark_done/mark_failed,
+    leaving the job in RUNNING state (owned by the new claimant).
+    """
+    await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source_lock": "jira-main"})
+
+    handler_started = asyncio.Event()
+    handler_completed = asyncio.Event()
+
+    async def long_handler(_job_type: str, _payload: dict) -> None:
+        handler_started.set()
+        await asyncio.sleep(10)  # Would block for 10s without cancellation
+        handler_completed.set()  # Must NOT be reached
+
+    original_extend = sqlite_job_queue.extend_visibility
+
+    async def claim_lost_extend(
+        _job_id: int, _lease_seconds: int, _claim_attempt: int
+    ) -> bool:
+        return False  # Signal: claim is no longer ours
+
+    sqlite_job_queue.extend_visibility = claim_lost_extend  # type: ignore[method-assign]
+
+    pool = QueueWorkerPool(
+        sqlite_job_queue,
+        handler=long_handler,
+        worker_count=1,
+        lease_seconds=3,  # deadline = now+3s; renewal_interval = max(1, 3//3) = 1s
+        # With lease_seconds=3 the visibility deadline is 3s in the future when the
+        # job is claimed. The renewal fires at 1s and returns False (claim lost).
+        # At that point 2s of deadline remain, so claim_next() won't re-claim the job.
+    )
+
+    try:
+        processed = await pool.run_until_empty()
+    finally:
+        sqlite_job_queue.extend_visibility = original_extend
+
+    assert processed == 1
+    assert handler_started.is_set(), "Handler must have started"
+    assert (
+        not handler_completed.is_set()
+    ), "Handler must have been cancelled before completing"
+
+    # Claim was lost: pool must NOT have transitioned the job to DONE or FAILED
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE)
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED)
+    running_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.RUNNING)
+
+    assert len(done_jobs) == 0
+    assert len(failed_jobs) == 0
+    assert len(running_jobs) == 1  # Job remains RUNNING; the "new owner" is responsible
+
+
+@pytest.mark.asyncio
 async def test_lease_renew_errors_do_not_mask_handler_error(
     sqlite_job_queue: SQLiteJobQueue,
 ):
@@ -321,7 +382,9 @@ async def test_lease_renew_errors_do_not_mask_handler_error(
 
     original_extend_visibility = sqlite_job_queue.extend_visibility
 
-    async def flaky_extend_visibility(job_id: int, lease_seconds: int) -> bool:
+    async def flaky_extend_visibility(
+        _job_id: int, _lease_seconds: int, _claim_attempt: int
+    ) -> bool:
         raise RuntimeError("db down during extend_visibility")
 
     sqlite_job_queue.extend_visibility = flaky_extend_visibility  # type: ignore[method-assign]

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -332,7 +332,7 @@ async def test_worker_pool_cancels_handler_and_skips_update_on_claim_loss(
     original_extend = sqlite_job_queue.extend_visibility
 
     async def claim_lost_extend(
-        _job_id: int, _lease_seconds: int, _claim_attempt: int
+        _job_id: int, _lease_seconds: int, claim_attempt: int
     ) -> bool:
         return False  # Signal: claim is no longer ours
 

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -354,6 +354,35 @@ async def test_extend_visibility_on_pending_job_fails(
 
 
 @pytest.mark.asyncio
+async def test_extend_visibility_rejects_stale_claim_attempt(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """A stale worker must not renew a lease after reclaim increments attempts."""
+    job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "test"})
+
+    first_claim = await sqlite_job_queue.claim_next(lease_seconds=1)
+    assert first_claim is not None
+
+    await asyncio.sleep(1.1)
+
+    second_claim = await sqlite_job_queue.claim_next(lease_seconds=60)
+    assert second_claim is not None
+    assert second_claim.attempts == first_claim.attempts + 1
+
+    # First claimant is stale now and must not be able to renew.
+    stale_extended = await sqlite_job_queue.extend_visibility(
+        job.id, lease_seconds=30, claim_attempt=first_claim.attempts
+    )
+    assert stale_extended is False
+
+    # Current claimant can still renew.
+    current_extended = await sqlite_job_queue.extend_visibility(
+        job.id, lease_seconds=30, claim_attempt=second_claim.attempts
+    )
+    assert current_extended is True
+
+
+@pytest.mark.asyncio
 async def test_list_with_offset_and_limit_pagination(sqlite_job_queue: SQLiteJobQueue):
     """Test pagination using offset and limit parameters."""
     # Create 25 jobs


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Affected Components
Impacts the **serve/worker activity tracking** path in the qdrant-loader serving pipeline: `serve_cmd` logging and the async job orchestration in `core/worker/pool.py` (per-worker activity, worker_id-aware handling, lease-renewal + handler cancellation) and `core/worker/queue.py` (docstring clarification). Also includes minor typing cleanup in `chunk_enricher.py` and makes docling-dependent conversion tests optional.

## Config Schema Changes
**Additive/no-breaking**: `serve_cmd` now emits structured runtime worker fields (`worker_count`, `lease_seconds`, `max_attempts`, `retry_backoff_base_seconds`) from `config_obj.workers.runtime`; no schema changes.

## Test Coverage
Covers the new/changed worker code paths:
- New claim-loss cancellation test in `test_pool.py`
- New stale-claim rejection test in `test_queue.py`
- Updated existing pool tests; conversion tests updated for optional `docling`.

## Security & Resource Safety
Improves queue-state safety on ownership changes (skips status mutations on claim loss) and reduces error masking by cancelling the handler when renewal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->