### PR TITLE
fix: parallelize embedding and upsert batch processing

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/embedding_worker.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/embedding_worker.py
@@ -30,14 +30,21 @@ class EmbeddingWorker(BaseWorker):
         self.embedding_service = embedding_service
         self.shutdown_event = shutdown_event or asyncio.Event()
 
-    async def process(self, chunks: list[Any]) -> list[tuple[Any, list[float]]]:
+    async def process(
+        self, chunks: list[Any]
+    ) -> list[tuple[Any, list[float] | None]]:
         """Process a batch of chunks into embeddings.
+
+        The result is aligned 1:1 with ``chunks``: a chunk whose embedding
+        came back empty (invalid content was skipped by ``get_embeddings``)
+        is still included, paired with ``None``, so callers can account for
+        every chunk's fate instead of the failure silently disappearing.
 
         Args:
             chunks: List of chunks to embed
 
         Returns:
-            List of (chunk, embedding) tuples
+            List of (chunk, embedding) tuples; embedding is None on failure.
         """
         if not chunks:
             return []
@@ -65,14 +72,11 @@ class EmbeddingWorker(BaseWorker):
                     logger.debug("EmbeddingWorker skipping result due to shutdown")
                     return []
 
-                # Filter out chunks whose embedding is empty (invalid content was
-                # skipped in get_embeddings and replaced with [] placeholder).
-                result = [
-                    (chunk, emb)
+                result: list[tuple[Any, list[float] | None]] = [
+                    (chunk, emb if emb else None)
                     for chunk, emb in zip(chunks, embeddings, strict=False)
-                    if emb
                 ]
-                skipped = len(chunks) - len(result)
+                skipped = sum(1 for _, emb in result if emb is None)
                 if skipped:
                     logger.warning(
                         f"Skipped {skipped} chunk(s) with empty embeddings, they will not be upserted"
@@ -94,22 +98,89 @@ class EmbeddingWorker(BaseWorker):
             logger.error(f"EmbeddingWorker error processing batch: {e}")
             raise
 
+    async def _process_batch_guarded(
+        self, batch: list[Any], batch_index: int
+    ) -> list[tuple[Any, list[float] | None]]:
+        """Run process() for a batch under the shared concurrency semaphore.
+
+        Bounds how many embedding batches run concurrently to ``max_workers``
+        so that ``max_embed_workers`` actually governs concurrency, instead of
+        every batch running to completion before the next one starts.
+
+        If the whole batch raises (timeout, service error), every chunk in it
+        is still returned, paired with ``None``, instead of being dropped —
+        otherwise those chunks vanish from accounting entirely and their
+        parent documents can end up looking untouched rather than failed.
+        """
+        async with self.semaphore:
+            try:
+                logger.debug(
+                    f"🔄 Processing embedding batch {batch_index} "
+                    f"with {len(batch)} chunks..."
+                )
+                return await self.process(batch)
+            except Exception as e:
+                logger.error(f"EmbeddingWorker batch processing failed: {e}")
+                for chunk in batch:
+                    logger.error(f"Embedding failed for chunk {chunk.id}: {e}")
+                return [(chunk, None) for chunk in batch]
+
     async def process_chunks(
         self, chunks: AsyncIterator[Any]
-    ) -> AsyncIterator[tuple[Any, list[float]]]:
+    ) -> AsyncIterator[tuple[Any, list[float] | None]]:
         """Process chunks into embeddings.
+
+        Batches are dispatched concurrently, but the number of batches
+        dispatched-and-not-yet-yielded is capped at ``max_workers``: once that
+        many are in flight, the oldest is awaited before a new one is created.
+        This bounds memory use (not just execution concurrency) when chunks
+        arrive far faster than embedding calls complete, while still yielding
+        results in submission order. Every dispatched chunk is yielded exactly
+        once, paired with ``None`` if it failed to embed, so downstream stages
+        can account for it instead of it silently vanishing.
 
         Args:
             chunks: AsyncIterator of chunks to process
 
         Yields:
-            (chunk, embedding) tuples
+            (chunk, embedding) tuples; embedding is None on failure.
         """
         logger.debug("EmbeddingWorker started")
-        logger.info("🔄 Starting embedding generation...")
+        logger.info(
+            f"🔄 Starting embedding generation (max_workers={self.max_workers})..."
+        )
         batch_size = self.embedding_service.batch_size
-        batch = []
+        batch: list[Any] = []
+        pending: list[asyncio.Task] = []
+        batch_index = 0
         total_processed = 0
+        total_failed = 0
+
+        async def drain_oldest() -> list[tuple[Any, list[float] | None]]:
+            nonlocal total_processed, total_failed
+            results = await pending.pop(0)
+            if not results:
+                return []
+
+            succeeded = sum(1 for _, embedding in results if embedding is not None)
+            failed = len(results) - succeeded
+            total_processed += succeeded
+            total_failed += failed
+            logger.info(
+                f"🔗 Generated embeddings: {succeeded} items in batch"
+                + (f" ({failed} failed)" if failed else "")
+                + f", {total_processed} total processed"
+            )
+            return results
+
+        def dispatch(batch_to_dispatch: list[Any]) -> None:
+            nonlocal batch_index
+            batch_index += 1
+            pending.append(
+                asyncio.create_task(
+                    self._process_batch_guarded(batch_to_dispatch, batch_index)
+                )
+            )
 
         try:
             async for chunk in chunks:
@@ -119,51 +190,37 @@ class EmbeddingWorker(BaseWorker):
 
                 batch.append(chunk)
 
-                # Process batch when it reaches the desired size
+                # Dispatch batch when it reaches the desired size
                 if len(batch) >= batch_size:
-                    try:
-                        logger.debug(
-                            f"🔄 Processing embedding batch of {len(batch)} chunks..."
-                        )
-                        results = await self.process(batch)
-                        total_processed += len(results)
-                        logger.info(
-                            f"🔗 Generated embeddings: {len(results)} items in batch, {total_processed} total processed"
-                        )
-
-                        for result in results:
-                            yield result
-                    except Exception as e:
-                        logger.error(f"EmbeddingWorker batch processing failed: {e}")
-                        # Mark chunks as failed but continue processing
-                        for chunk in batch:
-                            logger.error(f"Embedding failed for chunk {chunk.id}: {e}")
-
+                    batch_to_submit = batch
                     batch = []
 
-            # Process any remaining chunks in the final batch
+                    # Keep at most max_workers batches in flight so memory
+                    # use stays bounded, not just execution concurrency.
+                    if len(pending) >= self.max_workers:
+                        for result in await drain_oldest():
+                            yield result
+
+                    dispatch(batch_to_submit)
+
+            # Dispatch any remaining chunks in the final batch
             if batch and not self.shutdown_event.is_set():
-                try:
-                    logger.debug(
-                        f"🔄 Processing final embedding batch of {len(batch)} chunks..."
-                    )
-                    results = await self.process(batch)
-                    total_processed += len(results)
-                    logger.info(
-                        f"🔗 Generated embeddings: {len(results)} items in final batch, {total_processed} total processed"
-                    )
+                dispatch(batch)
 
-                    for result in results:
-                        yield result
-                except Exception as e:
-                    logger.error(f"EmbeddingWorker final batch processing failed: {e}")
-                    for chunk in batch:
-                        logger.error(f"Embedding failed for chunk {chunk.id}: {e}")
+            while pending:
+                for result in await drain_oldest():
+                    yield result
 
-            logger.info(f"✅ Embedding completed: {total_processed} chunks processed")
+            logger.info(
+                f"✅ Embedding completed: {total_processed} chunks processed, "
+                f"{total_failed} failed"
+            )
 
         except asyncio.CancelledError:
             logger.debug("EmbeddingWorker cancelled")
+            for task in pending:
+                if not task.done():
+                    task.cancel()
             raise
         finally:
             logger.debug("EmbeddingWorker exited")

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
@@ -51,11 +51,16 @@ class UpsertWorker(BaseWorker):
         same_batch_duplicates: set[str],
         cross_batch_duplicates: set[str],
         new_chunk_ids: set[str],
-        successful_doc_ids: set[str],
         result: PipelineResult,
         errors: list[str],
     ) -> None:
-        """Handle duplicate chunk IDs and update result/error bookkeeping."""
+        """Log/record duplicate chunk IDs and their error-count impact.
+
+        Whether a duplicate-affected document ends up in
+        ``successfully_processed_documents`` or ``failed_document_ids`` is
+        decided by the per-document completion tracking in
+        ``process_embedded_chunks`` (via ``note_chunk_outcome``), not here.
+        """
         if not duplicate_chunk_ids:
             return
 
@@ -65,9 +70,6 @@ class UpsertWorker(BaseWorker):
                 parent_doc = chunk.metadata.get("parent_document")
                 if parent_doc:
                     duplicate_doc_ids.add(parent_doc.id)
-
-        successful_doc_ids -= duplicate_doc_ids
-        result.successfully_processed_documents -= duplicate_doc_ids
 
         same_batch_duplicate_occurrences = sum(
             count - 1 for count in batch_chunk_id_counts.values() if count > 1
@@ -174,10 +176,134 @@ class UpsertWorker(BaseWorker):
 
         return success_count, error_count, successful_doc_ids, errors
 
+    def _reserve_chunk_ids(
+        self, batch: list[tuple[Any, list[float]]], seen_chunk_ids: set[str]
+    ) -> dict[str, Any]:
+        """Compute duplicate-chunk-id bookkeeping for a batch and reserve its new IDs.
+
+        This runs synchronously (no ``await``) at batch-formation time, before
+        the batch is handed off for concurrent upserting. That ordering is
+        what keeps duplicate detection correct once batches are processed
+        concurrently: reservations happen strictly in submission order, so two
+        in-flight batches can never both believe the same chunk id is new.
+        """
+        batch_chunk_id_list = [str(chunk.id) for chunk, _ in batch]
+        batch_chunk_ids = set(batch_chunk_id_list)
+        batch_chunk_id_counts = Counter(batch_chunk_id_list)
+        same_batch_duplicates = {
+            chunk_id for chunk_id, count in batch_chunk_id_counts.items() if count > 1
+        }
+        cross_batch_duplicates = batch_chunk_ids & seen_chunk_ids
+        duplicate_chunk_ids = cross_batch_duplicates | same_batch_duplicates
+        new_chunk_ids = batch_chunk_ids - seen_chunk_ids - same_batch_duplicates
+
+        # Reserve now so the next batch's cross-batch check sees it, regardless
+        # of how long this batch's upsert takes to actually complete.
+        seen_chunk_ids.update(new_chunk_ids)
+
+        return {
+            "batch_chunk_id_counts": batch_chunk_id_counts,
+            "same_batch_duplicates": same_batch_duplicates,
+            "cross_batch_duplicates": cross_batch_duplicates,
+            "duplicate_chunk_ids": duplicate_chunk_ids,
+            "new_chunk_ids": new_chunk_ids,
+        }
+
+    @staticmethod
+    def _note_chunk_outcome(
+        chunk: Any,
+        failed: bool,
+        result: PipelineResult,
+        doc_totals: dict[str, int],
+        doc_seen: dict[str, int],
+        doc_failed: dict[str, bool],
+    ) -> None:
+        """Record one chunk's fate and finalize its document once complete.
+
+        A document is only added to ``successfully_processed_documents`` once
+        *every* chunk chunking produced for it has been accounted for (via
+        ``parent_document_total_chunks``) with none failed — a document isn't
+        "done" just because the first batch containing one of its chunks
+        happened to succeed. If any chunk failed (embedding failure, upsert
+        failure, or duplicate-id collision), the document lands in
+        ``failed_document_ids`` instead so a later incremental run retries it.
+        """
+        parent_doc = chunk.metadata.get("parent_document")
+        if not parent_doc:
+            return
+
+        doc_id = parent_doc.id
+        total = chunk.metadata.get("parent_document_total_chunks") or 1
+        doc_totals.setdefault(doc_id, total)
+
+        seen = doc_seen.get(doc_id, 0) + 1
+        doc_seen[doc_id] = seen
+        if failed:
+            doc_failed[doc_id] = True
+
+        if seen >= doc_totals[doc_id]:
+            if doc_failed.get(doc_id):
+                result.failed_document_ids.add(doc_id)
+                result.successfully_processed_documents.discard(doc_id)
+            else:
+                result.successfully_processed_documents.add(doc_id)
+
+    def _merge_batch_outcome(
+        self,
+        batch: list[tuple[Any, list[float]]],
+        dedup: dict[str, Any],
+        outcome: tuple[int, int, set[str], list[str]],
+        result: PipelineResult,
+        seen_chunk_ids: set[str],
+        doc_totals: dict[str, int],
+        doc_seen: dict[str, int],
+        doc_failed: dict[str, bool],
+    ) -> None:
+        """Fold one batch's process() outcome into the running PipelineResult."""
+        success_count, error_count, successful_doc_ids, errors = outcome
+
+        if success_count > 0:
+            if dedup["duplicate_chunk_ids"]:
+                self._handle_duplicate_chunk_ids(
+                    batch=batch,
+                    batch_chunk_id_counts=dedup["batch_chunk_id_counts"],
+                    duplicate_chunk_ids=dedup["duplicate_chunk_ids"],
+                    same_batch_duplicates=dedup["same_batch_duplicates"],
+                    cross_batch_duplicates=dedup["cross_batch_duplicates"],
+                    new_chunk_ids=dedup["new_chunk_ids"],
+                    result=result,
+                    errors=errors,
+                )
+            result.success_count += len(dedup["new_chunk_ids"])
+        else:
+            # Nothing was actually written; release the reservation so a
+            # later batch with the same id isn't wrongly treated as a dup.
+            seen_chunk_ids.difference_update(dedup["new_chunk_ids"])
+
+        result.error_count += error_count
+        result.errors.extend(errors)
+
+        for chunk, _ in batch:
+            chunk_failed = success_count == 0 or str(chunk.id) in dedup[
+                "duplicate_chunk_ids"
+            ]
+            self._note_chunk_outcome(
+                chunk, chunk_failed, result, doc_totals, doc_seen, doc_failed
+            )
+
     async def process_embedded_chunks(
-        self, embedded_chunks: AsyncIterator[tuple[Any, list[float]]]
+        self, embedded_chunks: AsyncIterator[tuple[Any, list[float] | None]]
     ) -> PipelineResult:
         """Upsert embedded chunks to Qdrant.
+
+        The number of batches dispatched-and-not-yet-merged is capped at
+        ``max_workers``: once that many are in flight, the oldest is awaited
+        before a new one is created. This bounds memory use (not just upsert
+        concurrency) when embeddings arrive far faster than Qdrant upserts
+        complete, while still merging outcomes in submission order. A chunk
+        arriving with ``embedding is None`` (embedding failed upstream) is
+        never sent to Qdrant, but is still accounted for so its parent
+        document doesn't get marked successful with pieces missing.
 
         Args:
             embedded_chunks: AsyncIterator of (chunk, embedding) tuples
@@ -186,105 +312,78 @@ class UpsertWorker(BaseWorker):
             PipelineResult with processing statistics
         """
         logger.debug("UpsertWorker started")
+        logger.info(f"🔄 Starting upsert processing (max_workers={self.max_workers})...")
         result = PipelineResult()
-        batch = []
         seen_chunk_ids: set[str] = set()
+        doc_totals: dict[str, int] = {}
+        doc_seen: dict[str, int] = {}
+        doc_failed: dict[str, bool] = {}
+        batch: list[tuple[Any, list[float]]] = []
+        pending: list[
+            tuple[asyncio.Task, list[tuple[Any, list[float]]], dict[str, Any]]
+        ] = []
+
+        async def drain_oldest() -> None:
+            task, task_batch, dedup = pending.pop(0)
+            outcome = await task
+            self._merge_batch_outcome(
+                task_batch,
+                dedup,
+                outcome,
+                result,
+                seen_chunk_ids,
+                doc_totals,
+                doc_seen,
+                doc_failed,
+            )
+
+        def dispatch(batch_to_dispatch: list[tuple[Any, list[float]]]) -> None:
+            dedup = self._reserve_chunk_ids(batch_to_dispatch, seen_chunk_ids)
+            task = asyncio.create_task(self.process_with_semaphore(batch_to_dispatch))
+            pending.append((task, batch_to_dispatch, dedup))
 
         try:
-            async for chunk_embedding in embedded_chunks:
+            async for chunk, embedding in embedded_chunks:
                 if self.shutdown_event.is_set():
                     logger.debug("UpsertWorker exiting due to shutdown")
                     break
 
-                batch.append(chunk_embedding)
-
-                # Process batch when it reaches the desired size
-                if len(batch) >= self.batch_size:
-                    batch_chunk_id_list = [str(chunk.id) for chunk, _ in batch]
-                    batch_chunk_ids = set(batch_chunk_id_list)
-                    batch_chunk_id_counts = Counter(batch_chunk_id_list)
-                    success_count, error_count, successful_doc_ids, errors = (
-                        await self.process(batch)
+                if embedding is None:
+                    result.error_count += 1
+                    result.errors.append(
+                        f"Embedding failed for chunk {chunk.id}, skipped upsert"
                     )
+                    self._note_chunk_outcome(
+                        chunk, True, result, doc_totals, doc_seen, doc_failed
+                    )
+                    continue
 
-                    if success_count > 0:
-                        same_batch_duplicates = {
-                            chunk_id
-                            for chunk_id, count in batch_chunk_id_counts.items()
-                            if count > 1
-                        }
-                        cross_batch_duplicates = batch_chunk_ids & seen_chunk_ids
-                        duplicate_chunk_ids = (
-                            cross_batch_duplicates | same_batch_duplicates
-                        )
-                        new_chunk_ids = (
-                            batch_chunk_ids - seen_chunk_ids - same_batch_duplicates
-                        )
+                batch.append((chunk, embedding))
 
-                        self._handle_duplicate_chunk_ids(
-                            batch=batch,
-                            batch_chunk_id_counts=batch_chunk_id_counts,
-                            duplicate_chunk_ids=duplicate_chunk_ids,
-                            same_batch_duplicates=same_batch_duplicates,
-                            cross_batch_duplicates=cross_batch_duplicates,
-                            new_chunk_ids=new_chunk_ids,
-                            successful_doc_ids=successful_doc_ids,
-                            result=result,
-                            errors=errors,
-                        )
-
-                        # Only update seen_chunk_ids with non-duplicate IDs
-                        seen_chunk_ids.update(new_chunk_ids)
-                        result.success_count += len(new_chunk_ids)
-
-                    result.error_count += error_count
-                    result.successfully_processed_documents.update(successful_doc_ids)
-                    result.errors.extend(errors)
+                # Dispatch batch when it reaches the desired size
+                if len(batch) >= self.batch_size:
+                    batch_to_submit = batch
                     batch = []
 
-            # Process any remaining chunks in the final batch
+                    # Keep at most max_workers batches in flight so memory
+                    # use stays bounded, not just upsert concurrency.
+                    if len(pending) >= self.max_workers:
+                        await drain_oldest()
+
+                    dispatch(batch_to_submit)
+
+            # Dispatch any remaining chunks in the final batch
             if batch and not self.shutdown_event.is_set():
-                batch_chunk_id_list = [str(chunk.id) for chunk, _ in batch]
-                batch_chunk_ids = set(batch_chunk_id_list)
-                batch_chunk_id_counts = Counter(batch_chunk_id_list)
-                success_count, error_count, successful_doc_ids, errors = (
-                    await self.process(batch)
-                )
+                dispatch(batch)
 
-                if success_count > 0:
-                    same_batch_duplicates = {
-                        chunk_id
-                        for chunk_id, count in batch_chunk_id_counts.items()
-                        if count > 1
-                    }
-                    cross_batch_duplicates = batch_chunk_ids & seen_chunk_ids
-                    duplicate_chunk_ids = cross_batch_duplicates | same_batch_duplicates
-                    new_chunk_ids = (
-                        batch_chunk_ids - seen_chunk_ids - same_batch_duplicates
-                    )
-
-                    self._handle_duplicate_chunk_ids(
-                        batch=batch,
-                        batch_chunk_id_counts=batch_chunk_id_counts,
-                        duplicate_chunk_ids=duplicate_chunk_ids,
-                        same_batch_duplicates=same_batch_duplicates,
-                        cross_batch_duplicates=cross_batch_duplicates,
-                        new_chunk_ids=new_chunk_ids,
-                        successful_doc_ids=successful_doc_ids,
-                        result=result,
-                        errors=errors,
-                    )
-
-                    # Only update seen_chunk_ids with non-duplicate IDs
-                    seen_chunk_ids.update(new_chunk_ids)
-                    result.success_count += len(new_chunk_ids)
-
-                result.error_count += error_count
-                result.successfully_processed_documents.update(successful_doc_ids)
-                result.errors.extend(errors)
+            while pending:
+                await drain_oldest()
 
         except asyncio.CancelledError:
             logger.debug("UpsertWorker cancelled")
+            for task, _, _ in pending:
+                if not task.done():
+                    task.cancel()
             raise
         finally:
             logger.debug("UpsertWorker exited")

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
@@ -87,6 +87,36 @@ class TestEmbeddingWorker:
         )
 
     @pytest.mark.asyncio
+    async def test_process_partial_empty_embeddings(self):
+        """A chunk with an empty embedding is kept in the result, paired with None."""
+        mock_chunk1 = Mock()
+        mock_chunk1.content = "Test content 1"
+        mock_chunk1.id = "chunk1"
+
+        mock_chunk2 = Mock()
+        mock_chunk2.content = "Test content 2"
+        mock_chunk2.id = "chunk2"
+
+        chunks = [mock_chunk1, mock_chunk2]
+
+        # Second chunk's content was invalid, so get_embeddings returns []
+        # for it instead of raising.
+        self.mock_embedding_service.get_embeddings = AsyncMock(
+            return_value=[[0.1, 0.2, 0.3], []]
+        )
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.embedding_worker.prometheus_metrics"
+        ):
+            result = await self.embedding_worker.process(chunks)
+
+        # Both chunks are present, not just the successful one, so callers
+        # can tell the second one failed instead of it silently disappearing.
+        assert len(result) == 2
+        assert result[0] == (mock_chunk1, [0.1, 0.2, 0.3])
+        assert result[1] == (mock_chunk2, None)
+
+    @pytest.mark.asyncio
     async def test_process_with_shutdown_during_processing(self):
         """Test processing with shutdown event set during processing."""
         mock_chunk = Mock()
@@ -306,8 +336,11 @@ class TestEmbeddingWorker:
                 ):
                     results.append(result)
 
-                # Should get no results due to exceptions
-                assert len(results) == 0
+                # Failed chunks are still surfaced (paired with None) so
+                # their parent documents can be accounted for downstream,
+                # instead of silently vanishing.
+                assert len(results) == 2
+                assert results == [(mock_chunk1, None), (mock_chunk2, None)]
 
                 # Verify error logging
                 assert mock_logger.error.call_count >= 2  # One for each chunk
@@ -359,9 +392,11 @@ class TestEmbeddingWorker:
                 ):
                     results.append(result)
 
-                # Should get result for first chunk only
-                assert len(results) == 1
+                # First chunk succeeds; second is still surfaced, paired
+                # with None, instead of disappearing from accounting.
+                assert len(results) == 2
                 assert results[0] == (mock_chunk1, [0.1, 0.2, 0.3])
+                assert results[1] == (mock_chunk2, None)
 
                 # Verify error logging for second chunk
                 mock_logger.error.assert_called()
@@ -418,3 +453,63 @@ class TestEmbeddingWorker:
 
         # Verify embedding service was not called
         self.mock_embedding_service.get_embeddings.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_chunks_bounds_concurrent_batches_to_max_workers(self):
+        """No more than max_workers embedding batches should be in flight at once.
+
+        Regression guard for the dispatch loop: batches used to be created
+        eagerly with no cap, so max_embed_workers only throttled execution,
+        not how many batches (and their chunk data) piled up in memory.
+        """
+        worker = EmbeddingWorker(
+            embedding_service=self.mock_embedding_service,
+            max_workers=2,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+        self.mock_embedding_service.batch_size = 1
+
+        chunks = []
+        for i in range(6):
+            chunk = Mock()
+            chunk.content = f"Test content {i}"
+            chunk.id = f"chunk{i}"
+            chunks.append(chunk)
+
+        async def chunk_iterator():
+            for chunk in chunks:
+                yield chunk
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def get_embeddings_side_effect(contents):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            async with lock:
+                in_flight -= 1
+            return [[0.1, 0.2, 0.3] for _ in contents]
+
+        self.mock_embedding_service.get_embeddings = AsyncMock(
+            side_effect=get_embeddings_side_effect
+        )
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.embedding_worker.prometheus_metrics"
+        ):
+            results = []
+            async for result in worker.process_chunks(chunk_iterator()):
+                results.append(result)
+
+        # All chunks still get processed, in submission order...
+        assert len(results) == 6
+        assert [chunk.id for chunk, _ in results] == [c.id for c in chunks]
+        # ...but concurrency never exceeded max_workers, and genuine
+        # concurrency (>1) did happen, ruling out an accidental fully
+        # sequential implementation.
+        assert max_in_flight == 2

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
@@ -263,7 +263,16 @@ class TestEmbeddingWorker:
 
     @pytest.mark.asyncio
     async def test_process_chunks_with_shutdown_during_iteration(self):
-        """Test chunk processing with shutdown during iteration."""
+        """Shutdown mid-stream: a batch still in flight when shutdown lands is
+        dropped (its document stays unfinished and is retried on the next run),
+        and chunks arriving after shutdown are never dispatched.
+
+        Under the concurrent dispatch model the first chunk's batch is created
+        before shutdown but *executes* after the flag is set, so process()'s
+        shutdown check discards its result. The completed-before-shutdown case
+        (results still yielded) is covered by
+        test_process_chunks_shutdown_drains_dispatched_batches.
+        """
         # Setup mock chunks
         mock_chunk1 = Mock()
         mock_chunk1.content = "Test content 1"
@@ -295,9 +304,11 @@ class TestEmbeddingWorker:
             async for result in self.embedding_worker.process_chunks(chunk_iterator()):
                 results.append(result)
 
-        # Should only get result for first chunk before shutdown
-        assert len(results) == 1
-        assert results[0] == (mock_chunk1, [0.1, 0.2, 0.3])
+        # The in-flight batch was discarded at the shutdown check: nothing is
+        # yielded, so the parent document is left unfinished for a later retry.
+        assert results == []
+        # chunk1 was dispatched (and embedded) before the drop; chunk2 never was.
+        self.mock_embedding_service.get_embeddings.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_process_chunks_with_batch_processing_exception(self):
@@ -513,3 +524,178 @@ class TestEmbeddingWorker:
         # concurrency (>1) did happen, ruling out an accidental fully
         # sequential implementation.
         assert max_in_flight == 2
+
+    @pytest.mark.asyncio
+    async def test_process_chunks_cancellation_cancels_in_flight_batches(self):
+        """Cancelling the consumer must cancel dispatched-but-unfinished batch tasks.
+
+        Guards the `except CancelledError: for task in pending: task.cancel()`
+        cleanup: without it, in-flight embedding calls (up to the 300s timeout)
+        keep running after the pipeline is torn down.
+        """
+        worker = EmbeddingWorker(
+            embedding_service=self.mock_embedding_service,
+            max_workers=2,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+        self.mock_embedding_service.batch_size = 1
+
+        hold = asyncio.Event()
+        started: list = []
+        cancelled: list = []
+
+        async def blocking_get_embeddings(contents):
+            started.append(contents)
+            try:
+                await hold.wait()
+            except asyncio.CancelledError:
+                cancelled.append(contents)
+                raise
+            return [[0.1, 0.2, 0.3] for _ in contents]
+
+        self.mock_embedding_service.get_embeddings = AsyncMock(
+            side_effect=blocking_get_embeddings
+        )
+
+        chunks = []
+        for i in range(3):
+            chunk = Mock()
+            chunk.content = f"content {i}"
+            chunk.id = f"chunk{i}"
+            chunks.append(chunk)
+
+        async def chunk_iterator():
+            for chunk in chunks:
+                yield chunk
+
+        async def consume():
+            with patch(
+                "qdrant_loader.core.pipeline.workers.embedding_worker.prometheus_metrics"
+            ):
+                async for _ in worker.process_chunks(chunk_iterator()):
+                    pass
+
+        consumer = asyncio.create_task(consume())
+        try:
+            # Wait until both batch tasks are genuinely in flight.
+            while len(started) < 2:
+                await asyncio.sleep(0.01)
+
+            consumer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await consumer
+
+            # Give cancellation a tick to propagate into the batch tasks.
+            await asyncio.sleep(0.05)
+            assert len(cancelled) == 2, (
+                f"expected both in-flight batches cancelled, got {len(cancelled)}: "
+                f"{cancelled}"
+            )
+        finally:
+            hold.set()  # unblock any leaked task so the loop can close cleanly
+            await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_process_chunks_mixed_failures_conserve_all_chunks(self):
+        """With concurrent batches where some fail outright, every dispatched
+        chunk is yielded exactly once, in submission order, with None pairing
+        for the failed ones — even when later batches finish first."""
+        worker = EmbeddingWorker(
+            embedding_service=self.mock_embedding_service,
+            max_workers=3,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+        self.mock_embedding_service.batch_size = 1
+
+        async def flaky_get_embeddings(contents):
+            idx = int(contents[0].rsplit(" ", 1)[1])
+            # Stagger so completion order is roughly reversed vs submission.
+            await asyncio.sleep(0.03 - idx * 0.004)
+            if idx % 2 == 0:
+                raise Exception(f"embedding service down for batch {idx}")
+            return [[float(idx), 0.2, 0.3] for _ in contents]
+
+        self.mock_embedding_service.get_embeddings = AsyncMock(
+            side_effect=flaky_get_embeddings
+        )
+
+        chunks = []
+        for i in range(6):
+            chunk = Mock()
+            chunk.content = f"content {i}"
+            chunk.id = f"chunk{i}"
+            chunks.append(chunk)
+
+        async def chunk_iterator():
+            for chunk in chunks:
+                yield chunk
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.embedding_worker.prometheus_metrics"
+        ):
+            results = []
+            async for result in worker.process_chunks(chunk_iterator()):
+                results.append(result)
+
+        # Conservation: all 6 yielded exactly once, in submission order.
+        assert [chunk.id for chunk, _ in results] == [c.id for c in chunks]
+        # Even-indexed batches failed -> None; odd-indexed succeeded.
+        assert [emb is None for _, emb in results] == [
+            True, False, True, False, True, False,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_chunks_shutdown_drains_dispatched_batches(self):
+        """Batches dispatched (and completed) before shutdown are still yielded;
+        chunks arriving after shutdown are never dispatched."""
+        shutdown_event = asyncio.Event()
+        worker = EmbeddingWorker(
+            embedding_service=self.mock_embedding_service,
+            max_workers=2,
+            queue_size=1000,
+            shutdown_event=shutdown_event,
+        )
+        self.mock_embedding_service.batch_size = 1
+
+        completed = 0
+
+        async def fast_get_embeddings(contents):
+            nonlocal completed
+            result = [[0.1, 0.2, 0.3] for _ in contents]
+            completed += 1
+            return result
+
+        self.mock_embedding_service.get_embeddings = AsyncMock(
+            side_effect=fast_get_embeddings
+        )
+
+        chunks = []
+        for i in range(3):
+            chunk = Mock()
+            chunk.content = f"content {i}"
+            chunk.id = f"chunk{i}"
+            chunks.append(chunk)
+
+        async def chunk_iterator():
+            yield chunks[0]
+            yield chunks[1]
+            # Let both dispatched batches finish before signalling shutdown,
+            # then produce one more chunk that must NOT be dispatched.
+            while completed < 2:
+                await asyncio.sleep(0.01)
+            shutdown_event.set()
+            yield chunks[2]
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.embedding_worker.prometheus_metrics"
+        ):
+            results = []
+            async for result in worker.process_chunks(chunk_iterator()):
+                results.append(result)
+
+        # The two pre-shutdown chunks were drained and yielded...
+        assert [chunk.id for chunk, _ in results] == ["chunk0", "chunk1"]
+        # ...and the post-shutdown chunk never reached the embedding service.
+        assert self.mock_embedding_service.get_embeddings.call_count == 2

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
@@ -635,6 +635,8 @@ class TestUpsertWorker:
         assert len(result.errors) == 1
         assert "duplicate chunk IDs" in result.errors[0]
         assert "affecting 1 document(s)" in result.errors[0]
+        assert result.successfully_processed_documents == {"doc1"}
+        assert result.failed_document_ids == {"doc2"}
         mock_logger.warning.assert_called()
 
     @pytest.mark.asyncio
@@ -730,3 +732,149 @@ class TestUpsertWorker:
         assert len(result.errors) == 1
         assert "duplicate chunk IDs" in result.errors[0]
         mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_skips_upsert_on_failed_embedding(self):
+        """A (chunk, None) pair from a failed embedding must not reach Qdrant."""
+        mock_chunk = Mock()
+        mock_chunk.id = "chunk1"
+        mock_chunk.metadata = {"parent_document": Mock(id="doc1")}
+
+        async def embedded_chunks_iterator():
+            yield (mock_chunk, None)
+
+        with patch("qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"):
+            result = await self.upsert_worker.process_embedded_chunks(
+                embedded_chunks_iterator()
+            )
+
+        # Nothing should ever be sent to Qdrant for a chunk that failed to embed.
+        self.mock_qdrant_manager.upsert_points.assert_not_called()
+
+        assert result.success_count == 0
+        assert result.error_count == 1
+        assert len(result.errors) == 1
+        assert "Embedding failed for chunk chunk1" in result.errors[0]
+        # The document must not look successful just because nothing "failed to upsert" —
+        # it never had a chance to be upserted at all.
+        assert result.successfully_processed_documents == set()
+        assert result.failed_document_ids == {"doc1"}
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_partial_document_failure_not_marked_successful(
+        self,
+    ):
+        """A document is only 'successful' once every chunk it produced is accounted for."""
+        parent_doc = Mock(id="doc1")
+
+        # doc1 was chunked into 3 pieces; only 2 arrive with a real embedding.
+        good_chunk_1 = Mock()
+        good_chunk_1.id = "doc1-chunk-1"
+        good_chunk_1.content = "Content 1"
+        good_chunk_1.source = "test_source"
+        good_chunk_1.source_type = "test"
+        good_chunk_1.created_at = datetime(2023, 1, 1, 12, 0, 0)
+        good_chunk_1.metadata = {
+            "parent_document": parent_doc,
+            "parent_document_total_chunks": 3,
+        }
+
+        good_chunk_2 = Mock()
+        good_chunk_2.id = "doc1-chunk-2"
+        good_chunk_2.content = "Content 2"
+        good_chunk_2.source = "test_source"
+        good_chunk_2.source_type = "test"
+        good_chunk_2.created_at = datetime(2023, 1, 1, 12, 0, 0)
+        good_chunk_2.metadata = {
+            "parent_document": parent_doc,
+            "parent_document_total_chunks": 3,
+        }
+
+        failed_chunk = Mock()
+        failed_chunk.id = "doc1-chunk-3"
+        failed_chunk.metadata = {
+            "parent_document": parent_doc,
+            "parent_document_total_chunks": 3,
+        }
+
+        async def embedded_chunks_iterator():
+            yield (good_chunk_1, [0.1, 0.2, 0.3])
+            yield (good_chunk_2, [0.4, 0.5, 0.6])
+            yield (failed_chunk, None)  # embedding failed upstream
+
+        self.upsert_worker.batch_size = 10  # keep the 2 good chunks in one batch
+
+        with patch("qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"):
+            result = await self.upsert_worker.process_embedded_chunks(
+                embedded_chunks_iterator()
+            )
+
+        # 2 of 3 chunks upserted fine...
+        assert result.success_count == 2
+        assert result.error_count == 1
+        # ...but the document as a whole must NOT be marked successful, since
+        # one of its three chunks never made it in. It should be retried.
+        assert result.successfully_processed_documents == set()
+        assert result.failed_document_ids == {"doc1"}
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_bounds_concurrent_batches_to_max_workers(
+        self,
+    ):
+        """No more than max_workers upsert batches should be in flight at once.
+
+        Regression guard for the dispatch loop: batches used to be created
+        eagerly with no cap, so max_upsert_workers only throttled execution,
+        not how many batches (and their embeddings) piled up in memory.
+        """
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=1,
+            max_workers=2,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+
+        chunks = []
+        for i in range(6):
+            chunk = Mock()
+            chunk.id = f"chunk{i}"
+            chunk.content = f"Test content {i}"
+            chunk.source = "test_source"
+            chunk.source_type = "test"
+            chunk.created_at = datetime(2023, 1, 1, 12, 0, 0)
+            chunk.metadata = {"parent_document": Mock(id=f"doc{i}")}
+            chunks.append(chunk)
+
+        async def embedded_chunks_iterator():
+            for i, chunk in enumerate(chunks):
+                yield (chunk, [0.1 * i, 0.2 * i, 0.3 * i])
+
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        async def upsert_points_side_effect(points):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.01)
+            async with lock:
+                in_flight -= 1
+
+        self.mock_qdrant_manager.upsert_points = AsyncMock(
+            side_effect=upsert_points_side_effect
+        )
+
+        with patch("qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"):
+            result = await worker.process_embedded_chunks(embedded_chunks_iterator())
+
+        assert result.success_count == 6
+        assert result.successfully_processed_documents == {
+            f"doc{i}" for i in range(6)
+        }
+        # Concurrency never exceeded max_workers, and genuine concurrency
+        # (>1) did happen, ruling out an accidental fully sequential
+        # implementation.
+        assert max_in_flight == 2

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
@@ -1053,3 +1053,112 @@ class TestUpsertWorker:
 
 
 
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_cancellation_cancels_in_flight_batches(
+        self,
+    ):
+        """Cancelling the consumer must cancel dispatched-but-unfinished upsert
+        tasks so no orphaned Qdrant writes keep running after teardown."""
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=1,
+            max_workers=2,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+
+        hold = asyncio.Event()
+        started: list = []
+        cancelled: list = []
+
+        async def blocking_upsert(points):
+            started.append(points)
+            try:
+                await hold.wait()
+            except asyncio.CancelledError:
+                cancelled.append(points)
+                raise
+
+        self.mock_qdrant_manager.upsert_points = AsyncMock(
+            side_effect=blocking_upsert
+        )
+
+        chunks = [_make_chunk(f"chunk{i}") for i in range(3)]
+
+        async def embedded_chunks_iterator():
+            for chunk in chunks:
+                yield (chunk, [0.1, 0.2, 0.3])
+
+        async def consume():
+            with patch(
+                "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+            ):
+                await worker.process_embedded_chunks(embedded_chunks_iterator())
+
+        consumer = asyncio.create_task(consume())
+        try:
+            while len(started) < 2:
+                await asyncio.sleep(0.01)
+
+            consumer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await consumer
+
+            await asyncio.sleep(0.05)
+            assert len(cancelled) == 2, (
+                f"expected both in-flight upsert batches cancelled, got "
+                f"{len(cancelled)}"
+            )
+        finally:
+            hold.set()
+            await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_shutdown_merges_dispatched_batches(self):
+        """Batches dispatched before shutdown are still merged into the result;
+        chunks arriving after shutdown are never upserted."""
+        shutdown_event = asyncio.Event()
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=1,
+            max_workers=2,
+            queue_size=1000,
+            shutdown_event=shutdown_event,
+        )
+
+        completed = 0
+
+        async def fast_upsert(points):
+            nonlocal completed
+            completed += 1
+
+        self.mock_qdrant_manager.upsert_points = AsyncMock(side_effect=fast_upsert)
+
+        doc1, doc2, doc3 = (Mock(id=f"doc{i}") for i in (1, 2, 3))
+        chunk1 = _make_chunk("chunk1", doc1, total_chunks=1)
+        chunk2 = _make_chunk("chunk2", doc2, total_chunks=1)
+        chunk3 = _make_chunk("chunk3", doc3, total_chunks=1)
+
+        async def embedded_chunks_iterator():
+            yield (chunk1, [0.1, 0.2, 0.3])
+            yield (chunk2, [0.4, 0.5, 0.6])
+            # Let both dispatched batches finish, then signal shutdown before
+            # producing a third chunk that must NOT be upserted.
+            while completed < 2:
+                await asyncio.sleep(0.01)
+            shutdown_event.set()
+            yield (chunk3, [0.7, 0.8, 0.9])
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            result = await worker.process_embedded_chunks(embedded_chunks_iterator())
+
+        # Pre-shutdown batches fully merged...
+        assert result.success_count == 2
+        assert result.successfully_processed_documents == {"doc1", "doc2"}
+        # ...and the post-shutdown chunk never reached Qdrant.
+        assert self.mock_qdrant_manager.upsert_points.call_count == 2
+        assert "doc3" not in result.successfully_processed_documents
+        assert "doc3" not in result.failed_document_ids

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
@@ -25,6 +25,23 @@ class TestPipelineResult:
         assert result.errors == []
 
 
+def _make_chunk(chunk_id: str, parent_doc=None, total_chunks: int | None = None):
+    """Build a mock chunk with attributes UpsertWorker touches."""
+    chunk = Mock()
+    chunk.id = chunk_id
+    chunk.context = f"Content {chunk_id}"
+    chunk.source = "test_source"
+    chunk.source_type = "test"
+    chunk.created_at = datetime(2023, 1, 1, 12, 0, 0)
+    metadata = {}
+    if parent_doc is not None:
+        metadata["parent_document"] = parent_doc
+        if total_chunks is not None:
+            metadata["parent_document_total_chunks"] = total_chunks
+    chunk.metadata = metadata
+    return chunk
+
+
 class TestUpsertWorker:
     """Test cases for UpsertWorker."""
 
@@ -878,3 +895,161 @@ class TestUpsertWorker:
         # (>1) did happen, ruling out an accidental fully sequential
         # implementation.
         assert max_in_flight == 2
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_releases_reservation_on_failed_batch(self):
+        """A chunk ID from a batch where nothing was written must not poison a retry.
+
+        _merge_batch_outcome releases seen_chunk_ids reservations when
+        success_count == 0; otherwise the retried chunk would be miscounted
+        as a cross-batch duplicate.
+        """
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=1,
+            max_workers=1,  # failed batch merges (and releases) before retry dispatch
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+
+        # Same chunk ID twice: first attempt fails at Qdrant, retry succeeds.
+        attempt = _make_chunk("chunk-x")
+        retry = _make_chunk("chunk-x")
+
+        calls = 0
+
+        async def upsert_side_effect(points):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise Exception("Qdrant write failed")
+
+        self.mock_qdrant_manager.upsert_points = AsyncMock(
+            side_effect=upsert_side_effect
+        )
+
+        async def embedded_chunks_iterator():
+            yield (attempt, [0.1, 0.2, 0.3])
+            yield (retry, [0.1, 0.2, 0.3])
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            result = await worker.process_embedded_chunks(embedded_chunks_iterator())
+
+        # The retry counts as a genuine success, not a duplicate.
+        assert result.success_count == 1
+        # And no duplicate-collision error was recorded for the retried ID.
+        assert not any("duplicate chunk ids" in e.lower() for e in result.errors)
+        # The original failure is still accounted.
+        assert any("Upsert failed for chunk chunk-x" in e for e in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_reserves_ids_for_in_flight_batches(self):
+        """Reservation is synchronized at dispatch: a batch dispatched while an
+        earlier batch with the same chunk ID is still in flight must see it as
+        a cross-batch duplicate and not double-count the chunk."""
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=1,
+            max_workers=2,  # both single-chunk batches genuinely in flight together
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+
+        first = _make_chunk("chunk-x")
+        second = _make_chunk("chunk-x")  # same ID, dispatched while first runs
+
+        async def slow_upsert(points):
+            await asyncio.sleep(0.05)  # keep the first batch in flight
+
+        self.mock_qdrant_manager.upsert_points = AsyncMock(side_effect=slow_upsert)
+
+        async def embedded_chunks_iterator():
+            yield (first, [0.1, 0.2, 0.3])
+            yield (second, [0.4, 0.5, 0.6])
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            result = await worker.process_embedded_chunks(embedded_chunks_iterator())
+
+        # The ID is counted exactly once even though both writes happened.
+        assert result.success_count == 1
+        assert self.mock_qdrant_manager.upsert_points.call_count == 2
+        # The collision was detected and surfaced.
+        assert any("duplicate chunk ids" in e.lower() for e in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_batch_failure_fails_docs_but_continues(self):
+        """If a batch writes nothing, every parent doc in it lands in
+        failed_document_ids, and later batches are unaffected."""
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=2,
+            max_workers=1,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+
+        doc1, doc2 = Mock(id="doc1"), Mock(id="doc2")
+        batch1 = [_make_chunk(f"d1-c{i}", doc1, total_chunks=2) for i in (1, 2)]
+        batch2 = [_make_chunk(f"d2-c{i}", doc2, total_chunks=2) for i in (1, 2)]
+
+        calls = 0
+
+        async def upsert_side_effect(points):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise Exception("Qdrant write failed")
+
+        self.mock_qdrant_manager.upsert_points = AsyncMock(
+            side_effect=upsert_side_effect
+        )
+
+        async def embedded_chunks_iterator():
+            for chunk in (*batch1, *batch2):
+                yield (chunk, [0.1, 0.2, 0.3])
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            result = await worker.process_embedded_chunks(embedded_chunks_iterator())
+
+        assert result.failed_document_ids == {"doc1"}
+        assert result.successfully_processed_documents == {"doc2"}
+        assert result.success_count == 2  # only doc2's chunks were written
+        assert result.error_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_document_success_across_batches(self):
+        """A doc whose chunks span several batches is marked successful only
+        after ALL its chunks are accounted for — and does end up successful."""
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=2,
+            max_workers=1,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+        self.mock_qdrant_manager.upsert_points = AsyncMock()
+
+        doc = Mock(id="doc1")
+        chunks = [_make_chunk(f"d1-c{i}", doc, total_chunks=4) for i in range(4)]
+
+        async def embedded_chunks_iterator():
+            for chunk in chunks:
+                yield (chunk, [0.1, 0.2, 0.3])
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            result = await worker.process_embedded_chunks(embedded_chunks_iterator())
+
+        assert result.success_count == 4
+        assert result.successfully_processed_documents == {"doc1"}
+        assert result.failed_document_ids == set()
+
+
+


### PR DESCRIPTION
# Pull Request

## Summary

Replace serial batch processing in EmbeddingWorker and UpsertWorker with bounded concurrent task execution.

Add synchronized duplicate chunk ID reservation for concurrent upserts.

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore