### PR TITLE
feat: add concurrency configuration for document ingestion pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ install: ## Install both packages in development mode
 install-dev: ## Install both packages with development dependencies
 	uv sync --all-packages --all-extras
 
-test: ## Run all tests
-	uv run pytest packages/
+test: test-core test-loader test-mcp ## Run all tests
 
 test-loader: ## Run tests for qdrant-loader package only
 	uv run pytest packages/qdrant-loader/tests/
@@ -25,7 +24,9 @@ test-core: ## Run tests for qdrant-loader-core package only
 	uv run pytest packages/qdrant-loader-core/tests/
 
 test-coverage: ## Run tests with coverage report
-	uv run pytest packages/ --cov=packages --cov-report=html --cov-report=term-missing
+	cd packages/qdrant-loader-core && uv run pytest tests/ --cov=src --cov-report=html --cov-report=term-missing
+	cd packages/qdrant-loader && uv run pytest tests/ --cov=src --cov-report=html --cov-report=term-missing
+	cd packages/qdrant-loader-mcp-server && uv run pytest tests/ --cov=src --cov-report=html --cov-report=term-missing
 
 quality: ## Run quality gates (import cycles, module sizes) for qdrant-loader
 	cd packages/qdrant-loader && uv run pytest -q tests/unit/quality -v

--- a/packages/qdrant-loader-mcp-server/tests/integration/test_phase2_3_cross_document_intelligence.py
+++ b/packages/qdrant-loader-mcp-server/tests/integration/test_phase2_3_cross_document_intelligence.py
@@ -31,13 +31,10 @@ class TestCrossDocumentIntelligenceIntegration:
     """Integration tests for the complete cross-document intelligence workflow."""
 
     @pytest.fixture
-    async def spacy_analyzer(self):
+    def spacy_analyzer(self):
         """Create a real SpaCy analyzer for integration testing."""
         # Use a lightweight model for testing
-        analyzer = SpaCyQueryAnalyzer(spacy_model="en_core_web_sm")
-        await analyzer.initialize()
-        yield analyzer
-        await analyzer.cleanup()
+        return SpaCyQueryAnalyzer(spacy_model="en_core_web_sm")
 
     @pytest.fixture
     def intelligence_engine(self, spacy_analyzer):

--- a/packages/qdrant-loader/conf/config.template.yaml
+++ b/packages/qdrant-loader/conf/config.template.yaml
@@ -126,6 +126,12 @@ global:
     # OpenAI: "cl100k_base"
     max_tokens_per_request: 8000
     max_tokens_per_chunk: 8000
+    min_request_interval: 0.5
+    # Minimum seconds between embedding API requests, enforced across all
+    # concurrent embed workers (see concurrency.max_embed_workers below).
+    # Guards against provider rate limits (HTTP 429).
+    # Ollama/local models: safe to lower to 0
+    # OpenAI/hosted providers: raise if you see 429s, lower if you have headroom
 
   # Unified LLM configuration (provider-agnostic)
   # New preferred configuration block; legacy embedding/markitdown fields still work
@@ -288,6 +294,21 @@ global:
         enabled: false
         # Supports integer seconds or duration strings (e.g., 5s, 5m, 1h)
         interval: 5s
+
+  # Ingestion pipeline concurrency configuration
+  # Controls how many chunk/embed/upsert operations run in parallel during ingestion.
+  # Unrelated to `workers` above, which governs the job-scheduling queue.
+  concurrency:
+    # Maximum number of documents chunked concurrently
+    max_chunk_workers: 10
+    # Maximum number of embedding batch requests in flight concurrently
+    max_embed_workers: 4
+    # Maximum number of Qdrant upsert batch requests in flight concurrently
+    max_upsert_workers: 4
+    # Advisory queue size hint passed to pipeline workers
+    queue_size: 1000
+    # Chunks per Qdrant upsert batch; omit to default to the embedding batch size
+    # upsert_batch_size: 100
 
 # Multi-project configuration
 # Define multiple projects, each with their own sources and settings

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
@@ -154,7 +154,14 @@ async def _serve_main(
 
     logger.info("serve.pipeline_init")
     pipeline_factory = PipelineComponentsFactory()
-    pipeline_config = PipelineConfig()
+    concurrency = config_obj.concurrency
+    pipeline_config = PipelineConfig(
+        max_chunk_workers=concurrency.max_chunk_workers,
+        max_embed_workers=concurrency.max_embed_workers,
+        max_upsert_workers=concurrency.max_upsert_workers,
+        queue_size=concurrency.queue_size,
+        upsert_batch_size=concurrency.upsert_batch_size,
+    )
     pipeline_components = pipeline_factory.create_components(
         settings,
         pipeline_config,

--- a/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/__init__.py
@@ -17,6 +17,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from ..utils.logging import LoggingConfig
 from ..utils.sensitive import sanitize_exception_message
 from .chunking import ChunkingConfig
+from .concurrency import ConcurrencyConfig
 
 # Import consolidated configs
 from .global_config import GlobalConfig, SemanticAnalysisConfig
@@ -65,6 +66,7 @@ def _get_connector_configs():
 
 __all__ = [
     "ChunkingConfig",
+    "ConcurrencyConfig",
     "ConfluenceSpaceConfig",
     "GitAuthConfig",
     "GitRepoConfig",

--- a/packages/qdrant-loader/src/qdrant_loader/config/concurrency.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/concurrency.py
@@ -1,0 +1,36 @@
+from pydantic import Field
+
+from qdrant_loader.config.base import BaseConfig
+
+
+class ConcurrencyConfig(BaseConfig):
+    """Concurrency knobs for the document ingestion pipeline's stages."""
+
+    max_chunk_workers: int = Field(
+        default=10,
+        gt=0,
+        description="Maximum number of documents chunked concurrently",
+    )
+    max_embed_workers: int = Field(
+        default=4,
+        gt=0,
+        description="Maximum number of embedding batch requests in flight concurrently",
+    )
+    max_upsert_workers: int = Field(
+        default=4,
+        gt=0,
+        description="Maximum number of Qdrant upsert batch requests in flight concurrently",
+    )
+    queue_size: int = Field(
+        default=1000,
+        gt=0,
+        description="Advisory queue size hint passed to pipeline workers",
+    )
+    upsert_batch_size: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Number of chunks per Qdrant upsert batch. Defaults to the "
+            "embedding batch size when unset."
+        ),
+    )

--- a/packages/qdrant-loader/src/qdrant_loader/config/embedding.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/embedding.py
@@ -38,3 +38,13 @@ class EmbeddingConfig(BaseConfig):
         default=8000,
         description="Maximum tokens allowed for a single chunk (should match or be below model's context limit)",
     )
+    min_request_interval: float = Field(
+        default=0.5,
+        ge=0,
+        description=(
+            "Minimum time in seconds between embedding API requests, enforced "
+            "across all concurrent embed workers. Guards against provider rate "
+            "limits (HTTP 429); lower or set to 0 for local/self-hosted models "
+            "or providers with generous rate limits."
+        ),
+    )

--- a/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/global_config.py
@@ -10,6 +10,7 @@ from pydantic import Field
 
 from qdrant_loader.config.base import BaseConfig
 from qdrant_loader.config.chunking import ChunkingConfig
+from qdrant_loader.config.concurrency import ConcurrencyConfig
 from qdrant_loader.config.embedding import EmbeddingConfig
 from qdrant_loader.config.graph import GraphConfig
 from qdrant_loader.config.qdrant import QdrantConfig
@@ -62,6 +63,10 @@ class GlobalConfig(BaseConfig):
         default_factory=WorkersConfig,
         description="Worker scheduling and runtime configuration",
     )
+    concurrency: ConcurrencyConfig = Field(
+        default_factory=ConcurrencyConfig,
+        description="Ingestion pipeline concurrency configuration (chunk/embed/upsert)",
+    )
     graph: GraphConfig = Field(
         default_factory=GraphConfig, description="Graph configuration"
     )
@@ -112,5 +117,6 @@ class GlobalConfig(BaseConfig):
             },
             "qdrant": self.qdrant.to_dict(),
             "workers": self.workers.to_dict(),
+            "concurrency": self.concurrency.to_dict(),
             "graph": self.graph.to_dict(),
         }

--- a/packages/qdrant-loader/src/qdrant_loader/core/async_ingestion_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/async_ingestion_pipeline.py
@@ -34,10 +34,10 @@ class AsyncIngestionPipeline:
         settings: Settings,
         qdrant_manager: QdrantManager,
         state_manager: StateManager | None = None,
-        max_chunk_workers: int = 10,
-        max_embed_workers: int = 4,
-        max_upsert_workers: int = 4,
-        queue_size: int = 1000,
+        max_chunk_workers: int | None = None,
+        max_embed_workers: int | None = None,
+        max_upsert_workers: int | None = None,
+        queue_size: int | None = None,
         upsert_batch_size: int | None = None,
         enable_metrics: bool = False,
         metrics_dir: Path | None = None,  # New parameter for workspace support
@@ -49,11 +49,16 @@ class AsyncIngestionPipeline:
             qdrant_manager: QdrantManager instance
             state_manager: Optional state manager
 
-            max_chunk_workers: Maximum number of chunking workers
-            max_embed_workers: Maximum number of embedding workers
-            max_upsert_workers: Maximum number of upsert workers
-            queue_size: Queue size for workers
-            upsert_batch_size: Batch size for upserts
+            max_chunk_workers: Maximum number of chunking workers. Defaults to
+                ``settings.global_config.concurrency.max_chunk_workers``.
+            max_embed_workers: Maximum number of embedding workers. Defaults to
+                ``settings.global_config.concurrency.max_embed_workers``.
+            max_upsert_workers: Maximum number of upsert workers. Defaults to
+                ``settings.global_config.concurrency.max_upsert_workers``.
+            queue_size: Queue size for workers. Defaults to
+                ``settings.global_config.concurrency.queue_size``.
+            upsert_batch_size: Batch size for upserts. Defaults to
+                ``settings.global_config.concurrency.upsert_batch_size``.
             enable_metrics: Whether to enable metrics server
             metrics_dir: Custom metrics directory (for workspace support)
         """
@@ -66,13 +71,32 @@ class AsyncIngestionPipeline:
                 "Global configuration not available. Please check your configuration file."
             )
 
-        # Create pipeline configuration with worker and batch size settings.
+        # Explicit constructor args win; otherwise fall back to the user's
+        # settings.yaml (global.concurrency), so these knobs are actually
+        # reachable from configuration instead of being stuck at a literal.
+        concurrency = settings.global_config.concurrency
         self.pipeline_config = PipelineConfig(
-            max_chunk_workers=max_chunk_workers,
-            max_embed_workers=max_embed_workers,
-            max_upsert_workers=max_upsert_workers,
-            queue_size=queue_size,
-            upsert_batch_size=upsert_batch_size,
+            max_chunk_workers=(
+                max_chunk_workers
+                if max_chunk_workers is not None
+                else concurrency.max_chunk_workers
+            ),
+            max_embed_workers=(
+                max_embed_workers
+                if max_embed_workers is not None
+                else concurrency.max_embed_workers
+            ),
+            max_upsert_workers=(
+                max_upsert_workers
+                if max_upsert_workers is not None
+                else concurrency.max_upsert_workers
+            ),
+            queue_size=queue_size if queue_size is not None else concurrency.queue_size,
+            upsert_batch_size=(
+                upsert_batch_size
+                if upsert_batch_size is not None
+                else concurrency.upsert_batch_size
+            ),
             enable_metrics=enable_metrics,
         )
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/embedding/embedding_service.py
@@ -52,7 +52,7 @@ class EmbeddingService:
                 self.encoding = None
 
         self.last_request_time = 0
-        self.min_request_interval = 0.5  # 500ms between requests
+        self.min_request_interval = settings.global_config.embedding.min_request_interval
 
         # Retry configuration for network resilience
         self.max_retries = 3

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -858,14 +858,20 @@ class PipelineOrchestrator:
             logger.debug("Initializing state manager for document state updates")
             await self.components.state_manager.initialize()
 
-        for doc in successfully_processed_docs:
-            try:
-                await self.components.state_manager.update_document_state(
-                    doc, project_id
-                )
+        if not successfully_processed_docs:
+            return
+
+        # One session/commit for the whole batch instead of one per document
+        # (each document's write is still isolated via a SAVEPOINT, so a
+        # single failure doesn't affect the others' results below).
+        results = await self.components.state_manager.update_document_states_batch(
+            successfully_processed_docs, project_id
+        )
+        for doc, _record, error in results:
+            if error is None:
                 logger.debug(f"Updated document state for {doc.id}")
-            except Exception as e:
+            else:
                 logger.error(
-                    f"Failed to update document state for {doc.id}: {sanitize_exception_message(e)}",
-                    error_type=type(e).__name__,
+                    f"Failed to update document state for {doc.id}: {sanitize_exception_message(error)}",
+                    error_type=type(error).__name__,
                 )

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
@@ -465,6 +465,30 @@ class StateManager:
             )
             raise
 
+    async def update_document_states_batch(
+        self, documents: list[Document], project_id: str | None = None
+    ) -> list[tuple[Document, DocumentStateRecord | None, Exception | None]]:
+        """Update state for multiple documents in one session/commit.
+
+        Unlike calling ``update_document_state`` once per document, this
+        commits once for the whole batch (each document's write is isolated
+        by its own SAVEPOINT, so one failure doesn't affect the others).
+        Returns per-document ``(document, record_or_None, exception_or_None)``
+        so callers can report success/failure exactly as before.
+        """
+        if not self._initialized:
+            raise RuntimeError("StateManager not initialized. Call initialize() first.")
+
+        self.logger.debug(
+            f"Updating document state for {len(documents)} documents in one batch "
+            f"(project: {project_id})"
+        )
+        return await _transitions.update_document_states_batch(
+            self._session_factory,  # type: ignore[arg-type]
+            documents=documents,
+            project_id=project_id,
+        )
+
     async def update_conversion_metrics(
         self,
         source_type: str,

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/transitions.py
@@ -175,109 +175,163 @@ async def update_document_state(
     project_id: str | None,
 ) -> DocumentStateRecord:
     async with session_factory() as session:  # type: ignore
-        query = select(DocumentStateRecord).filter(
-            DocumentStateRecord.source_type == document.source_type,
-            DocumentStateRecord.source == document.source,
-            DocumentStateRecord.document_id == document.id,
+        document_state_record = await _apply_document_state_update(
+            session, document=document, project_id=project_id
         )
-        if project_id is not None:
-            query = query.filter(DocumentStateRecord.project_id == project_id)
-        result = await session.execute(query)
-        document_state_record = result.scalar_one_or_none()
-
-        now = datetime.now(UTC)
-
-        metadata = document.metadata
-        conversion_method = metadata.get("conversion_method")
-        is_converted = conversion_method is not None
-        conversion_failed = metadata.get("conversion_failed", False)
-
-        is_attachment = metadata.get("is_attachment", False)
-        parent_document_id = metadata.get("parent_document_id")
-        attachment_id = metadata.get("attachment_id")
-
-        if document_state_record:
-            document_state_record.title = document.title  # type: ignore
-            document_state_record.content_hash = document.content_hash  # type: ignore
-            document_state_record.is_deleted = False  # type: ignore
-            document_state_record.updated_at = now  # type: ignore
-
-            document_state_record.is_converted = is_converted  # type: ignore
-            document_state_record.conversion_method = conversion_method  # type: ignore
-            document_state_record.original_file_type = metadata.get("original_file_type")  # type: ignore
-            document_state_record.original_filename = metadata.get("original_filename")  # type: ignore
-            document_state_record.file_size = metadata.get("file_size")  # type: ignore
-            document_state_record.conversion_failed = conversion_failed  # type: ignore
-            document_state_record.conversion_error = metadata.get("conversion_error")  # type: ignore
-            document_state_record.conversion_time = metadata.get("conversion_time")  # type: ignore
-
-            document_state_record.is_attachment = is_attachment  # type: ignore
-            document_state_record.parent_document_id = parent_document_id  # type: ignore
-            document_state_record.attachment_id = attachment_id  # type: ignore
-            document_state_record.attachment_filename = metadata.get("attachment_filename")  # type: ignore
-            document_state_record.attachment_mime_type = metadata.get("attachment_mime_type")  # type: ignore
-            document_state_record.attachment_download_url = metadata.get("attachment_download_url")  # type: ignore
-            document_state_record.attachment_author = metadata.get("attachment_author")  # type: ignore
-
-            attachment_created_str = metadata.get("attachment_created_at")
-            if attachment_created_str:
-                try:
-                    if isinstance(attachment_created_str, str):
-                        document_state_record.attachment_created_at = (
-                            datetime.fromisoformat(
-                                attachment_created_str.replace("Z", "+00:00")
-                            )
-                        )  # type: ignore
-                    elif isinstance(attachment_created_str, datetime):
-                        document_state_record.attachment_created_at = attachment_created_str  # type: ignore
-                except (ValueError, TypeError):
-                    document_state_record.attachment_created_at = None  # type: ignore
-        else:
-            attachment_created_at = None
-            attachment_created_str = metadata.get("attachment_created_at")
-            if attachment_created_str:
-                try:
-                    if isinstance(attachment_created_str, str):
-                        attachment_created_at = datetime.fromisoformat(
-                            attachment_created_str.replace("Z", "+00:00")
-                        )
-                    elif isinstance(attachment_created_str, datetime):
-                        attachment_created_at = attachment_created_str
-                except (ValueError, TypeError):
-                    attachment_created_at = None
-
-            document_state_record = DocumentStateRecord(
-                project_id=project_id,
-                document_id=document.id,
-                source_type=document.source_type,
-                source=document.source,
-                url=document.url,
-                title=document.title,
-                content_hash=document.content_hash,
-                is_deleted=False,
-                created_at=now,
-                updated_at=now,
-                is_converted=is_converted,
-                conversion_method=conversion_method,
-                original_file_type=metadata.get("original_file_type"),
-                original_filename=metadata.get("original_filename"),
-                file_size=metadata.get("file_size"),
-                conversion_failed=conversion_failed,
-                conversion_error=metadata.get("conversion_error"),
-                conversion_time=metadata.get("conversion_time"),
-                is_attachment=is_attachment,
-                parent_document_id=parent_document_id,
-                attachment_id=attachment_id,
-                attachment_filename=metadata.get("attachment_filename"),
-                attachment_mime_type=metadata.get("attachment_mime_type"),
-                attachment_download_url=metadata.get("attachment_download_url"),
-                attachment_author=metadata.get("attachment_author"),
-                attachment_created_at=attachment_created_at,
-            )
-            session.add(document_state_record)
-
         await session.commit()
         return document_state_record
+
+
+async def update_document_states_batch(
+    session_factory: AsyncSessionFactory,
+    *,
+    documents: list[Document],
+    project_id: str | None,
+) -> list[tuple[Document, DocumentStateRecord | None, Exception | None]]:
+    """Update state for multiple documents in a single session and commit.
+
+    Each document's read+write is wrapped in its own SAVEPOINT
+    (``session.begin_nested()``), so a failure on one document rolls back
+    only that document's changes -- the rest of the batch still lands in the
+    single, final ``commit()``. This turns N sequential fsync'd transactions
+    (the previous per-document behavior) into one, while preserving the
+    per-document error isolation callers rely on.
+
+    Returns a list of ``(document, record_or_None, exception_or_None)``
+    aligned with ``documents``, so callers can log per-document
+    success/failure exactly as before.
+    """
+    results: list[tuple[Document, DocumentStateRecord | None, Exception | None]] = []
+    async with session_factory() as session:  # type: ignore
+        for document in documents:
+            try:
+                async with session.begin_nested():
+                    record = await _apply_document_state_update(
+                        session, document=document, project_id=project_id
+                    )
+                results.append((document, record, None))
+            except Exception as e:  # noqa: BLE001 - reported to caller, not swallowed
+                results.append((document, None, e))
+
+        await session.commit()
+
+    return results
+
+
+async def _apply_document_state_update(
+    session: Any,
+    *,
+    document: Document,
+    project_id: str | None,
+) -> DocumentStateRecord:
+    """Fetch (if present) and update/create a document's state record.
+
+    Operates within the caller's session/transaction and does not commit --
+    callers own the commit boundary so single- and batch-update paths can
+    share this logic while controlling transaction granularity themselves.
+    """
+    query = select(DocumentStateRecord).filter(
+        DocumentStateRecord.source_type == document.source_type,
+        DocumentStateRecord.source == document.source,
+        DocumentStateRecord.document_id == document.id,
+    )
+    if project_id is not None:
+        query = query.filter(DocumentStateRecord.project_id == project_id)
+    result = await session.execute(query)
+    document_state_record = result.scalar_one_or_none()
+
+    now = datetime.now(UTC)
+
+    metadata = document.metadata
+    conversion_method = metadata.get("conversion_method")
+    is_converted = conversion_method is not None
+    conversion_failed = metadata.get("conversion_failed", False)
+
+    is_attachment = metadata.get("is_attachment", False)
+    parent_document_id = metadata.get("parent_document_id")
+    attachment_id = metadata.get("attachment_id")
+
+    if document_state_record:
+        document_state_record.title = document.title  # type: ignore
+        document_state_record.content_hash = document.content_hash  # type: ignore
+        document_state_record.is_deleted = False  # type: ignore
+        document_state_record.updated_at = now  # type: ignore
+
+        document_state_record.is_converted = is_converted  # type: ignore
+        document_state_record.conversion_method = conversion_method  # type: ignore
+        document_state_record.original_file_type = metadata.get("original_file_type")  # type: ignore
+        document_state_record.original_filename = metadata.get("original_filename")  # type: ignore
+        document_state_record.file_size = metadata.get("file_size")  # type: ignore
+        document_state_record.conversion_failed = conversion_failed  # type: ignore
+        document_state_record.conversion_error = metadata.get("conversion_error")  # type: ignore
+        document_state_record.conversion_time = metadata.get("conversion_time")  # type: ignore
+
+        document_state_record.is_attachment = is_attachment  # type: ignore
+        document_state_record.parent_document_id = parent_document_id  # type: ignore
+        document_state_record.attachment_id = attachment_id  # type: ignore
+        document_state_record.attachment_filename = metadata.get("attachment_filename")  # type: ignore
+        document_state_record.attachment_mime_type = metadata.get("attachment_mime_type")  # type: ignore
+        document_state_record.attachment_download_url = metadata.get("attachment_download_url")  # type: ignore
+        document_state_record.attachment_author = metadata.get("attachment_author")  # type: ignore
+
+        attachment_created_str = metadata.get("attachment_created_at")
+        if attachment_created_str:
+            try:
+                if isinstance(attachment_created_str, str):
+                    document_state_record.attachment_created_at = (
+                        datetime.fromisoformat(
+                            attachment_created_str.replace("Z", "+00:00")
+                        )
+                    )  # type: ignore
+                elif isinstance(attachment_created_str, datetime):
+                    document_state_record.attachment_created_at = attachment_created_str  # type: ignore
+            except (ValueError, TypeError):
+                document_state_record.attachment_created_at = None  # type: ignore
+    else:
+        attachment_created_at = None
+        attachment_created_str = metadata.get("attachment_created_at")
+        if attachment_created_str:
+            try:
+                if isinstance(attachment_created_str, str):
+                    attachment_created_at = datetime.fromisoformat(
+                        attachment_created_str.replace("Z", "+00:00")
+                    )
+                elif isinstance(attachment_created_str, datetime):
+                    attachment_created_at = attachment_created_str
+            except (ValueError, TypeError):
+                attachment_created_at = None
+
+        document_state_record = DocumentStateRecord(
+            project_id=project_id,
+            document_id=document.id,
+            source_type=document.source_type,
+            source=document.source,
+            url=document.url,
+            title=document.title,
+            content_hash=document.content_hash,
+            is_deleted=False,
+            created_at=now,
+            updated_at=now,
+            is_converted=is_converted,
+            conversion_method=conversion_method,
+            original_file_type=metadata.get("original_file_type"),
+            original_filename=metadata.get("original_filename"),
+            file_size=metadata.get("file_size"),
+            conversion_failed=conversion_failed,
+            conversion_error=metadata.get("conversion_error"),
+            conversion_time=metadata.get("conversion_time"),
+            is_attachment=is_attachment,
+            parent_document_id=parent_document_id,
+            attachment_id=attachment_id,
+            attachment_filename=metadata.get("attachment_filename"),
+            attachment_mime_type=metadata.get("attachment_mime_type"),
+            attachment_download_url=metadata.get("attachment_download_url"),
+            attachment_author=metadata.get("attachment_author"),
+            attachment_created_at=attachment_created_at,
+        )
+        session.add(document_state_record)
+
+    return document_state_record
 
 
 async def update_conversion_metrics(

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -10,6 +10,7 @@ import spacy
 from gensim import corpora
 from gensim.models import LdaModel
 from gensim.parsing.preprocessing import preprocess_string
+from qdrant_loader.core.text_processing import spacy_model_cache
 from spacy.cli.download import download as spacy_download
 from spacy.tokens import Doc
 
@@ -61,13 +62,22 @@ class SemanticAnalyzer:
         """
         self.logger = logging.getLogger(__name__)
 
-        # Initialize spaCy
-        try:
-            self.nlp = spacy.load(spacy_model)
-        except OSError:
-            self.logger.info(f"Downloading spaCy model {spacy_model}...")
-            spacy_download(spacy_model)
-            self.nlp = spacy.load(spacy_model)
+        # Initialize spaCy. Cached and shared across instances -- a
+        # SemanticAnalyzer is constructed fresh per document (via
+        # ChunkProcessor), and spacy.load() is too expensive to repeat for
+        # every one of them.
+        def _load_nlp():
+            try:
+                nlp = spacy.load(spacy_model)
+            except OSError:
+                self.logger.info(f"Downloading spaCy model {spacy_model}...")
+                spacy_download(spacy_model)
+                nlp = spacy.load(spacy_model)
+            return nlp
+
+        self.nlp = spacy_model_cache.get_or_load(
+            ("semantic_analyzer", spacy_model), _load_nlp
+        )
 
         # Initialize LDA parameters
         self.num_topics = num_topics

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/spacy_model_cache.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/spacy_model_cache.py
@@ -1,0 +1,51 @@
+"""Process-wide, thread-safe cache for loaded spaCy models.
+
+``spacy.load()`` is expensive (disk read + model deserialization, often
+hundreds of milliseconds), and the returned ``Language`` object is safe to
+share for read-only inference across callers. Without this cache, callers
+like ``TextProcessor`` and ``SemanticAnalyzer`` were re-loading a model on
+every construction -- which happens once per document, since chunking
+strategies (and therefore their text processors) are instantiated per
+document. Because document chunking runs on a thread pool, that repeated,
+heavy CPU-bound load also serializes chunk-worker threads on the GIL,
+defeating ``max_chunk_workers`` concurrency.
+
+The cache is held under a lock only while the first load for a given key is
+in flight, so concurrent callers block and share that one load instead of
+each independently loading the model.
+"""
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+_cache: dict[Any, Any] = {}
+_lock = threading.Lock()
+
+
+def get_or_load(cache_key: Any, loader: Callable[[], Any]) -> Any:
+    """Return the cached value for ``cache_key``, loading it via ``loader()`` once.
+
+    ``loader`` is only ever invoked on a cache miss, and is called by the
+    caller's own module so provider-specific error handling (e.g. an
+    OSError-triggered model download) stays where it already is.
+    """
+    cached = _cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    with _lock:
+        # Re-check: another thread may have populated it while we waited.
+        cached = _cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        value = loader()
+        _cache[cache_key] = value
+        return value
+
+
+def clear() -> None:
+    """Clear all cached models. Intended for test isolation."""
+    with _lock:
+        _cache.clear()

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/text_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/text_processor.py
@@ -4,6 +4,7 @@ import nltk
 import spacy
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from qdrant_loader.config import Settings
+from qdrant_loader.core.text_processing import spacy_model_cache
 from qdrant_loader.utils.logging import LoggingConfig
 from spacy.cli.download import download
 
@@ -36,28 +37,29 @@ class TextProcessor:
         except LookupError:
             nltk.download("stopwords")
 
-        # Load spaCy model with optimized settings
+        # Load spaCy model with optimized settings. Cached and shared across
+        # instances -- TextProcessor is constructed fresh per document, and
+        # spacy.load() is too expensive to repeat for every one of them.
         spacy_model = settings.global_config.semantic_analysis.spacy_model
-        try:
-            self.nlp = spacy.load(spacy_model)
-            # Optimize spaCy pipeline for speed
-            # Select only essential components for faster processing
-            if "parser" in self.nlp.pipe_names:
-                # Keep only essential components: tokenizer, tagger, ner (exclude parser)
-                essential_pipes = [
-                    pipe for pipe in self.nlp.pipe_names if pipe != "parser"
-                ]
-                self.nlp.select_pipes(enable=essential_pipes)
-        except OSError:
-            logger.info(f"Downloading spaCy model {spacy_model}...")
-            download(spacy_model)
-            self.nlp = spacy.load(spacy_model)
-            if "parser" in self.nlp.pipe_names:
-                # Keep only essential components: tokenizer, tagger, ner (exclude parser)
-                essential_pipes = [
-                    pipe for pipe in self.nlp.pipe_names if pipe != "parser"
-                ]
-                self.nlp.select_pipes(enable=essential_pipes)
+
+        def _load_nlp():
+            try:
+                nlp = spacy.load(spacy_model)
+            except OSError:
+                logger.info(f"Downloading spaCy model {spacy_model}...")
+                download(spacy_model)
+                nlp = spacy.load(spacy_model)
+
+            # Optimize spaCy pipeline for speed: keep only essential
+            # components (tokenizer, tagger, ner), excluding the parser.
+            if "parser" in nlp.pipe_names:
+                essential_pipes = [pipe for pipe in nlp.pipe_names if pipe != "parser"]
+                nlp.select_pipes(enable=essential_pipes)
+            return nlp
+
+        self.nlp = spacy_model_cache.get_or_load(
+            ("text_processor", spacy_model), _load_nlp
+        )
 
         # Initialize LangChain text splitter with configuration from settings
         self.text_splitter = RecursiveCharacterTextSplitter(

--- a/packages/qdrant-loader/tests/conftest.py
+++ b/packages/qdrant-loader/tests/conftest.py
@@ -79,6 +79,23 @@ def setup_test_environment():
         shutil.rmtree(data_dir)
 
 
+@pytest.fixture(autouse=True)
+def _clear_spacy_model_cache():
+    """Clear the process-wide spaCy model cache before every test.
+
+    Many tests patch spacy.load / spacy_download and assert on call counts
+    or specific mock return values. Without resetting this cache, only the
+    first test to request a given (variant, model_name) key would ever call
+    the mock -- every later test would silently see that first test's cached
+    (mocked) model instead of its own.
+    """
+    from qdrant_loader.core.text_processing import spacy_model_cache
+
+    spacy_model_cache.clear()
+    yield
+    spacy_model_cache.clear()
+
+
 @pytest.fixture(scope="session")
 def test_settings():
     """Get test settings."""

--- a/packages/qdrant-loader/tests/unit/config/test_concurrency_config.py
+++ b/packages/qdrant-loader/tests/unit/config/test_concurrency_config.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from qdrant_loader.config.concurrency import ConcurrencyConfig
+from qdrant_loader.config.global_config import GlobalConfig
+
+
+def test_concurrency_config_defaults():
+    cfg = ConcurrencyConfig()
+    assert cfg.max_chunk_workers == 10
+    assert cfg.max_embed_workers == 4
+    assert cfg.max_upsert_workers == 4
+    assert cfg.queue_size == 1000
+    assert cfg.upsert_batch_size is None
+
+
+def test_concurrency_config_accepts_overrides():
+    cfg = ConcurrencyConfig(
+        max_chunk_workers=20,
+        max_embed_workers=8,
+        max_upsert_workers=6,
+        queue_size=500,
+        upsert_batch_size=100,
+    )
+    assert cfg.max_chunk_workers == 20
+    assert cfg.max_embed_workers == 8
+    assert cfg.max_upsert_workers == 6
+    assert cfg.queue_size == 500
+    assert cfg.upsert_batch_size == 100
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["max_chunk_workers", "max_embed_workers", "max_upsert_workers", "queue_size"],
+)
+def test_concurrency_config_rejects_non_positive_values(field):
+    with pytest.raises(ValidationError):
+        ConcurrencyConfig(**{field: 0})
+
+
+def test_concurrency_config_rejects_non_positive_upsert_batch_size():
+    with pytest.raises(ValidationError):
+        ConcurrencyConfig(upsert_batch_size=0)
+
+
+def test_global_config_includes_concurrency_defaults():
+    cfg = GlobalConfig(skip_validation=True)
+    assert isinstance(cfg.concurrency, ConcurrencyConfig)
+    assert cfg.concurrency.max_embed_workers == 4
+    assert cfg.concurrency.max_upsert_workers == 4
+
+
+def test_global_config_to_dict_includes_concurrency():
+    cfg = GlobalConfig(skip_validation=True)
+    data = cfg.to_dict()
+    assert data["concurrency"]["max_chunk_workers"] == 10
+    assert data["concurrency"]["max_embed_workers"] == 4
+    assert data["concurrency"]["max_upsert_workers"] == 4
+    assert data["concurrency"]["queue_size"] == 1000
+    assert data["concurrency"]["upsert_batch_size"] is None
+
+
+def test_global_config_parses_concurrency_from_dict():
+    cfg = GlobalConfig(
+        skip_validation=True,
+        concurrency={
+            "max_chunk_workers": 15,
+            "max_embed_workers": 12,
+            "max_upsert_workers": 8,
+            "queue_size": 2000,
+            "upsert_batch_size": 250,
+        },
+    )
+    assert cfg.concurrency.max_chunk_workers == 15
+    assert cfg.concurrency.max_embed_workers == 12
+    assert cfg.concurrency.max_upsert_workers == 8
+    assert cfg.concurrency.queue_size == 2000
+    assert cfg.concurrency.upsert_batch_size == 250

--- a/packages/qdrant-loader/tests/unit/core/embedding/test_embedding_service.py
+++ b/packages/qdrant-loader/tests/unit/core/embedding/test_embedding_service.py
@@ -25,6 +25,7 @@ def mock_settings():
     embedding_config.vector_size = 1536
     embedding_config.max_tokens_per_request = 8000
     embedding_config.max_tokens_per_chunk = 8000
+    embedding_config.min_request_interval = 0.5
     embedding_config.api_key = "test-key"
 
     # Attach embedding config to global config
@@ -238,6 +239,7 @@ async def test_rate_limiting():
     global_config = MagicMock()
     embedding_config = MagicMock()
     embedding_config.endpoint = "http://localhost:8000"
+    embedding_config.min_request_interval = 0.5
     global_config.embedding = embedding_config
 
     settings = MagicMock(spec=Settings)
@@ -251,6 +253,29 @@ async def test_rate_limiting():
     end_time = asyncio.get_event_loop().time()
 
     assert end_time - start_time >= 0.5  # Minimum interval is 500ms
+
+
+@pytest.mark.asyncio
+async def test_rate_limiting_uses_configured_interval():
+    """min_request_interval should come from EmbeddingConfig, not a hardcoded value."""
+    global_config = MagicMock()
+    embedding_config = MagicMock()
+    embedding_config.endpoint = "http://localhost:8000"
+    embedding_config.min_request_interval = 0.05
+    global_config.embedding = embedding_config
+
+    settings = MagicMock(spec=Settings)
+    settings.global_config = global_config
+
+    service = EmbeddingService(settings)
+    assert service.min_request_interval == 0.05
+
+    start_time = asyncio.get_event_loop().time()
+    await service._apply_rate_limit()
+    await service._apply_rate_limit()
+    end_time = asyncio.get_event_loop().time()
+
+    assert 0.05 <= end_time - start_time < 0.5
 
 
 def test_count_tokens_with_tokenizer(mock_settings):

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_async_ingestion_pipeline.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_async_ingestion_pipeline.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from qdrant_loader.config import Settings
+from qdrant_loader.config.concurrency import ConcurrencyConfig
 from qdrant_loader.core.async_ingestion_pipeline import AsyncIngestionPipeline
 from qdrant_loader.core.document import Document
 from qdrant_loader.core.qdrant_manager import QdrantManager
@@ -31,6 +32,9 @@ class TestAsyncIngestionPipeline:
         settings.global_config.state_management = Mock()
         settings.global_config.qdrant = Mock()
         settings.global_config.qdrant.collection_name = "test_collection"
+        # Real config object (not a Mock) so unset constructor args fall back
+        # to real default values instead of auto-generated Mock attributes.
+        settings.global_config.concurrency = ConcurrencyConfig()
         settings.projects_config = Mock()
         return settings
 
@@ -780,3 +784,71 @@ class TestAsyncIngestionPipeline:
             assert config.queue_size == 1000  # Default
             assert config.upsert_batch_size is None  # Default
             assert config.enable_metrics is False  # Default
+
+    def test_pipeline_config_sourced_from_settings_concurrency(
+        self, mock_settings, mock_qdrant_manager
+    ):
+        """Unset constructor args must fall back to settings.global_config.concurrency.
+
+        This is what makes max_embed_workers/max_upsert_workers actually
+        configurable via settings.yaml instead of being stuck at whatever
+        literal defaults AsyncIngestionPipeline.__init__ happens to declare.
+        """
+        mock_settings.global_config.concurrency = ConcurrencyConfig(
+            max_chunk_workers=20,
+            max_embed_workers=12,
+            max_upsert_workers=9,
+            queue_size=5000,
+            upsert_batch_size=333,
+        )
+
+        with (
+            patch(
+                "qdrant_loader.core.async_ingestion_pipeline.PipelineComponentsFactory"
+            ),
+            patch("qdrant_loader.core.async_ingestion_pipeline.PipelineOrchestrator"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.ResourceManager"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.IngestionMonitor"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.prometheus_metrics"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.Path"),
+        ):
+            pipeline = AsyncIngestionPipeline(
+                settings=mock_settings,
+                qdrant_manager=mock_qdrant_manager,
+            )
+
+            config = pipeline.pipeline_config
+            assert config.max_chunk_workers == 20
+            assert config.max_embed_workers == 12
+            assert config.max_upsert_workers == 9
+            assert config.queue_size == 5000
+            assert config.upsert_batch_size == 333
+
+    def test_pipeline_config_explicit_args_override_settings_concurrency(
+        self, mock_settings, mock_qdrant_manager
+    ):
+        """An explicitly passed constructor arg still wins over settings.yaml."""
+        mock_settings.global_config.concurrency = ConcurrencyConfig(
+            max_embed_workers=12,
+            max_upsert_workers=9,
+        )
+
+        with (
+            patch(
+                "qdrant_loader.core.async_ingestion_pipeline.PipelineComponentsFactory"
+            ),
+            patch("qdrant_loader.core.async_ingestion_pipeline.PipelineOrchestrator"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.ResourceManager"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.IngestionMonitor"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.prometheus_metrics"),
+            patch("qdrant_loader.core.async_ingestion_pipeline.Path"),
+        ):
+            pipeline = AsyncIngestionPipeline(
+                settings=mock_settings,
+                qdrant_manager=mock_qdrant_manager,
+                max_embed_workers=2,
+            )
+
+            config = pipeline.pipeline_config
+            assert config.max_embed_workers == 2
+            assert config.max_upsert_workers == 9  # still sourced from settings

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -743,6 +743,9 @@ class TestPipelineOrchestrator:
 
         # Setup state manager
         self.state_manager._initialized = False
+        self.state_manager.update_document_states_batch.side_effect = (
+            lambda docs, project_id: [(doc, Mock(), None) for doc in docs]
+        )
 
         # Execute
         await self.orchestrator._update_document_states(
@@ -751,12 +754,9 @@ class TestPipelineOrchestrator:
 
         # Verify
         self.state_manager.initialize.assert_called_once()
-        # Should update states for doc1 and doc3 only
-        assert self.state_manager.update_document_state.call_count == 2
-        updated_docs = [
-            call.args[0]
-            for call in self.state_manager.update_document_state.call_args_list
-        ]
+        # Should update states for doc1 and doc3 only, in a single batch call
+        self.state_manager.update_document_states_batch.assert_called_once()
+        updated_docs = self.state_manager.update_document_states_batch.call_args.args[0]
         updated_doc_ids = {doc.id for doc in updated_docs}
         assert updated_doc_ids == {"doc1", "doc3"}
 
@@ -768,14 +768,17 @@ class TestPipelineOrchestrator:
 
         # Setup state manager as already initialized
         self.state_manager._initialized = True
+        self.state_manager.update_document_states_batch.side_effect = (
+            lambda docs, project_id: [(doc, Mock(), None) for doc in docs]
+        )
 
         # Execute
         await self.orchestrator._update_document_states(mock_documents, successfully_processed_doc_ids, None)  # type: ignore
 
         # Verify
         self.state_manager.initialize.assert_not_called()
-        self.state_manager.update_document_state.assert_called_once_with(
-            mock_documents[0], None
+        self.state_manager.update_document_states_batch.assert_called_once_with(
+            mock_documents, None
         )
 
     @pytest.mark.asyncio
@@ -790,17 +793,19 @@ class TestPipelineOrchestrator:
         # Setup state manager
         self.state_manager._initialized = True
 
-        # Configure one update to fail
-        self.state_manager.update_document_state.side_effect = [
-            None,  # Success for doc1
-            Exception("Update failed for doc2"),  # Failure for doc2
+        # Configure one document's update to fail within the batch
+        self.state_manager.update_document_states_batch.return_value = [
+            (mock_documents[0], Mock(), None),  # Success for doc1
+            (mock_documents[1], None, Exception("Update failed for doc2")),
         ]
 
         # Execute (should not raise exception)
         await self.orchestrator._update_document_states(mock_documents, successfully_processed_doc_ids, None)  # type: ignore
 
-        # Verify both updates were attempted
-        assert self.state_manager.update_document_state.call_count == 2
+        # Verify both documents were included in the single batch call
+        self.state_manager.update_document_states_batch.assert_called_once_with(
+            mock_documents, None
+        )
 
     @pytest.mark.asyncio
     async def test_update_document_states_empty_success_set(self):
@@ -814,8 +819,8 @@ class TestPipelineOrchestrator:
         # Execute
         await self.orchestrator._update_document_states(mock_documents, successfully_processed_doc_ids, None)  # type: ignore
 
-        # Verify no updates were attempted (but initialization was called)
-        self.state_manager.update_document_state.assert_not_called()
+        # Verify no batch update was attempted (but initialization was called)
+        self.state_manager.update_document_states_batch.assert_not_called()
         self.state_manager.initialize.assert_called_once()
 
     @pytest.mark.asyncio

--- a/packages/qdrant-loader/tests/unit/core/state/test_state_manager.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_state_manager.py
@@ -154,6 +154,109 @@ async def test_update_document_state(state_manager, sample_document):
 
 
 @pytest.mark.asyncio
+async def test_update_document_states_batch_success(state_manager):
+    """A batch update commits all documents and returns their records."""
+    documents = [
+        Document(
+            id=f"batch-doc-{i}",
+            title=f"Doc {i}",
+            content=f"Content {i}",
+            content_type="text/plain",
+            source_type="test",
+            source="test-source",
+            url=f"http://test.com/doc{i}",
+            metadata={},
+        )
+        for i in range(3)
+    ]
+
+    results = await state_manager.update_document_states_batch(documents)
+
+    assert len(results) == 3
+    for doc, record, error in results:
+        assert error is None
+        assert record is not None
+        assert record.document_id == doc.id
+
+    for doc in documents:
+        stored = await state_manager.get_document_state_record(
+            source_type="test", source="test-source", document_id=doc.id
+        )
+        assert stored is not None
+
+
+@pytest.mark.asyncio
+async def test_update_document_states_batch_isolates_per_document_failure(
+    state_manager,
+):
+    """One document's failure must not prevent the others from being committed."""
+    documents = [
+        Document(
+            id="good-doc-1",
+            title="Good 1",
+            content="Content",
+            content_type="text/plain",
+            source_type="test",
+            source="test-source",
+            url="http://test.com/good1",
+            metadata={},
+        ),
+        Document(
+            id="bad-doc",
+            title="Bad",
+            content="Content",
+            content_type="text/plain",
+            source_type="test",
+            source="test-source",
+            url="http://test.com/bad",
+            metadata={},
+        ),
+        Document(
+            id="good-doc-2",
+            title="Good 2",
+            content="Content",
+            content_type="text/plain",
+            source_type="test",
+            source="test-source",
+            url="http://test.com/good2",
+            metadata={},
+        ),
+    ]
+
+    from qdrant_loader.core.state import transitions as _transitions
+
+    original_apply = _transitions._apply_document_state_update
+
+    async def failing_apply(session, *, document, project_id):
+        if document.id == "bad-doc":
+            raise RuntimeError("simulated failure")
+        return await original_apply(session, document=document, project_id=project_id)
+
+    with patch.object(
+        _transitions, "_apply_document_state_update", side_effect=failing_apply
+    ):
+        results = await state_manager.update_document_states_batch(documents)
+
+    results_by_id = {doc.id: error for doc, _record, error in results}
+    assert results_by_id["good-doc-1"] is None
+    assert results_by_id["bad-doc"] is not None
+    assert results_by_id["good-doc-2"] is None
+
+    good1 = await state_manager.get_document_state_record(
+        source_type="test", source="test-source", document_id="good-doc-1"
+    )
+    good2 = await state_manager.get_document_state_record(
+        source_type="test", source="test-source", document_id="good-doc-2"
+    )
+    bad = await state_manager.get_document_state_record(
+        source_type="test", source="test-source", document_id="bad-doc"
+    )
+    assert good1 is not None
+    assert good2 is not None
+    assert bad is None
+
+
+@pytest.mark.asyncio
 async def test_mark_document_deleted(state_manager, sample_document):
     """Test marking a document as deleted."""
     # First create the document state


### PR DESCRIPTION
# Pull Request

## Summary

Bring out config for embedding worker and upsert worker to global
Set config for `min_request_interval` for embedding model rather than give fixed value (0.5s)

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Docs update
- [ ] Chore