### PR TITLE
chore(docker): update docker for v1.0.4 base on feedback

### DIFF
--- a/docker/Dockerfile.dev.qdrant-loader
+++ b/docker/Dockerfile.dev.qdrant-loader
@@ -1,4 +1,4 @@
-FROM astral/uv:python3.12-bookworm-slim AS base
+FROM ghcr.io/astral-sh/uv:0.11.28-python3.12-trixie-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 

--- a/docker/Dockerfile.dev.qdrant-loader
+++ b/docker/Dockerfile.dev.qdrant-loader
@@ -1,8 +1,6 @@
-FROM python:3.12.13-slim AS base
+FROM astral/uv:python3.12-bookworm-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
-
-COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /bin/
 
 WORKDIR /qdrant-loader
 
@@ -10,7 +8,7 @@ COPY uv.lock pyproject.toml README.md* LICENSE* ./
 COPY packages/qdrant-loader-core /qdrant-loader/packages/qdrant-loader-core
 COPY packages/qdrant-loader /qdrant-loader/packages/qdrant-loader
 
-RUN uv sync  --frozen --package qdrant-loader --package qdrant-loader-core --all-extras --no-dev --no-cache --no-install-project \
+RUN uv sync  --frozen --package qdrant-loader --package qdrant-loader-core --all-extras --no-dev --no-install-project \
     && .venv/bin/python -m spacy download en_core_web_md
 
 
@@ -43,8 +41,6 @@ USER appuser
 COPY --chown=appuser:appuser --from=base /qdrant-loader/.venv /qdrant-loader/.venv
 COPY --chown=appuser:appuser packages/qdrant-loader-core /qdrant-loader/packages/qdrant-loader-core
 COPY --chown=appuser:appuser packages/qdrant-loader /qdrant-loader/packages/qdrant-loader
-
-RUN chmod +x /qdrant-loader/packages/qdrant-loader/entrypoint.sh
 
 ENV PATH="/qdrant-loader/.venv/bin:$PATH"
 

--- a/docker/Dockerfile.dev.qdrant-loader-mcp-server
+++ b/docker/Dockerfile.dev.qdrant-loader-mcp-server
@@ -1,8 +1,6 @@
-FROM python:3.12.13-slim AS base
+FROM ghcr.io/astral-sh/uv:0.11.28-python3.12-trixie-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
-
-COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /bin/
 
 WORKDIR /qdrant-loader-mcp-server
 

--- a/docker/Dockerfile.dev.qdrant-loader-mcp-server
+++ b/docker/Dockerfile.dev.qdrant-loader-mcp-server
@@ -10,7 +10,7 @@ COPY uv.lock pyproject.toml README.md* LICENSE* ./
 COPY packages/qdrant-loader-core /qdrant-loader-mcp-server/packages/qdrant-loader-core
 COPY packages/qdrant-loader-mcp-server /qdrant-loader-mcp-server/packages/qdrant-loader-mcp-server
 
-RUN uv sync  --frozen --package qdrant-loader-mcp-server --package qdrant-loader-core --all-extras --no-dev --no-cache --no-install-project \
+RUN uv sync  --frozen --package qdrant-loader-mcp-server --package qdrant-loader-core --all-extras --no-dev --no-install-project \
     && .venv/bin/python -m spacy download en_core_web_md
 
 RUN find /qdrant-loader-mcp-server/.venv -name "*.a" -delete && \

--- a/docker/Dockerfile.qdrant-loader
+++ b/docker/Dockerfile.qdrant-loader
@@ -26,9 +26,9 @@ USER appuser
 ARG QDRANT_LOADER_VERSION=latest
 
 RUN if [ "$QDRANT_LOADER_VERSION" = "latest" ]; then \
-       pip install --no-cache-dir qdrant-loader; \
+       pip install --no-cache-dir "qdrant-loader[postgres,server]"; \
      else \
-       pip install --no-cache-dir "qdrant-loader==${QDRANT_LOADER_VERSION}"; \
+       pip install --no-cache-dir "qdrant-loader[postgres,server]==${QDRANT_LOADER_VERSION}"; \
      fi && \
      python -m spacy download en_core_web_md
 

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -56,7 +56,7 @@ services:
     ports:
       # Bind to loopback only: internal services reach Postgres over qdrant-net;
       # this avoids exposing the DB to the host's network.
-      - "127.0.0.1:5432:5432"
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -53,8 +53,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-qdrant_loader}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (see .env.example)}
       - POSTGRES_DB=${POSTGRES_DB:-qdrant_loader}
-    ports:
-      - "5432:5432"
+    expose:
+      - "5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -54,8 +54,6 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (see .env.example)}
       - POSTGRES_DB=${POSTGRES_DB:-qdrant_loader}
     ports:
-      # Bind to loopback only: internal services reach Postgres over qdrant-net;
-      # this avoids exposing the DB to the host's network.
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
     ports:
       # Bind to loopback only: internal services reach Postgres over qdrant-net;
       # this avoids exposing the DB to the host's network.
-      - "127.0.0.1:5432:5432"
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -53,8 +53,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-qdrant_loader}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (see .env.example)}
       - POSTGRES_DB=${POSTGRES_DB:-qdrant_loader}
-    ports:
-      - "5432:5432"
+    expose:
+      - "5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -54,8 +54,6 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (see .env.example)}
       - POSTGRES_DB=${POSTGRES_DB:-qdrant_loader}
     ports:
-      # Bind to loopback only: internal services reach Postgres over qdrant-net;
-      # this avoids exposing the DB to the host's network.
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data


### PR DESCRIPTION
# Pull Request

## Summary

Update docker for v1.0.4 base on feedback

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [x] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Affected areas: Docker build/runtime setup for `qdrant-loader` and `qdrant-loader-mcp-server`, plus the `postgres` service in both `docker-compose.dev.yaml` and `docker-compose.yaml`. Pipeline/connector behavior isn’t directly changed, but the `qdrant-loader` container now installs `qdrant-loader` with `postgres` and `server` extras (including pinned-version handling), which adds required dependencies for those integrations.  

Config/schema changes: no application config schema changes. Compose networking behavior changed: `postgres` no longer publishes `5432` to the host; it now uses `expose` for `5432`, limiting access to other containers on the compose network (removing prior loopback/host binding).  

Tests: no test/coverage information provided for these Docker paths.  

Security/resource-safety: reduced host attack surface for Postgres by removing host port binding; ensure compose-network access is acceptable. Minor Docker build adjustments (uv base image/sync flags, removal of `chmod +x` on the entrypoint) could affect runtime execution if permissions aren’t already correct in the image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->