### PR TITLE
fix: harden test fixtures and update Apache-2.0 metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -441,7 +441,7 @@ uv run python release.py
 
 ## 📄 License
 
-By contributing to QDrant Loader, you agree that your contributions will be licensed under the GNU GPLv3 license.
+By contributing to QDrant Loader, you agree that your contributions will be licensed under the Apache License 2.0.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI - qdrant-loader-core](https://img.shields.io/pypi/v/qdrant-loader-core?label=qdrant-loader-core)](https://pypi.org/project/qdrant-loader-core/)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/martin-papy/qdrant-loader?labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 [![Test Coverage](https://img.shields.io/badge/coverage-view%20reports-blue)](https://qdrant-loader.net/coverage/)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 📝 **[Changelog v1.0.4](./CHANGELOG.md)** - Latest improvements and bug fixes
 
@@ -259,7 +259,7 @@ uv sync
 
 ## 📄 License
 
-This project is licensed under the GNU GPLv3 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 
 ---
 

--- a/packages/qdrant-loader-core/README.md
+++ b/packages/qdrant-loader-core/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/qdrant-loader-core)](https://pypi.org/project/qdrant-loader-core/)
 [![Python](https://img.shields.io/pypi/pyversions/qdrant-loader-core)](https://pypi.org/project/qdrant-loader-core/)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 Shared core library for the QDrant Loader ecosystem. It provides a provider‑agnostic LLM layer (embeddings and chat), configuration mapping, safe logging, and normalized error handling used by the CLI and MCP Server packages.
 
@@ -79,7 +79,7 @@ See **[CONTRIBUTING](../../CONTRIBUTING.md)** - Contribution guidelines, develop
 
 ## 📄 License
 
-This project is licensed under the GNU GPLv3 - see the [LICENSE](../../LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](../../LICENSE) file for details.
 
 ---
 

--- a/packages/qdrant-loader-core/pyproject.toml
+++ b/packages/qdrant-loader-core/pyproject.toml
@@ -11,7 +11,7 @@ version = "1.0.3"
 description = "Shared core for provider-agnostic LLM support and configuration mapping for qdrant-loader ecosystem"
 readme = "README.md"
 requires-python = ">=3.12"
-license = "GPL-3.0"
+license = "Apache-2.0"
 authors = [
     { name = "Martin Papy", email = "martin.papy@cbtw.tech" },
 ]

--- a/packages/qdrant-loader-mcp-server/README.md
+++ b/packages/qdrant-loader-mcp-server/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/qdrant-loader-mcp-server)](https://pypi.org/project/qdrant-loader-mcp-server/)
 [![Python](https://img.shields.io/pypi/pyversions/qdrant-loader-mcp-server)](https://pypi.org/project/qdrant-loader-mcp-server/)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 A Model Context Protocol (MCP) server that brings advanced RAG search to AI development tools. Part of the [QDrant Loader monorepo](../../) ecosystem.
 
@@ -228,7 +228,7 @@ See **[CONTRIBUTING](../../CONTRIBUTING.md)** - Contribution guidelines, develop
 
 ## 📄 License
 
-This project is licensed under the GNU GPLv3 - see the [LICENSE](../../LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](../../LICENSE) file for details.
 
 ---
 

--- a/packages/qdrant-loader-mcp-server/pyproject.toml
+++ b/packages/qdrant-loader-mcp-server/pyproject.toml
@@ -11,7 +11,7 @@ version = "1.0.3"
 description = "A Model Context Protocol (MCP) server that provides RAG capabilities to Cursor using Qdrant."
 readme = "README.md"
 requires-python = ">=3.12"
-license = "GPL-3.0"
+license = "Apache-2.0"
 keywords = [
     "qdrant",
     "vector-database",

--- a/packages/qdrant-loader/README.md
+++ b/packages/qdrant-loader/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/qdrant-loader)](https://pypi.org/project/qdrant-loader/)
 [![Python](https://img.shields.io/pypi/pyversions/qdrant-loader)](https://pypi.org/project/qdrant-loader/)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 A powerful data ingestion engine that collects and vectorizes technical content from multiple sources for storage in QDrant vector database. Part of the [QDrant Loader monorepo](../../) ecosystem.
 
@@ -165,7 +165,7 @@ See **[CONTRIBUTING](../../CONTRIBUTING.md)** - Contribution guidelines, develop
 
 ## 📄 License
 
-This project is licensed under the GNU GPLv3 - see the [LICENSE](../../LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](../../LICENSE) file for details.
 
 ---
 

--- a/packages/qdrant-loader/pyproject.toml
+++ b/packages/qdrant-loader/pyproject.toml
@@ -11,7 +11,7 @@ version = "1.0.3"
 description = "A tool for collecting and vectorizing technical content from multiple sources and storing it in a QDrant vector database."
 readme = "README.md"
 requires-python = ">=3.12"
-license = "GPL-3.0"
+license = "Apache-2.0"
 keywords = [
     "qdrant",
     "vector-database",

--- a/packages/qdrant-loader/src/qdrant_loader/connectors/confluence/connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/confluence/connector.py
@@ -846,7 +846,7 @@ class ConfluenceConnector(BaseConnector):
                                     f"Processed {content['type']} '{content['title']}' "
                                     f"(ID: {content['id']}) from space {self.config.space_key}"
                                 )
-                        except (ValueError, KeyError, AttributeError, TypeError) as e:
+                        except Exception as e:
                             logger.error(
                                 "Failed to process Confluence content",
                                 content_type=content.get("type"),
@@ -925,7 +925,7 @@ class ConfluenceConnector(BaseConnector):
                                     f"Processed {content['type']} '{content['title']}' "
                                     f"(ID: {content['id']}) from space {self.config.space_key}"
                                 )
-                        except (ValueError, KeyError, AttributeError, TypeError) as e:
+                        except Exception as e:
                             logger.error(
                                 "Failed to process Confluence content",
                                 content_type=content.get("type"),

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -678,53 +678,16 @@ class SemanticAnalyzer:
         return sum(weights) / len(weights) if weights else 0.0
 
     def clear_cache(self):
-        """Clear the document cache and release all resources."""
-        # Clear document cache
+        """Clear instance-owned caches and model state."""
         with self._doc_cache_lock:
             self._doc_cache.clear()
 
-        # A released model is no longer fitted; reset so reuse doesn't infer
-        # against a torn-down model.
+        # Reset topic model state for this analyzer instance.
         self._topic_model_fitted = False
+        self.lda_model = None
+        self.dictionary = None
 
-        # Release LDA model resources
-        if hasattr(self, "lda_model") and self.lda_model is not None:
-            try:
-                # Clear LDA model
-                self.lda_model = None
-            except Exception as e:
-                logger.warning(f"Error releasing LDA model: {e}")
-
-        # Release dictionary
-        if hasattr(self, "dictionary") and self.dictionary is not None:
-            try:
-                self.dictionary = None
-            except Exception as e:
-                logger.warning(f"Error releasing dictionary: {e}")
-
-        # Release spaCy model resources
-        if hasattr(self, "nlp") and self.nlp is not None:
-            try:
-                # Clear spaCy caches and release memory
-                if hasattr(self.nlp, "vocab") and hasattr(self.nlp.vocab, "strings"):
-                    # Try different methods to clear spaCy caches
-                    if hasattr(self.nlp.vocab.strings, "_map") and hasattr(
-                        self.nlp.vocab.strings._map, "clear"
-                    ):
-                        self.nlp.vocab.strings._map.clear()
-                    elif hasattr(self.nlp.vocab.strings, "clear"):
-                        self.nlp.vocab.strings.clear()
-                    # Additional cleanup for different spaCy versions
-                    if hasattr(self.nlp.vocab, "_vectors") and hasattr(
-                        self.nlp.vocab._vectors, "clear"
-                    ):
-                        self.nlp.vocab._vectors.clear()
-                # Note: We don't set nlp to None as it might be needed for other operations
-                # but we clear its internal caches
-            except Exception as e:
-                logger.debug(f"spaCy cache clearing skipped (version-specific): {e}")
-
-        logger.debug("Semantic analyzer resources cleared")
+        logger.debug("Semantic analyzer instance caches cleared")
 
     def shutdown(self):
         """Shutdown the semantic analyzer and release all resources.
@@ -734,12 +697,7 @@ class SemanticAnalyzer:
         """
         self.clear_cache()
 
-        # More aggressive cleanup for shutdown
         if hasattr(self, "nlp"):
-            try:
-                # Release the spaCy model completely
-                del self.nlp
-            except Exception as e:
-                logger.warning(f"Error releasing spaCy model: {e}")
+            del self.nlp
 
         logger.debug("Semantic analyzer shutdown completed")

--- a/packages/qdrant-loader/tests/conftest.py
+++ b/packages/qdrant-loader/tests/conftest.py
@@ -50,10 +50,9 @@ def setup_test_environment():
     config_template_path = tests_dir / "config.test.template.yaml"
     env_path = tests_dir / ".env.test"
 
-    # If config.test.yaml does not exist, generate it from template.
-    # This allows config.test.yaml to be .gitignore'd while CI/local setups
-    # can still run tests by auto-creating a working config from the template.
-    if not config_path.exists() and config_template_path.exists():
+    # Regenerate config.test.yaml from template on every setup run.
+    # This keeps local ignored files in sync and replaces stale config.
+    if config_template_path.exists():
         shutil.copy(config_template_path, config_path)
 
     # Load environment variables first

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
@@ -542,15 +542,21 @@ class TestEmbeddingWorker:
         self.mock_embedding_service.batch_size = 1
 
         hold = asyncio.Event()
+        all_started = asyncio.Event()
+        all_cancelled = asyncio.Event()
         started: list = []
         cancelled: list = []
 
         async def blocking_get_embeddings(contents):
             started.append(contents)
+            if len(started) >= 2:
+                all_started.set()
             try:
                 await hold.wait()
             except asyncio.CancelledError:
                 cancelled.append(contents)
+                if len(cancelled) >= 2:
+                    all_cancelled.set()
                 raise
             return [[0.1, 0.2, 0.3] for _ in contents]
 
@@ -578,16 +584,15 @@ class TestEmbeddingWorker:
 
         consumer = asyncio.create_task(consume())
         try:
-            # Wait until both batch tasks are genuinely in flight.
-            while len(started) < 2:
-                await asyncio.sleep(0.01)
+            # Wait until both batch tasks are genuinely in flight (5 s deadline).
+            await asyncio.wait_for(all_started.wait(), timeout=5)
 
             consumer.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await consumer
 
-            # Give cancellation a tick to propagate into the batch tasks.
-            await asyncio.sleep(0.05)
+            # Wait for cancellation to propagate into both batch tasks (5 s deadline).
+            await asyncio.wait_for(all_cancelled.wait(), timeout=5)
             assert len(cancelled) == 2, (
                 f"expected both in-flight batches cancelled, got {len(cancelled)}: "
                 f"{cancelled}"

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
@@ -589,7 +589,7 @@ class TestEmbeddingWorker:
 
             consumer.cancel()
             with pytest.raises(asyncio.CancelledError):
-                await consumer
+                await asyncio.wait_for(consumer, timeout=5)
 
             # Wait for cancellation to propagate into both batch tasks (5 s deadline).
             await asyncio.wait_for(all_cancelled.wait(), timeout=5)
@@ -599,7 +599,11 @@ class TestEmbeddingWorker:
             )
         finally:
             hold.set()  # unblock any leaked task so the loop can close cleanly
-            await asyncio.sleep(0)
+            consumer.cancel()
+            try:
+                await asyncio.wait_for(consumer, timeout=5)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
 
     @pytest.mark.asyncio
     async def test_process_chunks_mixed_failures_conserve_all_chunks(self):

--- a/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
+++ b/packages/qdrant-loader/tests/unit/core/worker/test_queue.py
@@ -85,10 +85,12 @@ async def test_claim_next_no_duplicate_claims_across_queue_instances(
     sqlite_job_queue: SQLiteJobQueue,
 ):
     # Simulate multiple independent workers/processes sharing the same DB.
+    # Each instance gets its own lock (as in production) to exercise
+    # cross-instance atomicity rather than trivially serialising via one lock.
     queues = [sqlite_job_queue] + [
         SQLiteJobQueue(
             sqlite_job_queue._session_factory,
-            db_op_lock=sqlite_job_queue._db_op_lock,
+            db_op_lock=asyncio.Lock(),
         )
         for _ in range(7)
     ]

--- a/tests/test_website_build_comprehensive.py
+++ b/tests/test_website_build_comprehensive.py
@@ -573,23 +573,23 @@ class TestWebsiteBuilderLicenseHandling:
 
         # Create a LICENSE file
         license_file = mock_project_structure / "LICENSE"
-        license_content = """GNU GENERAL PUBLIC LICENSE
-Version 3, 29 June 2007
+        license_content = """Apache License
+    Version 2.0, January 2004
 
-Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed."""
+    http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION"""
         license_file.write_text(license_content)
 
         builder.build_license_page(
-            "LICENSE", "LICENSE.html", "License", "GNU GPLv3 License"
+            "LICENSE", "LICENSE.html", "License", "Apache License 2.0"
         )
 
         output_file = mock_project_structure / "site" / "LICENSE.html"
         assert output_file.exists()
 
         content = output_file.read_text()
-        assert "GNU GENERAL PUBLIC LICENSE" in content
+        assert "Apache License" in content
         assert "License Information" in content
 
     def test_build_license_page_missing_file(

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -74,7 +74,7 @@
         },
         "downloadUrl": "https://pypi.org/project/qdrant-loader/",
         "codeRepository": "https://github.com/martin-papy/qdrant-loader",
-        "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+        "license": "https://www.apache.org/licenses/LICENSE-2.0",
         "version": "{{ version }}",
         "keywords": ["vector database", "AI", "machine learning", "embeddings", "search", "RAG", "python", "qdrant"],
         "screenshot": "{{ base_url }}assets/logos/qdrant-loader-social-card.png"


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Connectors/pipeline:** Confluence connector per-item processing during cloud/DC content streaming now catches `Exception` (wider than specific built-in exceptions) to keep failures isolated within the item loop. Semantic analyzer cache reset and shutdown cleanup were simplified (less defensive spaCy/model cleanup).  
- **Config schema:** No breaking/additive schema changes; pytest session fixture now regenerates `config.test.yaml` from `config.test.template.yaml` on every setup when the template exists.  
- **Tests:** Updated/strengthened coverage for changed paths: more deterministic embedding-worker in-flight cancellation assertions; queue-instance concurrency test now uses independent DB locks; Confluence error isolation is exercised indirectly; license-page build test updated for Apache 2.0.  
- **Security/resource safety:** License metadata switched from GPL-3.0 to Apache-2.0 across packages/tests. Broader per-item exception handling improves robustness but may hide unexpected failures; simplified semantic-model/spaCy cleanup should be monitored to ensure resources are released safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->