### PR TITLE
fix: prevent blocked service for interval duration and  duplicate job…

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -127,21 +127,18 @@ class SQLiteJobQueue:
             (Job.status == self.RUNNING) & (Job.visibility_deadline <= now),
         )
 
+        candidate_job_id_subquery = (
+            select(Job.id)
+            .where(claimable_filter)
+            .order_by(Job.enqueued_at.asc(), Job.id.asc())
+            .limit(1)
+            .scalar_subquery()
+        )
+
         async with self._session_factory() as session:
-            candidate_job_id = await session.scalar(
-                select(Job.id)
-                .where(claimable_filter)
-                .order_by(Job.enqueued_at.asc(), Job.id.asc())
-                .limit(1)
-            )
-
-            if candidate_job_id is None:
-                await session.commit()
-                return None
-
             result = await session.execute(
                 update(Job)
-                .where(Job.id == candidate_job_id, claimable_filter)
+                .where(Job.id == candidate_job_id_subquery, claimable_filter)
                 .values(
                     status=self.RUNNING,
                     started_at=now,
@@ -150,13 +147,20 @@ class SQLiteJobQueue:
                     attempts=Job.attempts + 1,
                     last_error=None,
                 )
+                .returning(Job.id)
             )
-            claimed = result.rowcount > 0
-            if not claimed:
+
+            # SQLite requires RETURNING cursors to be finalized before commit.
+            try:
+                claimed_job_id = result.scalar_one_or_none()
+            finally:
+                result.close()
+
+            if claimed_job_id is None:
                 await session.commit()
                 return None
 
-            claimed_job = await session.get(Job, candidate_job_id)
+            claimed_job = await session.get(Job, claimed_job_id)
             await session.commit()
             return claimed_job
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/scheduler.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/scheduler.py
@@ -38,7 +38,9 @@ class IncrementalPullScheduler:
             return
 
         interval = float(self._schedule.interval_seconds)
-        next_run_at = self._monotonic() + interval
+        # First scheduling pass should happen immediately on service startup.
+        # Subsequent passes run at the configured interval.
+        next_run_at = self._monotonic()
 
         logger.info(
             "scheduler.incremental_pull.started",

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -80,6 +80,29 @@ async def test_claim_next_no_duplicates_under_race(sqlite_job_queue: SQLiteJobQu
 
 
 @pytest.mark.asyncio
+async def test_claim_next_no_duplicate_claims_across_queue_instances(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    # Simulate multiple independent workers/processes sharing the same DB.
+    queues = [sqlite_job_queue] + [
+        SQLiteJobQueue(sqlite_job_queue._session_factory) for _ in range(7)
+    ]
+
+    for i in range(50):
+        job = await sqlite_job_queue.enqueue(
+            "INCREMENTAL_PULL", {"source": f"docs-{i}"}
+        )
+        claims = await asyncio.gather(
+            *(queue.claim_next(lease_seconds=30) for queue in queues)
+        )
+
+        claimed = [claim for claim in claims if claim is not None]
+        assert len(claimed) == 1
+        assert claimed[0].id == job.id
+        assert claimed[0].attempts == 1
+
+
+@pytest.mark.asyncio
 async def test_mark_failed_sets_error(sqlite_job_queue: SQLiteJobQueue):
     job = await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"source": "docs"})
 

--- a/packages/qdrant-loader/tests/unit/core/worker/test_scheduler.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 
@@ -139,3 +140,21 @@ async def test_scheduler_keeps_canonical_identity_over_payload_defaults():
     }
     assert first_payload["force"] is False
     assert first_payload["custom"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_scheduler_run_ticks_immediately_on_startup():
+    queue = _FakeQueue()
+    schedule = IncrementalPullScheduleConfig(enabled=True, interval=300)
+    scheduler = IncrementalPullScheduler(queue, _projects_config(), schedule)
+    stop_event = asyncio.Event()
+
+    async def _stop_soon():
+        await asyncio.sleep(0.05)
+        stop_event.set()
+
+    await asyncio.gather(scheduler.run(stop_event), _stop_soon())
+
+    # Startup tick should enqueue once immediately (without waiting 300s).
+    assert len(queue.enqueued) == 2
+    assert {payload["source"] for _, payload in queue.enqueued} == {"repo-a", "jira-a"}


### PR DESCRIPTION
… claims in concurrent queue worker pool

# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Affected stage: the qdrant-loader worker pipeline, specifically the SQLite job queue claim path and the incremental pull scheduler loop.

Config schema: no config/schema changes.

Tests: added coverage for concurrent job claiming across queue instances and for immediate scheduler startup ticking.

Security/resource-safety: no new security concerns noted; queue claiming now uses an atomic SQLite UPDATE/RETURNING flow to reduce duplicate claims, and the scheduler still respects the stop event/timeout loop without adding unbounded work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->