### PR TITLE
fix(state): prevent sqlite commit conflicts in serve queue workers

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/jobs_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/jobs_cmd.py
@@ -64,7 +64,10 @@ async def _run_with_queue(workspace, config, env, coro_factory):
     try:
         from qdrant_loader.core.worker.queue import SQLiteJobQueue
 
-        queue_instance = SQLiteJobQueue(state_manager.session_factory)
+        queue_instance = SQLiteJobQueue(
+            state_manager.session_factory,
+            db_op_lock=state_manager.queue_db_op_lock,
+        )
         return await coro_factory(queue_instance)
     finally:
         await state_manager.dispose()

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
@@ -147,7 +147,10 @@ async def _serve_main(
 
     logger.info("serve.queue_init")
     session_factory = state_manager.session_factory
-    job_queue = SQLiteJobQueue(session_factory)
+    job_queue = SQLiteJobQueue(
+        session_factory,
+        db_op_lock=state_manager.queue_db_op_lock,
+    )
 
     logger.info("serve.qdrant_init")
     qdrant_manager = QdrantManager(settings)

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/session.py
@@ -21,12 +21,22 @@ def initialize_engine_and_session(
     database_url = generate_database_url(config)
 
     if database_url.startswith("sqlite"):
-        engine = create_async_engine(
-            database_url,
-            poolclass=StaticPool,
-            connect_args={"check_same_thread": False},
-            echo=False,
-        )
+        is_in_memory = ":memory:" in database_url or "mode=memory" in database_url
+        connect_args = {"check_same_thread": False, "timeout": 30}
+
+        if is_in_memory:
+            engine = create_async_engine(
+                database_url,
+                poolclass=StaticPool,
+                connect_args=connect_args,
+                echo=False,
+            )
+        else:
+            engine = create_async_engine(
+                database_url,
+                connect_args=connect_args,
+                echo=False,
+            )
     else:
         # asyncpg is an optional dependency (the `postgres` extra), imported
         # lazily only on the Postgres path so SQLite installs don't need it.

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
@@ -2,6 +2,8 @@
 State management service for tracking document ingestion state.
 """
 
+import asyncio
+
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -35,6 +37,7 @@ class StateManager:
         self._initialized = False
         self._engine: AsyncEngine | None = None
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
+        self._queue_db_op_lock = asyncio.Lock()
         self.logger = LoggingConfig.get_logger(__name__)
 
     @property
@@ -48,6 +51,11 @@ class StateManager:
         if self._session_factory is None:
             raise RuntimeError("State manager session factory is not initialized")
         return self._session_factory
+
+    @property
+    def queue_db_op_lock(self) -> asyncio.Lock:
+        """Shared lock for queue DB operations on this state backend."""
+        return self._queue_db_op_lock
 
     async def get_session(self) -> "AsyncSession":
         """Return an async session context manager, initializing if needed.

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -94,13 +94,18 @@ class SQLiteJobQueue:
     FAILED = "failed"
     CANCELLED = "cancelled"
 
-    def __init__(self, session_factory: async_sessionmaker[AsyncSession]):
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        db_op_lock: asyncio.Lock,
+    ):
         self._session_factory = session_factory
         self._pending_event = asyncio.Event()
         # Serialize queue DB operations for SQLite-backed state stores.
-        # This avoids cross-task commit/statement conflicts when multiple
-        # workers (ingestion + webhook) operate on a shared queue.
-        self._db_op_lock = asyncio.Lock()
+        # Lock is injected by the shared owner (e.g. StateManager) so
+        # multiple SQLiteJobQueue instances that share a backend also share
+        # the same DB-operation lock.
+        self._db_op_lock = db_op_lock
 
     def notify(self) -> asyncio.Event:
         """Return the event used to signal when jobs become available."""
@@ -133,26 +138,34 @@ class SQLiteJobQueue:
     ) -> Job | None:
         if lease_seconds < 0:
             raise ValueError("lease_seconds must be non-negative")
-        now = datetime.now(UTC)
-        visibility_deadline = now + timedelta(seconds=lease_seconds)
-        claimable_filter = or_(
-            (Job.status == self.PENDING)
-            & ((Job.visibility_deadline.is_(None)) | (Job.visibility_deadline <= now)),
-            (Job.status == self.RUNNING) & (Job.visibility_deadline <= now),
-        )
 
         type_filter = Job.type.in_(job_types) if job_types else None
-        candidate_query = select(Job.id).where(claimable_filter)
-        if type_filter is not None:
-            candidate_query = candidate_query.where(type_filter)
-
-        candidate_job_id_subquery = (
-            candidate_query.order_by(Job.enqueued_at.asc(), Job.id.asc())
-            .limit(1)
-            .scalar_subquery()
-        )
 
         async with self._db_op_lock:
+            # Compute timestamps inside the lock so they reflect the actual
+            # moment the claim executes, not the moment the caller enqueued
+            # the coroutine (which may have waited for the lock).
+            now = datetime.now(UTC)
+            visibility_deadline = now + timedelta(seconds=lease_seconds)
+            claimable_filter = or_(
+                (Job.status == self.PENDING)
+                & (
+                    (Job.visibility_deadline.is_(None))
+                    | (Job.visibility_deadline <= now)
+                ),
+                (Job.status == self.RUNNING) & (Job.visibility_deadline <= now),
+            )
+
+            candidate_query = select(Job.id).where(claimable_filter)
+            if type_filter is not None:
+                candidate_query = candidate_query.where(type_filter)
+
+            candidate_job_id_subquery = (
+                candidate_query.order_by(Job.enqueued_at.asc(), Job.id.asc())
+                .limit(1)
+                .scalar_subquery()
+            )
+
             async with self._session_factory() as session:
                 where_clauses = [Job.id == candidate_job_id_subquery, claimable_filter]
                 if type_filter is not None:

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -97,31 +97,36 @@ class SQLiteJobQueue:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]):
         self._session_factory = session_factory
         self._pending_event = asyncio.Event()
+        # Serialize queue DB operations for SQLite-backed state stores.
+        # This avoids cross-task commit/statement conflicts when multiple
+        # workers (ingestion + webhook) operate on a shared queue.
+        self._db_op_lock = asyncio.Lock()
 
     def notify(self) -> asyncio.Event:
         """Return the event used to signal when jobs become available."""
         return self._pending_event
 
     async def enqueue(self, job_type: str, payload: dict[str, Any]) -> Job:
-        now = datetime.now(UTC)
-        job = Job(
-            type=job_type,
-            payload_json=json.dumps(payload, ensure_ascii=False, sort_keys=True),
-            status=self.PENDING,
-            enqueued_at=now,
-            attempts=0,
-            started_at=None,
-            finished_at=None,
-            last_error=None,
-            visibility_deadline=None,
-        )
+        async with self._db_op_lock:
+            now = datetime.now(UTC)
+            job = Job(
+                type=job_type,
+                payload_json=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                status=self.PENDING,
+                enqueued_at=now,
+                attempts=0,
+                started_at=None,
+                finished_at=None,
+                last_error=None,
+                visibility_deadline=None,
+            )
 
-        async with self._session_factory() as session:
-            session.add(job)
-            await session.commit()
-            await session.refresh(job)
-            self._pending_event.set()
-            return job
+            async with self._session_factory() as session:
+                session.add(job)
+                await session.commit()
+                await session.refresh(job)
+                self._pending_event.set()
+                return job
 
     async def claim_next(
         self, lease_seconds: int = 60, job_types: list[str] | None = None
@@ -147,82 +152,85 @@ class SQLiteJobQueue:
             .scalar_subquery()
         )
 
-        async with self._session_factory() as session:
-            where_clauses = [Job.id == candidate_job_id_subquery, claimable_filter]
-            if type_filter is not None:
-                where_clauses.append(type_filter)
+        async with self._db_op_lock:
+            async with self._session_factory() as session:
+                where_clauses = [Job.id == candidate_job_id_subquery, claimable_filter]
+                if type_filter is not None:
+                    where_clauses.append(type_filter)
 
-            result = await session.execute(
-                update(Job)
-                .where(*where_clauses)
-                .values(
-                    status=self.RUNNING,
-                    started_at=now,
-                    finished_at=None,
-                    visibility_deadline=visibility_deadline,
-                    attempts=Job.attempts + 1,
-                    last_error=None,
+                result = await session.execute(
+                    update(Job)
+                    .where(*where_clauses)
+                    .values(
+                        status=self.RUNNING,
+                        started_at=now,
+                        finished_at=None,
+                        visibility_deadline=visibility_deadline,
+                        attempts=Job.attempts + 1,
+                        last_error=None,
+                    )
+                    .returning(Job.id)
                 )
-                .returning(Job.id)
-            )
 
-            # SQLite requires RETURNING cursors to be finalized before commit.
-            try:
-                claimed_job_id = result.scalar_one_or_none()
-            finally:
-                result.close()
+                # SQLite requires RETURNING cursors to be finalized before commit.
+                try:
+                    claimed_job_id = result.scalar_one_or_none()
+                finally:
+                    result.close()
 
-            if claimed_job_id is None:
+                if claimed_job_id is None:
+                    await session.commit()
+                    return None
+
+                claimed_job = await session.get(Job, claimed_job_id)
                 await session.commit()
-                return None
-
-            claimed_job = await session.get(Job, claimed_job_id)
-            await session.commit()
-            return claimed_job
+                return claimed_job
 
     async def mark_done(self, job_id: int, claim_attempt: int) -> bool:
-        now = datetime.now(UTC)
-        async with self._session_factory() as session:
-            result = await session.execute(
-                update(Job)
-                .where(
-                    Job.id == job_id,
-                    Job.status == self.RUNNING,
-                    Job.attempts == claim_attempt,
+        async with self._db_op_lock:
+            now = datetime.now(UTC)
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status == self.RUNNING,
+                        Job.attempts == claim_attempt,
+                    )
+                    .values(
+                        status=self.DONE,
+                        finished_at=now,
+                        visibility_deadline=None,
+                        last_error=None,
+                    )
                 )
-                .values(
-                    status=self.DONE,
-                    finished_at=now,
-                    visibility_deadline=None,
-                    last_error=None,
-                )
-            )
-            updated = result.rowcount > 0
-            await session.commit()
-            return updated
+                updated = result.rowcount > 0
+                await session.commit()
+                return updated
 
     async def mark_failed(
         self, job_id: int, error_message: str, claim_attempt: int
     ) -> bool:
-        now = datetime.now(UTC)
-        async with self._session_factory() as session:
-            result = await session.execute(
-                update(Job)
-                .where(
-                    Job.id == job_id,
-                    Job.status == self.RUNNING,
-                    Job.attempts == claim_attempt,
+        async with self._db_op_lock:
+            now = datetime.now(UTC)
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status == self.RUNNING,
+                        Job.attempts == claim_attempt,
+                    )
+                    .values(
+                        status=self.FAILED,
+                        finished_at=now,
+                        visibility_deadline=None,
+                        last_error=error_message,
+                    )
                 )
-                .values(
-                    status=self.FAILED,
-                    finished_at=now,
-                    visibility_deadline=None,
-                    last_error=error_message,
-                )
-            )
-            updated = result.rowcount > 0
-            await session.commit()
-            return updated
+                updated = result.rowcount > 0
+                await session.commit()
+                return updated
 
     async def release_for_retry(
         self,
@@ -234,34 +242,35 @@ class SQLiteJobQueue:
         if retry_after_seconds < 0:
             raise ValueError("retry_after_seconds must be non-negative")
 
-        now = datetime.now(UTC)
-        retry_deadline = (
-            now + timedelta(seconds=retry_after_seconds)
-            if retry_after_seconds > 0
-            else None
-        )
-
-        async with self._session_factory() as session:
-            result = await session.execute(
-                update(Job)
-                .where(
-                    Job.id == job_id,
-                    Job.status == self.RUNNING,
-                    Job.attempts == claim_attempt,
-                )
-                .values(
-                    status=self.PENDING,
-                    started_at=None,
-                    finished_at=None,
-                    visibility_deadline=retry_deadline,
-                    last_error=error_message,
-                )
+        async with self._db_op_lock:
+            now = datetime.now(UTC)
+            retry_deadline = (
+                now + timedelta(seconds=retry_after_seconds)
+                if retry_after_seconds > 0
+                else None
             )
-            updated = result.rowcount > 0
-            await session.commit()
-            if updated:
-                self._pending_event.set()
-            return updated
+
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status == self.RUNNING,
+                        Job.attempts == claim_attempt,
+                    )
+                    .values(
+                        status=self.PENDING,
+                        started_at=None,
+                        finished_at=None,
+                        visibility_deadline=retry_deadline,
+                        last_error=error_message,
+                    )
+                )
+                updated = result.rowcount > 0
+                await session.commit()
+                if updated:
+                    self._pending_event.set()
+                return updated
 
     async def extend_visibility(
         self, job_id: int, lease_seconds: int, claim_attempt: int
@@ -271,24 +280,25 @@ class SQLiteJobQueue:
         Used to prevent lease expiration during long-running handler execution.
         Returns True if successfully extended, False if claim ownership changed.
         """
-        now = datetime.now(UTC)
-        new_deadline = now + timedelta(seconds=lease_seconds)
+        async with self._db_op_lock:
+            now = datetime.now(UTC)
+            new_deadline = now + timedelta(seconds=lease_seconds)
 
-        async with self._session_factory() as session:
-            result = await session.execute(
-                update(Job)
-                .where(
-                    Job.id == job_id,
-                    Job.status == self.RUNNING,
-                    Job.attempts == claim_attempt,
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status == self.RUNNING,
+                        Job.attempts == claim_attempt,
+                    )
+                    .values(
+                        visibility_deadline=new_deadline,
+                    )
                 )
-                .values(
-                    visibility_deadline=new_deadline,
-                )
-            )
-            updated = result.rowcount > 0
-            await session.commit()
-            return updated
+                updated = result.rowcount > 0
+                await session.commit()
+                return updated
 
     async def list(
         self, status: str | None = None, limit: int = 100, offset: int = 0
@@ -315,18 +325,19 @@ class SQLiteJobQueue:
                     break
                 offset += 1000
         """
-        async with self._session_factory() as session:
-            stmt = select(Job)
-            if status:
-                stmt = stmt.where(Job.status == status)
-            stmt = (
-                stmt.order_by(Job.enqueued_at.asc(), Job.id.asc())
-                .offset(offset)
-                .limit(limit)
-            )
+        async with self._db_op_lock:
+            async with self._session_factory() as session:
+                stmt = select(Job)
+                if status:
+                    stmt = stmt.where(Job.status == status)
+                stmt = (
+                    stmt.order_by(Job.enqueued_at.asc(), Job.id.asc())
+                    .offset(offset)
+                    .limit(limit)
+                )
 
-            result = await session.execute(stmt)
-            return list(result.scalars().all())
+                result = await session.execute(stmt)
+                return list(result.scalars().all())
 
     async def reset_to_pending(self, job_id: int) -> bool:
         """Reset a failed/done job back to pending for retry.
@@ -334,42 +345,44 @@ class SQLiteJobQueue:
         Preserve attempts so operator retries do not erase retry history.
         Does not reset CANCELLED jobs (operator must explicitly delete them).
         """
-        async with self._session_factory() as session:
-            result = await session.execute(
-                update(Job)
-                .where(
-                    Job.id == job_id,
-                    Job.status.in_([self.FAILED, self.DONE]),
+        async with self._db_op_lock:
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status.in_([self.FAILED, self.DONE]),
+                    )
+                    .values(
+                        status=self.PENDING,
+                        started_at=None,
+                        finished_at=None,
+                        visibility_deadline=None,
+                        last_error=None,
+                    )
                 )
-                .values(
-                    status=self.PENDING,
-                    started_at=None,
-                    finished_at=None,
-                    visibility_deadline=None,
-                    last_error=None,
-                )
-            )
-            updated = result.rowcount > 0
-            await session.commit()
-            return updated
+                updated = result.rowcount > 0
+                await session.commit()
+                return updated
 
     async def cancel(self, job_id: int) -> bool:
         """Cancel a pending job."""
-        now = datetime.now(UTC)
-        async with self._session_factory() as session:
-            result = await session.execute(
-                update(Job)
-                .where(
-                    Job.id == job_id,
-                    Job.status == self.PENDING,
+        async with self._db_op_lock:
+            now = datetime.now(UTC)
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    update(Job)
+                    .where(
+                        Job.id == job_id,
+                        Job.status == self.PENDING,
+                    )
+                    .values(
+                        status=self.CANCELLED,
+                        finished_at=now,
+                        visibility_deadline=None,
+                        last_error=None,
+                    )
                 )
-                .values(
-                    status=self.CANCELLED,
-                    finished_at=now,
-                    visibility_deadline=None,
-                    last_error=None,
-                )
-            )
-            updated = result.rowcount > 0
-            await session.commit()
-            return updated
+                updated = result.rowcount > 0
+                await session.commit()
+                return updated

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/queue.py
@@ -127,11 +127,15 @@ class SQLiteJobQueue:
             )
 
             async with self._session_factory() as session:
-                session.add(job)
-                await session.commit()
-                await session.refresh(job)
-                self._pending_event.set()
-                return job
+                try:
+                    session.add(job)
+                    await session.commit()
+                    await session.refresh(job)
+                    self._pending_event.set()
+                    return job
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def claim_next(
         self, lease_seconds: int = 60, job_types: list[str] | None = None
@@ -167,59 +171,67 @@ class SQLiteJobQueue:
             )
 
             async with self._session_factory() as session:
-                where_clauses = [Job.id == candidate_job_id_subquery, claimable_filter]
-                if type_filter is not None:
-                    where_clauses.append(type_filter)
-
-                result = await session.execute(
-                    update(Job)
-                    .where(*where_clauses)
-                    .values(
-                        status=self.RUNNING,
-                        started_at=now,
-                        finished_at=None,
-                        visibility_deadline=visibility_deadline,
-                        attempts=Job.attempts + 1,
-                        last_error=None,
-                    )
-                    .returning(Job.id)
-                )
-
-                # SQLite requires RETURNING cursors to be finalized before commit.
                 try:
-                    claimed_job_id = result.scalar_one_or_none()
-                finally:
-                    result.close()
+                    where_clauses = [Job.id == candidate_job_id_subquery, claimable_filter]
+                    if type_filter is not None:
+                        where_clauses.append(type_filter)
 
-                if claimed_job_id is None:
+                    result = await session.execute(
+                        update(Job)
+                        .where(*where_clauses)
+                        .values(
+                            status=self.RUNNING,
+                            started_at=now,
+                            finished_at=None,
+                            visibility_deadline=visibility_deadline,
+                            attempts=Job.attempts + 1,
+                            last_error=None,
+                        )
+                        .returning(Job.id)
+                    )
+
+                    # SQLite requires RETURNING cursors to be finalized before commit.
+                    try:
+                        claimed_job_id = result.scalar_one_or_none()
+                    finally:
+                        result.close()
+
+                    if claimed_job_id is None:
+                        await session.commit()
+                        return None
+
+                    claimed_job = await session.get(Job, claimed_job_id)
                     await session.commit()
-                    return None
-
-                claimed_job = await session.get(Job, claimed_job_id)
-                await session.commit()
-                return claimed_job
+                    return claimed_job
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def mark_done(self, job_id: int, claim_attempt: int) -> bool:
         async with self._db_op_lock:
             now = datetime.now(UTC)
             async with self._session_factory() as session:
-                result = await session.execute(
-                    update(Job)
-                    .where(
-                        Job.id == job_id,
-                        Job.status == self.RUNNING,
-                        Job.attempts == claim_attempt,
+                try:
+                    result = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status == self.RUNNING,
+                            Job.attempts == claim_attempt,
+                        )
+                        .values(
+                            status=self.DONE,
+                            finished_at=now,
+                            visibility_deadline=None,
+                            last_error=None,
+                        )
                     )
-                    .values(
-                        status=self.DONE,
-                        finished_at=now,
-                        visibility_deadline=None,
-                        last_error=None,
-                    )
-                )
-                updated = result.rowcount > 0
-                await session.commit()
-                return updated
+                    updated = result.rowcount > 0
+                    await session.commit()
+                    return updated
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def mark_failed(
         self, job_id: int, error_message: str, claim_attempt: int
@@ -227,23 +239,27 @@ class SQLiteJobQueue:
         async with self._db_op_lock:
             now = datetime.now(UTC)
             async with self._session_factory() as session:
-                result = await session.execute(
-                    update(Job)
-                    .where(
-                        Job.id == job_id,
-                        Job.status == self.RUNNING,
-                        Job.attempts == claim_attempt,
+                try:
+                    result = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status == self.RUNNING,
+                            Job.attempts == claim_attempt,
+                        )
+                        .values(
+                            status=self.FAILED,
+                            finished_at=now,
+                            visibility_deadline=None,
+                            last_error=error_message,
+                        )
                     )
-                    .values(
-                        status=self.FAILED,
-                        finished_at=now,
-                        visibility_deadline=None,
-                        last_error=error_message,
-                    )
-                )
-                updated = result.rowcount > 0
-                await session.commit()
-                return updated
+                    updated = result.rowcount > 0
+                    await session.commit()
+                    return updated
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def release_for_retry(
         self,
@@ -264,26 +280,30 @@ class SQLiteJobQueue:
             )
 
             async with self._session_factory() as session:
-                result = await session.execute(
-                    update(Job)
-                    .where(
-                        Job.id == job_id,
-                        Job.status == self.RUNNING,
-                        Job.attempts == claim_attempt,
+                try:
+                    result = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status == self.RUNNING,
+                            Job.attempts == claim_attempt,
+                        )
+                        .values(
+                            status=self.PENDING,
+                            started_at=None,
+                            finished_at=None,
+                            visibility_deadline=retry_deadline,
+                            last_error=error_message,
+                        )
                     )
-                    .values(
-                        status=self.PENDING,
-                        started_at=None,
-                        finished_at=None,
-                        visibility_deadline=retry_deadline,
-                        last_error=error_message,
-                    )
-                )
-                updated = result.rowcount > 0
-                await session.commit()
-                if updated:
-                    self._pending_event.set()
-                return updated
+                    updated = result.rowcount > 0
+                    await session.commit()
+                    if updated:
+                        self._pending_event.set()
+                    return updated
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def extend_visibility(
         self, job_id: int, lease_seconds: int, claim_attempt: int
@@ -298,20 +318,24 @@ class SQLiteJobQueue:
             new_deadline = now + timedelta(seconds=lease_seconds)
 
             async with self._session_factory() as session:
-                result = await session.execute(
-                    update(Job)
-                    .where(
-                        Job.id == job_id,
-                        Job.status == self.RUNNING,
-                        Job.attempts == claim_attempt,
+                try:
+                    result = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status == self.RUNNING,
+                            Job.attempts == claim_attempt,
+                        )
+                        .values(
+                            visibility_deadline=new_deadline,
+                        )
                     )
-                    .values(
-                        visibility_deadline=new_deadline,
-                    )
-                )
-                updated = result.rowcount > 0
-                await session.commit()
-                return updated
+                    updated = result.rowcount > 0
+                    await session.commit()
+                    return updated
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def list(
         self, status: str | None = None, limit: int = 100, offset: int = 0
@@ -340,17 +364,23 @@ class SQLiteJobQueue:
         """
         async with self._db_op_lock:
             async with self._session_factory() as session:
-                stmt = select(Job)
-                if status:
-                    stmt = stmt.where(Job.status == status)
-                stmt = (
-                    stmt.order_by(Job.enqueued_at.asc(), Job.id.asc())
-                    .offset(offset)
-                    .limit(limit)
-                )
+                try:
+                    stmt = select(Job)
+                    if status:
+                        stmt = stmt.where(Job.status == status)
+                    stmt = (
+                        stmt.order_by(Job.enqueued_at.asc(), Job.id.asc())
+                        .offset(offset)
+                        .limit(limit)
+                    )
 
-                result = await session.execute(stmt)
-                return list(result.scalars().all())
+                    result = await session.execute(stmt)
+                    jobs = list(result.scalars().all())
+                    await session.commit()
+                    return jobs
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def reset_to_pending(self, job_id: int) -> bool:
         """Reset a failed/done job back to pending for retry.
@@ -360,42 +390,50 @@ class SQLiteJobQueue:
         """
         async with self._db_op_lock:
             async with self._session_factory() as session:
-                result = await session.execute(
-                    update(Job)
-                    .where(
-                        Job.id == job_id,
-                        Job.status.in_([self.FAILED, self.DONE]),
+                try:
+                    result = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status.in_([self.FAILED, self.DONE]),
+                        )
+                        .values(
+                            status=self.PENDING,
+                            started_at=None,
+                            finished_at=None,
+                            visibility_deadline=None,
+                            last_error=None,
+                        )
                     )
-                    .values(
-                        status=self.PENDING,
-                        started_at=None,
-                        finished_at=None,
-                        visibility_deadline=None,
-                        last_error=None,
-                    )
-                )
-                updated = result.rowcount > 0
-                await session.commit()
-                return updated
+                    updated = result.rowcount > 0
+                    await session.commit()
+                    return updated
+                except Exception:
+                    await session.rollback()
+                    raise
 
     async def cancel(self, job_id: int) -> bool:
         """Cancel a pending job."""
         async with self._db_op_lock:
             now = datetime.now(UTC)
             async with self._session_factory() as session:
-                result = await session.execute(
-                    update(Job)
-                    .where(
-                        Job.id == job_id,
-                        Job.status == self.PENDING,
+                try:
+                    result = await session.execute(
+                        update(Job)
+                        .where(
+                            Job.id == job_id,
+                            Job.status == self.PENDING,
+                        )
+                        .values(
+                            status=self.CANCELLED,
+                            finished_at=now,
+                            visibility_deadline=None,
+                            last_error=None,
+                        )
                     )
-                    .values(
-                        status=self.CANCELLED,
-                        finished_at=now,
-                        visibility_deadline=None,
-                        last_error=None,
-                    )
-                )
-                updated = result.rowcount > 0
-                await session.commit()
-                return updated
+                    updated = result.rowcount > 0
+                    await session.commit()
+                    return updated
+                except Exception:
+                    await session.rollback()
+                    raise

--- a/packages/qdrant-loader/src/qdrant_loader/webhooks/queue_backend.py
+++ b/packages/qdrant-loader/src/qdrant_loader/webhooks/queue_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
@@ -100,6 +101,7 @@ class QueueBackendManager:
     _backend: QueueBackend | None = None
     _job_queue: SQLiteJobQueue | None = None
     _engine = None
+    _queue_db_op_lock: asyncio.Lock | None = None
 
     @classmethod
     async def initialize(cls) -> QueueBackend:
@@ -112,7 +114,12 @@ class QueueBackendManager:
         await create_tables(engine)
 
         cls._engine = engine
-        cls._job_queue = SQLiteJobQueue(session_factory)
+        if cls._queue_db_op_lock is None:
+            cls._queue_db_op_lock = asyncio.Lock()
+        cls._job_queue = SQLiteJobQueue(
+            session_factory,
+            db_op_lock=cls._queue_db_op_lock,
+        )
         cls._backend = SQLiteChangeEventQueue(cls._job_queue)
         logger.info(
             "Initialized persistent webhook queue",
@@ -140,6 +147,7 @@ class QueueBackendManager:
         if cls._engine is not None:
             await dispose_engine(cls._engine)
         cls._engine = None
+        cls._queue_db_op_lock = None
         cls._job_queue = None
         cls._backend = None
 
@@ -155,6 +163,7 @@ class QueueBackendManager:
     def reset(cls) -> None:
         """Reset manager state (for tests)."""
         cls._engine = None
+        cls._queue_db_op_lock = None
         cls._job_queue = None
         cls._backend = None
 

--- a/packages/qdrant-loader/tests/integration/test_serve.py
+++ b/packages/qdrant-loader/tests/integration/test_serve.py
@@ -37,7 +37,7 @@ async def _make_queue() -> tuple[SQLiteJobQueue, async_sessionmaker, any]:
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    return SQLiteJobQueue(factory), factory, engine
+    return SQLiteJobQueue(factory, db_op_lock=asyncio.Lock()), factory, engine
 
 
 # ── No-op job handler ────────────────────────────────────────────────────────

--- a/packages/qdrant-loader/tests/scripts/check_worker_pool.py
+++ b/packages/qdrant-loader/tests/scripts/check_worker_pool.py
@@ -40,7 +40,7 @@ async def main() -> None:
     cfg = StateManagementConfig(database_path=str(db_path))
     engine, session_factory = initialize_engine_and_session(cfg)
     await create_tables(engine)
-    queue = SQLiteJobQueue(session_factory)
+    queue = SQLiteJobQueue(session_factory, db_op_lock=asyncio.Lock())
 
     # 1) Prepare jobs
     for i in range(args.jobs):

--- a/packages/qdrant-loader/tests/unit/core/state/test_session.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_session.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from qdrant_loader.config.state import StateManagementConfig
+from qdrant_loader.core.state.session import dispose_engine, initialize_engine_and_session
+from sqlalchemy.pool import StaticPool
+
+
+@pytest.mark.asyncio
+async def test_sqlite_in_memory_uses_static_pool() -> None:
+    config = StateManagementConfig(database_path=":memory:")
+    engine, _ = initialize_engine_and_session(config)
+    try:
+        assert isinstance(engine.sync_engine.pool, StaticPool)
+    finally:
+        await dispose_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_file_based_does_not_use_static_pool(tmp_path) -> None:
+    db_path = tmp_path / "state.db"
+    config = StateManagementConfig(database_path=str(db_path))
+    engine, _ = initialize_engine_and_session(config)
+    try:
+        assert not isinstance(engine.sync_engine.pool, StaticPool)
+    finally:
+        await dispose_engine(engine)

--- a/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_pool.py
@@ -25,7 +25,7 @@ async def sqlite_job_queue(tmp_path: Path):
     engine, session_factory = initialize_engine_and_session(config)
     await create_tables(engine)
 
-    queue = SQLiteJobQueue(session_factory)
+    queue = SQLiteJobQueue(session_factory, db_op_lock=asyncio.Lock())
     try:
         yield queue
     finally:

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -20,8 +20,9 @@ async def sqlite_job_queue(tmp_path: Path):
     config = StateManagementConfig(database_path=str(db_path))
     engine, session_factory = initialize_engine_and_session(config)
     await create_tables(engine)
+    queue_lock = asyncio.Lock()
 
-    queue = SQLiteJobQueue(session_factory)
+    queue = SQLiteJobQueue(session_factory, db_op_lock=queue_lock)
     try:
         yield queue
     finally:
@@ -85,7 +86,11 @@ async def test_claim_next_no_duplicate_claims_across_queue_instances(
 ):
     # Simulate multiple independent workers/processes sharing the same DB.
     queues = [sqlite_job_queue] + [
-        SQLiteJobQueue(sqlite_job_queue._session_factory) for _ in range(7)
+        SQLiteJobQueue(
+            sqlite_job_queue._session_factory,
+            db_op_lock=sqlite_job_queue._db_op_lock,
+        )
+        for _ in range(7)
     ]
 
     for i in range(50):

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -475,3 +475,68 @@ async def test_list_default_offset_is_zero(sqlite_job_queue: SQLiteJobQueue):
     # Call without offset parameter (should default to 0, return first 5)
     jobs = await sqlite_job_queue.list(limit=10)
     assert len(jobs) == 5
+
+
+@pytest.mark.asyncio
+async def test_mixed_enqueue_and_claim_does_not_raise_sqlite_commit_conflict(
+    sqlite_job_queue: SQLiteJobQueue,
+):
+    """Concurrent enqueue + claim/mark should remain stable on SQLite."""
+    total_jobs = 120
+    producer_done = asyncio.Event()
+    errors: list[Exception] = []
+
+    async def producer() -> None:
+        try:
+            for i in range(total_jobs):
+                await sqlite_job_queue.enqueue("INCREMENTAL_PULL", {"index": i})
+                if i % 10 == 0:
+                    await asyncio.sleep(0)
+        except Exception as exc:  # pragma: no cover - defensive capture
+            errors.append(exc)
+        finally:
+            producer_done.set()
+
+    async def consumer() -> None:
+        while True:
+            try:
+                job = await sqlite_job_queue.claim_next(lease_seconds=30)
+            except Exception as exc:  # pragma: no cover - defensive capture
+                errors.append(exc)
+                return
+
+            if job is None:
+                if producer_done.is_set():
+                    pending = await sqlite_job_queue.list(
+                        status=SQLiteJobQueue.PENDING, limit=1
+                    )
+                    running = await sqlite_job_queue.list(
+                        status=SQLiteJobQueue.RUNNING, limit=1
+                    )
+                    if not pending and not running:
+                        return
+                await asyncio.sleep(0)
+                continue
+
+            try:
+                await sqlite_job_queue.mark_done(job.id, claim_attempt=job.attempts)
+            except Exception as exc:  # pragma: no cover - defensive capture
+                errors.append(exc)
+                return
+
+    await asyncio.wait_for(
+        asyncio.gather(producer(), *(consumer() for _ in range(4))),
+        timeout=20,
+    )
+
+    assert errors == []
+
+    done_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.DONE, limit=1000)
+    pending_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.PENDING, limit=1)
+    running_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.RUNNING, limit=1)
+    failed_jobs = await sqlite_job_queue.list(status=SQLiteJobQueue.FAILED, limit=1)
+
+    assert len(done_jobs) == total_jobs
+    assert pending_jobs == []
+    assert running_jobs == []
+    assert failed_jobs == []


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Affected areas:** Qdrant loader *serve* queue workers and the SQLite-backed job queue/state operations used by workers (`enqueue`, `claim_next`, `mark_done/mark_failed`, retry, `list`, `reset_to_pending`, `cancel`), plus SQLite engine/session initialization and queue backend initialization.
- **Configuration/schema:** No user-facing config/schema changes. Internal SQLite handling now differentiates in-memory (`:memory:`) vs file-backed DBs, sets `connect_args` (`check_same_thread=False`, `timeout=30`), and uses `StaticPool` only for in-memory SQLite.
- **Tests:** Unit tests added to assert engine pool behavior for in-memory vs file-backed SQLite, and a concurrency regression test that mixes enqueue and claim/complete to ensure no SQLite commit conflicts. Integration/worker-pool/unit fixtures were updated to use the shared DB lock.
- **Security/resource safety:** Centralized an injected `asyncio.Lock` (`db_op_lock`) to serialize all SQLite queue DB operations and avoid commit conflicts; SQLite `timeout=30` mitigates indefinite blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->