### PR TITLE
Feature/postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# Example environment for the Docker deployment (docker-compose.yaml).
+# Copy to .env and fill in real values. .env is gitignored — never commit secrets.
+# Placeholders here are intentionally fake.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# State database (PostgreSQL)
+# ─────────────────────────────────────────────────────────────────────────────
+# Credentials for the bundled `postgres` service. POSTGRES_PASSWORD is REQUIRED
+# (compose fails fast if unset). USER/DB are non-secret and have sane defaults.
+POSTGRES_USER=qdrant_loader
+POSTGRES_PASSWORD=change-me-since-this-is-fake
+POSTGRES_DB=qdrant_loader
+
+# Optional: override the full state DB URL. If unset, it is assembled from the
+# POSTGRES_* vars above and points at the in-compose `postgres` service.
+# For AWS RDS, point this at your RDS endpoint (no other change needed):
+# STATE_DB_URL=postgresql+asyncpg://user:pass@your-rds-endpoint:5432/qdrant_loader
+#
+# Community/local (no Docker): leave Postgres unset and use SQLite instead:
+# STATE_DB_PATH=./state.db
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Qdrant (vector store)
+# ─────────────────────────────────────────────────────────────────────────────
+QDRANT_URL=http://qdrant:6333
+QDRANT_COLLECTION_NAME=documents
+# QDRANT_API_KEY=                       # only if your Qdrant requires auth
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LLM / embeddings
+# ─────────────────────────────────────────────────────────────────────────────
+LLM_PROVIDER=openai
+LLM_BASE_URL=https://api.openai.com/v1
+LLM_API_KEY=your-llm-api-key
+LLM_EMBEDDING_MODEL=text-embedding-3-small
+LLM_CHAT_MODEL=gpt-4o-mini
+# Legacy (still supported):
+OPENAI_API_KEY=your-openai-api-key
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MCP server logging
+# ─────────────────────────────────────────────────────────────────────────────
+MCP_LOG_LEVEL=INFO
+MCP_LOG_FILE=mcp.log
+MCP_DISABLE_CONSOLE_LOGGING=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### State Management
+
+- Optional **PostgreSQL** backend for the state database, alongside the default
+  SQLite. Set `STATE_DB_URL` (or `state_management.database_url`) to a full
+  SQLAlchemy URL — e.g. `postgresql+asyncpg://user:pass@host:5432/db` — to switch
+  backends; SQLite remains the default when `STATE_DB_URL` is unset. A bare
+  `postgresql://` is auto-normalized to the async `asyncpg` driver. Postgres uses
+  a real connection pool (sized from `state_management.connection_pool`) with
+  `pool_pre_ping` + `pool_recycle` for AWS RDS resilience.
+- `docker-compose.yaml` now bundles a `postgres:16` service and defaults the
+  Docker deployment's state DB to Postgres (override `STATE_DB_URL` to point at
+  AWS RDS later with no code change). Local/CLI usage without Docker stays SQLite.
+- Alembic migrations are now Postgres-capable (async `env.py`, reusing `asyncpg`).
+
 ### Changed
 
 #### MCP Server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backends; SQLite remains the default when `STATE_DB_URL` is unset. A bare
   `postgresql://` is auto-normalized to the async `asyncpg` driver. Postgres uses
   a real connection pool (sized from `state_management.connection_pool`) with
-  `pool_pre_ping` + `pool_recycle` for AWS RDS resilience.
+  `pool_pre_ping` + `pool_recycle` for AWS RDS resilience. The `asyncpg` driver
+  is an optional extra — install with `pip install qdrant-loader[postgres]`;
+  SQLite-only installs don't pull it.
 - `docker-compose.yaml` now bundles a `postgres:16` service and defaults the
   Docker deployment's state DB to Postgres (override `STATE_DB_URL` to point at
   AWS RDS later with no code change). Local/CLI usage without Docker stays SQLite.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,27 @@ services:
     networks:
       - qdrant-net
   
+  postgres:
+    container_name: qdrant-loader-postgres
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-qdrant_loader}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-qdrant_loader}
+      - POSTGRES_DB=${POSTGRES_DB:-qdrant_loader}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-qdrant_loader} -d ${POSTGRES_DB:-qdrant_loader}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - qdrant-net
+
   qdrant-loader:
     container_name: qdrant-loader
     build:
@@ -28,8 +49,12 @@ services:
       dockerfile: Dockerfile.qdrant-loader
     image: qdrant-loader:latest
     restart: unless-stopped
-    depends_on: 
+    environment:
+      - STATE_DB_URL=${STATE_DB_URL:-postgresql+asyncpg://${POSTGRES_USER:-qdrant_loader}:${POSTGRES_PASSWORD:-qdrant_loader}@postgres:5432/${POSTGRES_DB:-qdrant_loader}}
+    depends_on:
       qdrant:
+        condition: service_healthy
+      postgres:
         condition: service_healthy
     networks:
       - qdrant-net
@@ -55,8 +80,11 @@ services:
       - MCP_LOG_LEVEL=${MCP_LOG_LEVEL:-INFO}
       - MCP_LOG_FILE=${MCP_LOG_FILE:-mcp.log}
       - MCP_DISABLE_CONSOLE_LOGGING=${MCP_DISABLE_CONSOLE_LOGGING:-false}
-    depends_on: 
+      - STATE_DB_URL=${STATE_DB_URL:-postgresql+asyncpg://${POSTGRES_USER:-qdrant_loader}:${POSTGRES_PASSWORD:-qdrant_loader}@postgres:5432/${POSTGRES_DB:-qdrant_loader}}
+    depends_on:
       qdrant:
+        condition: service_healthy
+      postgres:
         condition: service_healthy
     healthcheck:
       test:
@@ -75,6 +103,8 @@ services:
 
 volumes:
   qdrant_data:
+    driver: local
+  postgres_data:
     driver: local
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-qdrant_loader}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-qdrant_loader}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (see .env.example)}
       - POSTGRES_DB=${POSTGRES_DB:-qdrant_loader}
     ports:
       - "5432:5432"
@@ -50,7 +50,7 @@ services:
     image: qdrant-loader:latest
     restart: unless-stopped
     environment:
-      - STATE_DB_URL=${STATE_DB_URL:-postgresql+asyncpg://${POSTGRES_USER:-qdrant_loader}:${POSTGRES_PASSWORD:-qdrant_loader}@postgres:5432/${POSTGRES_DB:-qdrant_loader}}
+      - STATE_DB_URL=${STATE_DB_URL:-postgresql+asyncpg://${POSTGRES_USER:-qdrant_loader}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-qdrant_loader}}
     depends_on:
       qdrant:
         condition: service_healthy
@@ -80,7 +80,7 @@ services:
       - MCP_LOG_LEVEL=${MCP_LOG_LEVEL:-INFO}
       - MCP_LOG_FILE=${MCP_LOG_FILE:-mcp.log}
       - MCP_DISABLE_CONSOLE_LOGGING=${MCP_DISABLE_CONSOLE_LOGGING:-false}
-      - STATE_DB_URL=${STATE_DB_URL:-postgresql+asyncpg://${POSTGRES_USER:-qdrant_loader}:${POSTGRES_PASSWORD:-qdrant_loader}@postgres:5432/${POSTGRES_DB:-qdrant_loader}}
+      - STATE_DB_URL=${STATE_DB_URL:-postgresql+asyncpg://${POSTGRES_USER:-qdrant_loader}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-qdrant_loader}}
     depends_on:
       qdrant:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,9 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (see .env.example)}
       - POSTGRES_DB=${POSTGRES_DB:-qdrant_loader}
     ports:
-      - "5432:5432"
+      # Bind to loopback only: internal services reach Postgres over qdrant-net;
+      # this avoids exposing the DB to the host's network.
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -80,11 +82,8 @@ services:
       - MCP_LOG_LEVEL=${MCP_LOG_LEVEL:-INFO}
       - MCP_LOG_FILE=${MCP_LOG_FILE:-mcp.log}
       - MCP_DISABLE_CONSOLE_LOGGING=${MCP_DISABLE_CONSOLE_LOGGING:-false}
-      - STATE_DB_URL=${STATE_DB_URL:-postgresql+asyncpg://${POSTGRES_USER:-qdrant_loader}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-qdrant_loader}}
     depends_on:
       qdrant:
-        condition: service_healthy
-      postgres:
         condition: service_healthy
     healthcheck:
       test:

--- a/docs/users/configuration/environment-variables.md
+++ b/docs/users/configuration/environment-variables.md
@@ -248,6 +248,25 @@ sources:
       token: "${CONFLUENCE_TOKEN}"
 ```
 
+## 🗄️ State Database Backend (`STATE_DB_URL`)
+
+By default the state database is **SQLite** (`STATE_DB_PATH`, default `./state.db`).
+For an enterprise/multi-writer deployment you can switch to **PostgreSQL** by
+setting `STATE_DB_URL` to a full SQLAlchemy URL:
+
+```bash
+# PostgreSQL (overrides STATE_DB_PATH when set)
+STATE_DB_URL=postgresql+asyncpg://qdrant_loader:secret@db-host:5432/qdrant_loader
+```
+
+- When `STATE_DB_URL` is **unset**, SQLite (`STATE_DB_PATH`) is used — unchanged
+  for community/local use.
+- A bare `postgresql://...` is automatically normalized to `postgresql+asyncpg://`.
+- Pool sizing comes from `state_management.connection_pool` (`size`, `timeout`).
+- For **AWS RDS**, point `STATE_DB_URL` at the RDS endpoint; no other change is
+  needed. The Docker Compose setup runs a local `postgres` service by default —
+  swap it for RDS by overriding `STATE_DB_URL`.
+
 ## 📋 Environment File Templates
 
 ### Basic .env Template

--- a/packages/qdrant-loader/migrations/env.py
+++ b/packages/qdrant-loader/migrations/env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 # pyright: reportGeneralTypeIssues=false, reportAttributeAccessIssue=false
+import asyncio
 import importlib
 import os
 from logging.config import fileConfig
@@ -8,8 +9,10 @@ from pathlib import Path
 from typing import Any
 
 from qdrant_loader.core.state.models import Base
+from qdrant_loader.core.state.utils import _normalize_async_url
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 context: Any = importlib.import_module("alembic.context")
 config = context.config
@@ -30,6 +33,11 @@ def _is_special_sqlite_form(raw_path: str) -> bool:
 
 def _deterministic_sqlalchemy_url() -> str:
     """Resolve DB URL consistently regardless of current working directory."""
+    # STATE_DB_URL (Postgres or any full URL) takes precedence over the SQLite path,
+    # normalized to an async driver (postgresql+asyncpg, sqlite+aiosqlite).
+    state_db_url = os.getenv("STATE_DB_URL")
+    if state_db_url:
+        return _normalize_async_url(state_db_url)
     state_db_path = os.getenv("STATE_DB_PATH")
     if state_db_path:
         if _is_special_sqlite_form(state_db_path):
@@ -82,22 +90,39 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
+def _do_run_migrations(connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def _run_async_migrations() -> None:
+    """Online migrations for async drivers (postgresql+asyncpg, sqlite+aiosqlite)."""
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(_do_run_migrations)
+    await connectable.dispose()
+
+
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode."""
+    """Run migrations in 'online' mode (async path when the driver is async)."""
+    url = config.get_main_option("sqlalchemy.url")
+    if url and make_url(url).get_dialect().is_async:
+        asyncio.run(_run_async_migrations())
+        return
+
+    # Sync path (unchanged) — used by the SQLite sqlite:// form
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
-
     with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-        )
-
-        with context.begin_transaction():
-            context.run_migrations()
+        _do_run_migrations(connection)
 
 
 if context.is_offline_mode():

--- a/packages/qdrant-loader/pyproject.toml
+++ b/packages/qdrant-loader/pyproject.toml
@@ -68,7 +68,6 @@ dependencies = [
     "questionary>=2.0.0",
     "packaging>=21.0",
     "prometheus-client>=0.19.0,<1.0.0",
-    "asyncpg>=0.30",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -96,8 +95,12 @@ server = [
     "uvicorn>=0.24.0 ; sys_platform == 'win32'",
     "PyJWT[crypto]>=2.8.0",
 ]
+postgres = [
+    "asyncpg>=0.30",
+]
 dev = [
     "testcontainers[postgres]>=4.0",
+    "asyncpg>=0.30",
 ]
 
 [project.urls]

--- a/packages/qdrant-loader/pyproject.toml
+++ b/packages/qdrant-loader/pyproject.toml
@@ -96,6 +96,9 @@ server = [
     "uvicorn>=0.24.0 ; sys_platform == 'win32'",
     "PyJWT[crypto]>=2.8.0",
 ]
+dev = [
+    "testcontainers[postgres]>=4.0",
+]
 
 [project.urls]
 Homepage = "https://qdrant-loader.net"

--- a/packages/qdrant-loader/pyproject.toml
+++ b/packages/qdrant-loader/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "questionary>=2.0.0",
     "packaging>=21.0",
     "prometheus-client>=0.19.0,<1.0.0",
+    "asyncpg>=0.30",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
@@ -314,6 +314,13 @@ class Settings(BaseSettings):
         ):
             self.global_config.state_management.database_path = state_db
 
+        # STATE_DB_URL → state_management.database_url
+        # when set, selects the backend by dialect (e.g., postgresql+asyncpg://user:pass@host:5432/dbname)
+        # and overrides database_path. Namespaced to avoid clashing with a generic
+        # DATABASE_URL that might be used for other purposes.
+        state_database_url = os.getenv("STATE_DB_URL")
+        if state_database_url and not self.global_config.state_management.database_url:
+            self.global_config.state_management.database_url = state_database_url
     @property
     def qdrant_url(self) -> str:
         """Get the Qdrant URL from global configuration."""

--- a/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
@@ -321,6 +321,7 @@ class Settings(BaseSettings):
         state_database_url = os.getenv("STATE_DB_URL")
         if state_database_url and not self.global_config.state_management.database_url:
             self.global_config.state_management.database_url = state_database_url
+
     @property
     def qdrant_url(self) -> str:
         """Get the Qdrant URL from global configuration."""

--- a/packages/qdrant-loader/src/qdrant_loader/config/state.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/state.py
@@ -37,6 +37,15 @@ class StateManagementConfig(BaseConfig):
     database_path: str = Field(
         default="./state.db", description="Path to SQLite database file"
     )
+    database_url: str | None = Field(
+        default=None,
+                description=(
+            "Full SQLAlchemy database URL, e.g. "
+            "postgresql+asyncpg://user:pass@host:5432/dbname. When set, "
+            "overrides database_path and selects the backend by dialect. Leave "
+            "unset to use the SQLite database_path (community default)."
+        ),
+    )
     table_prefix: str = Field(
         default="qdrant_loader_", description="Prefix for database tables"
     )
@@ -110,6 +119,15 @@ class StateManagementConfig(BaseConfig):
             pass
 
         # Return the original value to preserve any environment variables
+        return v
+
+    @field_validator("database_url")
+    @classmethod
+    def validate_database_url(cls, v: str | None) -> str | None:
+        if v is not None and "://" not in v:
+            raise ValueError(
+                "database_url must be a a full SQLAlchemy URL (schema://...)"
+            )
         return v
 
     @field_validator("table_prefix")

--- a/packages/qdrant-loader/src/qdrant_loader/config/state.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/state.py
@@ -39,7 +39,8 @@ class StateManagementConfig(BaseConfig):
     )
     database_url: str | None = Field(
         default=None,
-                description=(
+        repr=False,  # may embed credentials; keep out of repr/logs/tracebacks
+        description=(
             "Full SQLAlchemy database URL, e.g. "
             "postgresql+asyncpg://user:pass@host:5432/dbname. When set, "
             "overrides database_path and selects the backend by dialect. Leave "
@@ -126,7 +127,7 @@ class StateManagementConfig(BaseConfig):
     def validate_database_url(cls, v: str | None) -> str | None:
         if v is not None and "://" not in v:
             raise ValueError(
-                "database_url must be a a full SQLAlchemy URL (schema://...)"
+                "database_url must be a full SQLAlchemy URL (scheme://...)"
             )
         return v
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
@@ -5,23 +5,39 @@ from sqlalchemy.pool import StaticPool
 
 from qdrant_loader.config.state import StateManagementConfig
 from qdrant_loader.core.state.models import Base
-from qdrant_loader.core.state.utils import generate_sqlite_aiosqlite_url as _gen_url
+from qdrant_loader.core.state.utils import generate_database_url
 
 
 def initialize_engine_and_session(
     config: StateManagementConfig,
 ) -> tuple[AsyncEngine, async_sessionmaker]:
-    """Create the async engine and session factory for state DB.
+    """Create the async engine and session factory for the state DB.
 
-    Uses the same engine configuration as StateManager did previously.
+    SQLite uses a StaticPool with check_same_thread disabled (single in-process
+    file/memory DB). PostgreSQL uses a real connection pool sized from
+    config.connection_pool, with pool_pre_ping so RDS idle-connection drops are
+    detected and recycled rather than surfacing as errors.
     """
-    database_url = _gen_url(config.database_path)
-    engine = create_async_engine(
-        database_url,
-        poolclass=StaticPool,
-        connect_args={"check_same_thread": False},
-        echo=False,
-    )
+    database_url = generate_database_url(config)
+
+    if database_url.startswith("sqlite"):
+        engine = create_async_engine(
+            database_url,
+            poolclass=StaticPool,
+            connect_args={"check_same_thread": False},
+            echo=False,
+        )
+    else:
+        pool = config.connection_pool or {}
+        engine = create_async_engine(
+            database_url,
+            pool_size=pool.get("size", 5),
+            pool_timeout=pool.get("timeout", 30),
+            pool_pre_ping=True,
+            pool_recycle=1800,  # recycle connections every 30 min (RDS-friendly)
+            echo=False,
+        )
+
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     return engine, session_factory
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
@@ -28,6 +28,16 @@ def initialize_engine_and_session(
             echo=False,
         )
     else:
+        # asyncpg is an optional dependency (the `postgres` extra), imported
+        # lazily only on the Postgres path so SQLite installs don't need it.
+        try:
+            import asyncpg  # noqa: F401
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "PostgreSQL state backend requires the 'postgres' extra: "
+                "install with `pip install qdrant-loader[postgres]`."
+            ) from exc
+
         pool = config.connection_pool or {}
         engine = create_async_engine(
             database_url,

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
@@ -38,11 +38,11 @@ def initialize_engine_and_session(
                 "install with `pip install qdrant-loader[postgres]`."
             ) from exc
 
-        pool = config.connection_pool or {}
+        pool_cfg = config.connection_pool or {}
         engine = create_async_engine(
             database_url,
-            pool_size=pool.get("size", 5),
-            pool_timeout=pool.get("timeout", 30),
+            pool_size=pool_cfg.get("size", 5),
+            pool_timeout=pool_cfg.get("timeout", 30),
             pool_pre_ping=True,
             pool_recycle=1800,  # recycle connections every 30 min (RDS-friendly)
             echo=False,

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/utils.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/utils.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qdrant_loader.config.state import StateManagementConfig
 
 from sqlalchemy import select
 
@@ -51,6 +55,34 @@ def generate_sqlite_aiosqlite_url(database_path: str) -> str:
     db_url_path = db_path.as_posix()
     # Absolute and relative are handled similarly here (three slashes)
     return f"sqlite+aiosqlite:///{db_url_path}"
+
+
+def _normalize_async_url(url: str) -> str:
+    """Ensure a database URL uses an async driver SQLAlchemy can use.
+
+    - postgres:// / postgresql://  -> postgresql+asyncpg://  (so a standard RDS/psql
+      URL works unchanged)
+    - sqlite://                    -> sqlite+aiosqlite://
+    - anything already carrying a driver (e.g. postgresql+asyncpg://) passes through.
+    """
+    if url.startswith(("postgresql://", "postgres://")):
+        return "postgresql+asyncpg://" + url.split("://", 1)[1]
+    if url.startswith("sqlite://") and "+aiosqlite" not in url:
+        return url.replace("sqlite://", "sqlite+aiosqlite://", 1)
+    return url
+
+
+def generate_database_url(config: StateManagementConfig) -> str:
+    """Build the async SQLAlchemy URL for the configured state backend.
+
+    Precedence: ``config.database_url`` (Postgres or any full SQLAlchemy URL) wins
+    and selects the backend by dialect; otherwise fall back to the SQLite
+    ``database_path`` (community default).
+    """
+    database_url = getattr(config, "database_url", None)
+    if database_url:
+        return _normalize_async_url(database_url)
+    return generate_sqlite_aiosqlite_url(config.database_path)
 
 
 def build_ingestion_history_select(

--- a/packages/qdrant-loader/tests/integration/core/state/conftest.py
+++ b/packages/qdrant-loader/tests/integration/core/state/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for state-layer integration tests (SQLite + Postgres)."""
+
+import os
+
+import pytest
+from qdrant_loader.core.state.utils import _normalize_async_url
+
+
+@pytest.fixture(scope="session")
+def postgres_url():
+    """A live Postgres async URL, or skip if none is available.
+
+    Precedence: TEST_POSTGRES_URL env (e.g. the docker-compose Postgres or a CI
+    service), else a throwaway testcontainers Postgres, else skip the param.
+    """
+    env_url = os.getenv("TEST_POSTGRES_URL")
+    if env_url:
+        yield _normalize_async_url(env_url)
+        return
+
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        pytest.skip("testcontainers not installed; set TEST_POSTGRES_URL to run PG tests")
+        return
+
+    try:
+        container = PostgresContainer("postgres:16-alpine", driver="asyncpg")
+        container.start()
+    except Exception as exc:  # Docker not running / image pull failed
+        pytest.skip(f"Postgres unavailable (Docker?): {exc}")
+        return
+
+    try:
+        yield container.get_connection_url()  # postgresql+asyncpg://...
+    finally:
+        container.stop()

--- a/packages/qdrant-loader/tests/integration/core/state/test_state_management.py
+++ b/packages/qdrant-loader/tests/integration/core/state/test_state_management.py
@@ -17,7 +17,7 @@ def mock_config(request):
     'postgres' param — the 'sqlite' param always runs.
     """
     if request.param == "sqlite":
-        return StateManagementConfig(database_path="sqlite:///:memory:")
+        return StateManagementConfig(database_url="sqlite+aiosqlite:///:memory:")
     postgres_url = request.getfixturevalue("postgres_url")
     return StateManagementConfig(database_url=postgres_url)
 

--- a/packages/qdrant-loader/tests/integration/core/state/test_state_management.py
+++ b/packages/qdrant-loader/tests/integration/core/state/test_state_management.py
@@ -2,8 +2,6 @@
 Tests for state management extensions - file conversion and attachment metadata tracking.
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 import pytest_asyncio
 from qdrant_loader.config.state import StateManagementConfig
@@ -11,13 +9,17 @@ from qdrant_loader.core.document import Document
 from qdrant_loader.core.state.state_manager import StateManager
 
 
-@pytest.fixture
-def mock_config():
-    """Create mock state management configuration."""
-    config = MagicMock(spec=StateManagementConfig)
-    config.database_path = "sqlite:///:memory:"
-    config.connection_pool = {"size": 5, "timeout": 30}
-    return config
+@pytest.fixture(params=["sqlite", "postgres"])
+def mock_config(request):
+    """State config parametrized over both backends.
+
+    postgres_url is resolved lazily so its skip-when-unavailable only affects the
+    'postgres' param — the 'sqlite' param always runs.
+    """
+    if request.param == "sqlite":
+        return StateManagementConfig(database_path="sqlite:///:memory:")
+    postgres_url = request.getfixturevalue("postgres_url")
+    return StateManagementConfig(database_url=postgres_url)
 
 
 @pytest_asyncio.fixture

--- a/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_migrations_smoke.py
@@ -21,6 +21,9 @@ def test_jobs_migration_smoke_upgrade_and_downgrade(
     """Ensure WS-4.1 migration creates and removes jobs schema artifacts."""
     # Keep this test isolated from developer shell env overrides.
     monkeypatch.delenv("STATE_DB_PATH", raising=False)
+    # STATE_DB_URL takes precedence in env.py; clear it so downgrade("base")
+    # can never run against a developer/CI Postgres instead of the temp SQLite DB.
+    monkeypatch.delenv("STATE_DB_URL", raising=False)
 
     package_root = Path(__file__).resolve().parents[4]
     db_path = tmp_path / "state_ws41.db"

--- a/uv.lock
+++ b/uv.lock
@@ -1045,6 +1045,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "urllib3", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4156,6 +4170,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "testcontainers", marker = "python_full_version < '3.13'" },
+]
 server = [
     { name = "fastapi", marker = "python_full_version < '3.13'" },
     { name = "pyjwt", extra = ["crypto"], marker = "python_full_version < '3.13'" },
@@ -4205,6 +4222,7 @@ requires-dist = [
     { name = "spacy", specifier = ">=3.7.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "structlog", specifier = ">=23.0.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "tomli", specifier = ">=2.0.1" },
     { name = "tomli-w", specifier = ">=1.0.0" },
@@ -4214,7 +4232,7 @@ requires-dist = [
     { name = "uvicorn", marker = "sys_platform == 'win32' and extra == 'server'", specifier = ">=0.24.0" },
     { name = "uvicorn", extras = ["standard"], marker = "sys_platform != 'win32' and extra == 'server'", specifier = ">=0.24.0" },
 ]
-provides-extras = ["server"]
+provides-extras = ["server", "dev"]
 
 [[package]]
 name = "qdrant-loader-core"
@@ -5179,6 +5197,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker", marker = "python_full_version < '3.13'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "urllib3", marker = "python_full_version < '3.13'" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -200,6 +200,46 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "atlassian-python-api"
 version = "4.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -4072,6 +4112,7 @@ dependencies = [
     { name = "aiosqlite", marker = "python_full_version < '3.13'" },
     { name = "alembic", marker = "python_full_version < '3.13'" },
     { name = "appdirs", marker = "python_full_version < '3.13'" },
+    { name = "asyncpg", marker = "python_full_version < '3.13'" },
     { name = "atlassian-python-api", marker = "python_full_version < '3.13'" },
     { name = "beautifulsoup4", marker = "python_full_version < '3.13'" },
     { name = "chardet", marker = "python_full_version < '3.13'" },
@@ -4127,6 +4168,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.12.0" },
     { name = "appdirs", specifier = ">=1.4.4" },
+    { name = "asyncpg", specifier = ">=0.30" },
     { name = "atlassian-python-api", specifier = ">=3.41.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "chardet", specifier = ">=5.2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -4126,7 +4126,6 @@ dependencies = [
     { name = "aiosqlite", marker = "python_full_version < '3.13'" },
     { name = "alembic", marker = "python_full_version < '3.13'" },
     { name = "appdirs", marker = "python_full_version < '3.13'" },
-    { name = "asyncpg", marker = "python_full_version < '3.13'" },
     { name = "atlassian-python-api", marker = "python_full_version < '3.13'" },
     { name = "beautifulsoup4", marker = "python_full_version < '3.13'" },
     { name = "chardet", marker = "python_full_version < '3.13'" },
@@ -4171,7 +4170,11 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "asyncpg", marker = "python_full_version < '3.13'" },
     { name = "testcontainers", marker = "python_full_version < '3.13'" },
+]
+postgres = [
+    { name = "asyncpg", marker = "python_full_version < '3.13'" },
 ]
 server = [
     { name = "fastapi", marker = "python_full_version < '3.13'" },
@@ -4185,7 +4188,8 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.12.0" },
     { name = "appdirs", specifier = ">=1.4.4" },
-    { name = "asyncpg", specifier = ">=0.30" },
+    { name = "asyncpg", marker = "extra == 'dev'", specifier = ">=0.30" },
+    { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.30" },
     { name = "atlassian-python-api", specifier = ">=3.41.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "chardet", specifier = ">=5.2.0" },
@@ -4232,7 +4236,7 @@ requires-dist = [
     { name = "uvicorn", marker = "sys_platform == 'win32' and extra == 'server'", specifier = ">=0.24.0" },
     { name = "uvicorn", extras = ["standard"], marker = "sys_platform != 'win32' and extra == 'server'", specifier = ">=0.24.0" },
 ]
-provides-extras = ["server", "dev"]
+provides-extras = ["server", "postgres", "dev"]
 
 [[package]]
 name = "qdrant-loader-core"


### PR DESCRIPTION
# Pull Request

## Summary

Added PostgreSQL as an optional, enterprise-grade backend for QDrant loader's state database

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [x] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Affected pipeline stages: state DB config/loading, SQLAlchemy engine/session setup, Alembic migrations, and Docker startup wiring for the qdrant-loader service.

Config changes: `StateManagementConfig` adds an optional `database_url` field. This is additive, but when set it overrides `database_path` and switches backend by SQLAlchemy dialect. `STATE_DB_URL` is now auto-applied from env when unset.

Tests: integration coverage was expanded to exercise both SQLite (`sqlite:///:memory:` via async URL handling) and PostgreSQL paths, with a fixture that can use `TEST_POSTGRES_URL` or a `testcontainers`-spawned Postgres instance.

Security/resource-safety: Postgres support introduces async driver and container dependencies plus a persistent DB volume in Docker. Engine pooling now uses `pool_pre_ping`/`pool_recycle` for better connection safety. One caveat from review: `asyncpg` is currently a hard dependency, so Postgres is not yet fully optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->