### PR TITLE
fix: Graph and add UT

### DIFF
--- a/packages/qdrant-loader-core/pyproject.toml
+++ b/packages/qdrant-loader-core/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 dependencies = [
     "pydantic>=2.0.0",
     "structlog>=23.0.0",
-    "FalkorDB>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
@@ -14,11 +14,6 @@ try:
 except ImportError:
     FalkorGraphStore = None
 
-try:
-    from qdrant_loader.config import get_settings
-except ImportError:  # pragma: no cover
-    get_settings = None
-
 
 __all__ = [
     "FalkorGraphStore",
@@ -54,37 +49,13 @@ async def get_graph_store(
                 final_host = host or "localhost"
                 final_port = port if port is not None else 6379
                 final_graph = graph_name or "default_graph"
-                final_max_conn = max_connections
-
-                if get_settings is not None:
-                    try:
-                        settings = get_settings()
-                        graph_cfg = getattr(settings.global_config, "graph", None)
-
-                        if graph_cfg is not None:
-                            if host is None:
-                                final_host = graph_cfg.connection.host
-                            if port is None:
-                                final_port = graph_cfg.connection.port
-                            if graph_name is None:
-                                final_graph = graph_cfg.graph_name
-                            if max_connections is None:
-                                final_max_conn = getattr(
-                                    graph_cfg.pool,
-                                    "max_connections",
-                                    None,
-                                )
-
-                    except AttributeError:
-                        pass
+                final_max_conn = max_connections if max_connections is not None else 10
 
                 _graph_store = FalkorGraphStore(
                     host=final_host,
                     port=int(final_port),
                     graph_name=final_graph,
-                    max_connections=(
-                        final_max_conn if final_max_conn is not None else 10
-                    ),
+                    max_connections=final_max_conn,
                 )
 
                 await init_schema(_graph_store)

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/__init__.py
@@ -31,6 +31,7 @@ _graph_store_lock = asyncio.Lock()
 async def get_graph_store(
     host: str | None = None,
     port: int | None = None,
+    password: str | None = None,
     graph_name: str | None = None,
     max_connections: int | None = None,
 ) -> FalkorGraphStore:
@@ -54,6 +55,7 @@ async def get_graph_store(
                 _graph_store = FalkorGraphStore(
                     host=final_host,
                     port=int(final_port),
+                    password=password,
                     graph_name=final_graph,
                     max_connections=final_max_conn,
                 )

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/confluence.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/confluence.py
@@ -45,18 +45,14 @@ class ConfluenceEntityExtractor(BaseEntityExtractor):
         doc: Document,
         project: str | None,
     ) -> GraphNode:
-        """
-        Build a document node enriched with filesystem metadata.
-        """
-
-        file_name = doc.metadata.get("file_name")
+        """Build a document node for a Confluence page."""
 
         return GraphNode(
             id=doc.id,
             label=CoreNodeLabel.DOCUMENT.value,
             project=project,
             properties={
-                "title": file_name,
+                "title": doc.title,
                 "url": doc.url,
                 "created_at": doc.metadata.get("created_at"),
                 "updated_at": doc.metadata.get("updated_at"),

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/git.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/git.py
@@ -27,11 +27,19 @@ class GitEntityExtractor(BaseEntityExtractor):
 
     source_type = "git"
 
+    @staticmethod
+    def _repository_id(doc: Document) -> str | None:
+        name = doc.metadata.get("repository_name")
+        if not name:
+            return None
+        owner = doc.metadata.get("repository_owner")
+        return f"{owner}/{name}" if owner else name
+
     def _project(
         self,
         doc: Document,
     ) -> str | None:
-        return doc.metadata.get("repository_name")
+        return self._repository_id(doc)
 
     def _build_document_node(
         self,
@@ -71,7 +79,7 @@ class GitEntityExtractor(BaseEntityExtractor):
         self,
         doc: Document,
     ) -> GraphNode | None:
-        repo_name = doc.metadata.get("repository_name")
+        repo_name = self._repository_id(doc)
 
         if not repo_name:
             return None

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
@@ -19,6 +19,7 @@ from .models import (
 )
 
 MAX_ROWS = 5000
+GLOBAL_PROJECT = "__global__"
 
 
 class FalkorGraphStore(GraphStore):
@@ -47,13 +48,16 @@ class FalkorGraphStore(GraphStore):
 
     def _node_payload(self, node: GraphNode) -> dict[str, Any]:
         props = self._clean_props(node.properties or {})
-        # Pop (not get): project is the MERGE identity key, resolved once here.
-        # Leaving it in props would let `SET n += props` overwrite that identity
-        # right after MERGE if node.project differs from the stale properties value.
+        # Pop (not get): project is the MERGE identity key; leaving it in props
+        # would let `SET n += props` overwrite it right after MERGE.
         props_project = props.pop("project", None)
         return {
             "id": node.id,
-            "project": node.project or props_project,
+            "project": (
+                node.project
+                if node.project is not None
+                else props_project or GLOBAL_PROJECT
+            ),
             "props": props,
         }
 
@@ -124,9 +128,8 @@ class FalkorGraphStore(GraphStore):
 
     def _edge_payload(self, edge: GraphEdge) -> dict[str, Any]:
         props = self._clean_props(edge.properties or {})
-        # Pop (not get): project is the MERGE identity key, resolved once here.
-        # Leaving it in props would let `SET r += props` overwrite that identity
-        # right after MERGE if edge.project differs from the stale properties value.
+        # Pop (not get): project is the MERGE identity key; leaving it in props
+        # would let `SET r += props` overwrite it right after MERGE.
         props_project = props.pop("project", None)
         return {
             "source": edge.source,
@@ -139,10 +142,9 @@ class FalkorGraphStore(GraphStore):
         self._validate_edge(edge)
         payload = self._edge_payload(edge)
 
-        # MERGE (not MATCH) the endpoints: the target of an edge (e.g. a linked
-        # Jira issue) may not have been ingested yet. MATCH would silently drop
-        # the edge with zero rows and no error; MERGE creates an unlabeled stub
-        # node instead, which upsert_node later enriches with its real label.
+        # MERGE (not MATCH) the endpoints: the target may not be ingested yet, and
+        # MATCH would silently drop the edge; MERGE creates an unlabeled stub node
+        # instead, which upsert_node later enriches with its real label.
         rel_pattern = (
             f"r:{edge.edge_type} {{kind: $props.kind}}"
             if "kind" in payload["props"]

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/falkor_store.py
@@ -31,7 +31,6 @@ class FalkorGraphStore(GraphStore):
         graph_name="default_graph",
         max_connections: int = 10,
     ):
-
         if max_connections < 1:
             raise ValueError("max_connections must be >= 1")
         self._semaphore = asyncio.Semaphore(max_connections)
@@ -48,8 +47,7 @@ class FalkorGraphStore(GraphStore):
 
     def _node_payload(self, node: GraphNode) -> dict[str, Any]:
         props = self._clean_props(node.properties or {})
-        # Pop (not get): project is the MERGE identity key; leaving it in props
-        # would let `SET n += props` overwrite it right after MERGE.
+        # Pop (not get): leaving project in props would let `SET n += props` overwrite the MERGE key.
         props_project = props.pop("project", None)
         return {
             "id": node.id,
@@ -128,13 +126,16 @@ class FalkorGraphStore(GraphStore):
 
     def _edge_payload(self, edge: GraphEdge) -> dict[str, Any]:
         props = self._clean_props(edge.properties or {})
-        # Pop (not get): project is the MERGE identity key; leaving it in props
-        # would let `SET r += props` overwrite it right after MERGE.
+        # Pop (not get): leaving project in props would let `SET r += props` overwrite the MERGE key.
         props_project = props.pop("project", None)
         return {
             "source": edge.source,
             "target": edge.target,
-            "project": edge.project or props_project,
+            "project": (
+                edge.project
+                if edge.project is not None
+                else props_project or GLOBAL_PROJECT
+            ),
             "props": props,
         }
 
@@ -142,9 +143,7 @@ class FalkorGraphStore(GraphStore):
         self._validate_edge(edge)
         payload = self._edge_payload(edge)
 
-        # MERGE (not MATCH) the endpoints: the target may not be ingested yet, and
-        # MATCH would silently drop the edge; MERGE creates an unlabeled stub node
-        # instead, which upsert_node later enriches with its real label.
+        # MERGE (not MATCH): MATCH would silently drop an edge whose target isn't ingested yet.
         rel_pattern = (
             f"r:{edge.edge_type} {{kind: $props.kind}}"
             if "kind" in payload["props"]

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/utils.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/utils.py
@@ -7,8 +7,15 @@ from .versioning import get_version_query, set_version_query
 
 logger = logging.getLogger(__name__)
 
-LATEST_VERSION = 1
+async def _apply_v1(graph_store) -> None:
+    await _ensure_indexes(graph_store)
+    await apply(graph_store)
 
+
+MIGRATIONS = {
+    1: _apply_v1,
+}
+LATEST_VERSION = max(MIGRATIONS)
 
 # ------------------------
 # ENTRY POINT
@@ -27,8 +34,7 @@ async def init_schema(graph_store):
             version,
         )
 
-        await _ensure_indexes(graph_store)
-        await apply(graph_store)
+        await MIGRATIONS[version](graph_store)
         await _set_version(graph_store, version)
 
         logger.info(

--- a/packages/qdrant-loader-core/tests/test_confluence_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_confluence_extractor.py
@@ -30,3 +30,74 @@ async def test_confluence_page():
 
     assert any(n.label == "Container" for n in result.nodes)
     assert any(e.edge_type == "BELONGS_TO" for e in result.edges)
+
+
+@pytest.mark.asyncio
+async def test_confluence_page_without_author_has_no_person():
+    extractor = ConfluenceEntityExtractor()
+
+    doc = Document(
+        title="No Author",
+        content_type="page",
+        content="content",
+        source_type="confluence",
+        source="confluence_instance",
+        url="http://conf/page2",
+        metadata={"space_key": "ENG"},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Person" for n in result.nodes)
+    assert not any(e.edge_type == "AUTHORED_BY" for e in result.edges)
+
+
+@pytest.mark.asyncio
+async def test_confluence_page_without_space_key_has_no_container():
+    extractor = ConfluenceEntityExtractor()
+
+    doc = Document(
+        title="No Space",
+        content_type="page",
+        content="content",
+        source_type="confluence",
+        source="confluence_instance",
+        url="http://conf/page3",
+        metadata={},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Container" for n in result.nodes)
+    assert not any(e.edge_type == "BELONGS_TO" for e in result.edges)
+
+
+@pytest.mark.asyncio
+async def test_confluence_page_with_parent_and_children():
+    extractor = ConfluenceEntityExtractor()
+
+    doc = Document(
+        title="Child Page",
+        content_type="page",
+        content="content",
+        source_type="confluence",
+        source="confluence_instance",
+        url="http://conf/page4",
+        metadata={
+            "space_key": "ENG",
+            "parent_id": "123",
+            "children": [{"id": "789"}, {}],
+        },
+    )
+
+    result = await extractor.extract(doc)
+
+    part_of_edges = [e for e in result.edges if e.edge_type == "PART_OF"]
+    has_child_edges = [e for e in result.edges if e.edge_type == "HAS_CHILD"]
+
+    assert len(part_of_edges) == 1
+    assert part_of_edges[0].target == "123"
+
+    # The child entry without an "id" is skipped; only "789" produces an edge.
+    assert len(has_child_edges) == 1
+    assert has_child_edges[0].target == "789"

--- a/packages/qdrant-loader-core/tests/test_falkor_store.py
+++ b/packages/qdrant-loader-core/tests/test_falkor_store.py
@@ -1,0 +1,556 @@
+import datetime
+import json
+from enum import Enum
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from qdrant_loader_core.graph.falkor_store import GLOBAL_PROJECT, FalkorGraphStore
+from qdrant_loader_core.graph.models import GraphEdge, GraphNode
+
+
+class FakeFalkorNode:
+    def __init__(self, id, labels, properties):
+        self.id = id
+        self.labels = labels
+        self.properties = properties
+
+
+class FakeFalkorRel:
+    def __init__(self, src_node, dest_node, relation, properties):
+        self.src_node = src_node
+        self.dest_node = dest_node
+        self.relation = relation
+        self.properties = properties
+
+
+@pytest.fixture
+def mock_falkordb():
+    with patch("qdrant_loader_core.graph.falkor_store.FalkorDB") as mock_cls:
+        mock_db = MagicMock()
+        mock_graph = MagicMock()
+        mock_db.select_graph.return_value = mock_graph
+        mock_cls.return_value = mock_db
+        yield mock_cls, mock_db, mock_graph
+
+
+@pytest.fixture
+def store(mock_falkordb):
+    return FalkorGraphStore(host="localhost", port=6379, graph_name="test_graph")
+
+
+def _fake_result(rows):
+    result = MagicMock()
+    result.result_set = rows
+    return result
+
+
+# ------------------------------------------------------------------
+# __init__
+# ------------------------------------------------------------------
+
+
+def test_init_creates_db_and_selects_graph(mock_falkordb):
+    mock_cls, mock_db, mock_graph = mock_falkordb
+
+    store = FalkorGraphStore(
+        host="h", port=1234, password="pw", graph_name="g", max_connections=5
+    )
+
+    mock_cls.assert_called_once_with(host="h", port=1234, password="pw")
+    mock_db.select_graph.assert_called_once_with("g")
+    assert store._graph is mock_graph
+    assert store._semaphore._value == 5
+
+
+def test_init_invalid_max_connections_raises(mock_falkordb):
+    with pytest.raises(ValueError, match="max_connections must be >= 1"):
+        FalkorGraphStore(max_connections=0)
+
+
+# ------------------------------------------------------------------
+# validation
+# ------------------------------------------------------------------
+
+
+def test_validate_node_valid_label_does_not_raise(store):
+    store._validate_node(GraphNode(id="1", label="Document"))
+
+
+def test_validate_node_invalid_label_raises(store):
+    with pytest.raises(ValueError, match="Invalid node label"):
+        store._validate_node(GraphNode(id="1", label="Bogus"))
+
+
+def test_validate_edge_valid_type_does_not_raise(store):
+    store._validate_edge(GraphEdge(source="1", target="2", edge_type="AUTHORED_BY"))
+
+
+def test_validate_edge_invalid_type_raises(store):
+    with pytest.raises(ValueError, match="Invalid edge type"):
+        store._validate_edge(GraphEdge(source="1", target="2", edge_type="BOGUS"))
+
+
+# ------------------------------------------------------------------
+# _node_payload
+# ------------------------------------------------------------------
+
+
+def test_node_payload_uses_node_project(store):
+    node = GraphNode(id="1", label="Document", project="proj", properties={"title": "t"})
+
+    payload = store._node_payload(node)
+
+    assert payload == {"id": "1", "project": "proj", "props": {"title": "t"}}
+
+
+def test_node_payload_falls_back_to_props_project(store):
+    node = GraphNode(
+        id="1",
+        label="Document",
+        project=None,
+        properties={"project": "from_props", "title": "t"},
+    )
+
+    payload = store._node_payload(node)
+
+    assert payload["project"] == "from_props"
+    assert "project" not in payload["props"]
+
+
+def test_node_payload_defaults_to_global_project(store):
+    node = GraphNode(id="1", label="Document", project=None, properties={})
+
+    payload = store._node_payload(node)
+
+    assert payload["project"] == GLOBAL_PROJECT
+
+
+# ------------------------------------------------------------------
+# upsert_node
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_with_project_builds_scoped_query(store):
+    store._run_query = AsyncMock()
+    node = GraphNode(id="1", label="Document", project="proj")
+
+    await store.upsert_node(node)
+
+    query, payload = store._run_query.await_args.args
+    assert "project: $project" in query
+    assert "SET n:Document" in query
+    assert payload["project"] == "proj"
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_invalid_label_raises(store):
+    store._run_query = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await store.upsert_node(GraphNode(id="1", label="Bad"))
+
+    store._run_query.assert_not_awaited()
+
+
+# ------------------------------------------------------------------
+# upsert_nodes_batch
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_empty_list_returns_immediately(store):
+    store._run_query = AsyncMock()
+
+    await store.upsert_nodes_batch([])
+
+    store._run_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_groups_by_label(store):
+    store._run_query = AsyncMock()
+    nodes = [
+        GraphNode(id="1", label="Document", project="p1"),
+        GraphNode(id="2", label="Person", project="p1"),
+        GraphNode(id="3", label="Document", project="p1"),
+    ]
+
+    await store.upsert_nodes_batch(nodes)
+
+    assert store._run_query.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_invalid_label_raises(store):
+    store._run_query = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await store.upsert_nodes_batch([GraphNode(id="1", label="Bad")])
+
+    store._run_query.assert_not_awaited()
+
+
+# ------------------------------------------------------------------
+# _edge_payload
+# ------------------------------------------------------------------
+
+
+def test_edge_payload_with_project_and_kind(store):
+    edge = GraphEdge(
+        source="a", target="b", edge_type="LINKS_TO", project="p", properties={"kind": "x"}
+    )
+
+    payload = store._edge_payload(edge)
+
+    assert payload["project"] == "p"
+    assert payload["props"]["kind"] == "x"
+
+
+def test_edge_payload_falls_back_to_props_project(store):
+    edge = GraphEdge(
+        source="a",
+        target="b",
+        edge_type="LINKS_TO",
+        project=None,
+        properties={"project": "from_props"},
+    )
+
+    payload = store._edge_payload(edge)
+
+    assert payload["project"] == "from_props"
+
+
+def test_edge_payload_no_project_at_all(store):
+    edge = GraphEdge(source="a", target="b", edge_type="LINKS_TO")
+
+    payload = store._edge_payload(edge)
+
+    assert payload["project"] is None
+
+
+# ------------------------------------------------------------------
+# upsert_edge
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_with_project_and_kind(store):
+    store._run_query = AsyncMock()
+    edge = GraphEdge(
+        source="a", target="b", edge_type="LINKS_TO", project="p", properties={"kind": "related"}
+    )
+
+    await store.upsert_edge(edge)
+
+    query, payload = store._run_query.await_args.args
+    assert "kind: $props.kind" in query
+    assert "project: $project" in query
+    assert payload["project"] == "p"
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_without_project_or_kind(store):
+    store._run_query = AsyncMock()
+    edge = GraphEdge(source="a", target="b", edge_type="LINKS_TO")
+
+    await store.upsert_edge(edge)
+
+    query, payload = store._run_query.await_args.args
+    assert "$project" not in query
+    assert "kind: $props.kind" not in query
+    assert payload["project"] is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_invalid_type_raises(store):
+    store._run_query = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await store.upsert_edge(GraphEdge(source="a", target="b", edge_type="BOGUS"))
+
+    store._run_query.assert_not_awaited()
+
+
+# ------------------------------------------------------------------
+# _edge_batch_query
+# ------------------------------------------------------------------
+
+
+def test_edge_batch_query_with_project(store):
+    query = store._edge_batch_query("r:LINKS_TO", with_project=True)
+
+    assert "project: e.project" in query
+    assert "SET r.project = e.project" in query
+
+
+def test_edge_batch_query_without_project(store):
+    query = store._edge_batch_query("r:LINKS_TO", with_project=False)
+
+    assert "SET r.project = e.project" not in query
+    assert "e.project" not in query
+
+
+# ------------------------------------------------------------------
+# upsert_edges_batch
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_empty_list_returns_immediately(store):
+    store._run_query = AsyncMock()
+
+    await store.upsert_edges_batch([])
+
+    store._run_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_groups_typed_and_untyped_with_and_without_project(store):
+    store._run_query = AsyncMock()
+    edges = [
+        GraphEdge(
+            source="a", target="b", edge_type="LINKS_TO", project="p", properties={"kind": "x"}
+        ),
+        GraphEdge(source="c", target="d", edge_type="LINKS_TO", properties={}),
+    ]
+
+    await store.upsert_edges_batch(edges)
+
+    assert store._run_query.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_invalid_type_raises(store):
+    store._run_query = AsyncMock()
+
+    with pytest.raises(ValueError):
+        await store.upsert_edges_batch([GraphEdge(source="a", target="b", edge_type="BOGUS")])
+
+    store._run_query.assert_not_awaited()
+
+
+# ------------------------------------------------------------------
+# neighbors
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_neighbors_invalid_edge_type_raises(store):
+    with pytest.raises(ValueError, match="Invalid edge types"):
+        await store.neighbors(node_id="1", depth=1, edge_types=["BOGUS"])
+
+
+@pytest.mark.asyncio
+async def test_neighbors_with_project_and_edge_types_extracts_falkor_objects(store):
+    n = FakeFalkorNode(id=1, labels=["Document"], properties={"id": "doc1"})
+    m = FakeFalkorNode(id=2, labels=["Person"], properties={"id": "person1"})
+    rel = FakeFalkorRel(src_node=1, dest_node=2, relation="AUTHORED_BY", properties={"role": "author"})
+    store._run_query = AsyncMock(return_value=_fake_result([[n, rel, m]]))
+
+    subgraph = await store.neighbors(
+        node_id="doc1", depth=2, edge_types=["AUTHORED_BY"], project="proj"
+    )
+
+    query, params = store._run_query.await_args.args
+    assert "project: $project" in query
+    assert ":AUTHORED_BY" in query
+    assert params == {"id": "doc1", "project": "proj"}
+
+    assert {node.id for node in subgraph.nodes} == {"doc1", "person1"}
+    assert len(subgraph.edges) == 1
+    assert subgraph.edges[0].source == "doc1"
+    assert subgraph.edges[0].target == "person1"
+    assert subgraph.edges[0].edge_type == "AUTHORED_BY"
+
+
+@pytest.mark.asyncio
+async def test_neighbors_without_project_builds_unscoped_query(store):
+    store._run_query = AsyncMock(return_value=_fake_result([]))
+
+    subgraph = await store.neighbors(node_id="1", depth=1)
+
+    query, params = store._run_query.await_args.args
+    assert "$project" not in query
+    assert params == {"id": "1"}
+    assert subgraph.nodes == []
+    assert subgraph.edges == []
+
+
+@pytest.mark.asyncio
+async def test_neighbors_extracts_dict_nodes_and_edges(store):
+    n = {"id": "doc1", "label": "Document"}
+    m = {"id": "person1", "label": "Person"}
+    rel = {"source": "doc1", "target": "person1", "edge_type": "AUTHORED_BY", "properties": {}}
+    store._run_query = AsyncMock(return_value=_fake_result([[n, [rel], m]]))
+
+    subgraph = await store.neighbors(node_id="doc1", depth=1)
+
+    assert len(subgraph.nodes) == 2
+    assert subgraph.edges[0].source == "doc1"
+    assert subgraph.edges[0].target == "person1"
+
+
+@pytest.mark.asyncio
+async def test_neighbors_extracts_fallback_scalar_nodes(store):
+    store._run_query = AsyncMock(
+        return_value=_fake_result([["raw_node_value", None, "raw_target_value"]])
+    )
+
+    subgraph = await store.neighbors(node_id="1", depth=1)
+
+    assert {node.id for node in subgraph.nodes} == {"raw_node_value", "raw_target_value"}
+    assert subgraph.edges == []
+
+
+@pytest.mark.asyncio
+async def test_neighbors_skips_malformed_rows(store):
+    store._run_query = AsyncMock(return_value=_fake_result([[1, 2]]))
+
+    subgraph = await store.neighbors(node_id="1", depth=1)
+
+    assert subgraph.nodes == []
+    assert subgraph.edges == []
+
+
+@pytest.mark.asyncio
+async def test_neighbors_skips_unsupported_relationship_type(store):
+    n = {"id": "doc1"}
+    m = {"id": "person1"}
+    store._run_query = AsyncMock(return_value=_fake_result([[n, [123], m]]))
+
+    subgraph = await store.neighbors(node_id="doc1", depth=1)
+
+    assert len(subgraph.nodes) == 2
+    assert subgraph.edges == []
+
+
+# ------------------------------------------------------------------
+# query_cypher
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_cypher_returns_result_set(store):
+    store._run_query = AsyncMock(return_value=_fake_result([["a", 1]]))
+
+    result = await store.query_cypher("MATCH (n) RETURN n", {"x": 1})
+
+    assert result == [["a", 1]]
+    store._run_query.assert_awaited_once_with("MATCH (n) RETURN n", {"x": 1})
+
+
+@pytest.mark.asyncio
+async def test_query_cypher_defaults_none_params_to_empty_dict(store):
+    store._run_query = AsyncMock(return_value=_fake_result([]))
+
+    await store.query_cypher("MATCH (n) RETURN n", None)
+
+    store._run_query.assert_awaited_once_with("MATCH (n) RETURN n", {})
+
+
+# ------------------------------------------------------------------
+# _clean_props
+# ------------------------------------------------------------------
+
+
+def test_clean_props_passes_through_primitives(store):
+    props = {"a": "str", "b": 1, "c": 1.5, "d": True}
+
+    assert store._clean_props(props) == props
+
+
+def test_clean_props_drops_none_values(store):
+    assert store._clean_props({"a": None}) == {}
+
+
+def test_clean_props_serializes_datetime_and_date(store):
+    dt = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    d = datetime.date(2026, 1, 1)
+
+    result = store._clean_props({"dt": dt, "d": d})
+
+    assert result["dt"] == dt.isoformat()
+    assert result["d"] == d.isoformat()
+
+
+def test_clean_props_serializes_enum_to_value(store):
+    class Color(Enum):
+        RED = "red"
+
+    assert store._clean_props({"c": Color.RED}) == {"c": "red"}
+
+
+def test_clean_props_keeps_list_of_primitives(store):
+    assert store._clean_props({"tags": ["a", 1, True]}) == {"tags": ["a", 1, True]}
+
+
+def test_clean_props_list_drops_none_items(store):
+    assert store._clean_props({"items": [None, "a"]}) == {"items": ["a"]}
+
+
+def test_clean_props_list_json_encodes_nested_dict(store):
+    result = store._clean_props({"items": [{"x": 1}]})
+
+    assert result["items"] == [json.dumps({"x": 1}, ensure_ascii=False)]
+
+
+def test_clean_props_list_stringifies_nested_object(store):
+    class Foo:
+        def __str__(self):
+            return "foo_str"
+
+    result = store._clean_props({"items": [Foo()]})
+
+    assert result["items"] == ["foo_str"]
+
+
+def test_clean_props_dict_value_json_encoded(store):
+    result = store._clean_props({"meta": {"a": 1}})
+
+    assert result["meta"] == json.dumps({"a": 1}, ensure_ascii=False)
+
+
+def test_clean_props_dict_value_falls_back_to_str_on_json_failure(store):
+    class Unserializable:
+        def __repr__(self):
+            return "<Unserializable>"
+
+    value = {"x": Unserializable()}
+
+    result = store._clean_props({"meta": value})
+
+    assert result["meta"] == str(value)
+
+
+def test_clean_props_object_falls_back_to_str(store):
+    class Foo:
+        def __str__(self):
+            return "custom"
+
+    assert store._clean_props({"obj": Foo()}) == {"obj": "custom"}
+
+
+def test_clean_props_drops_value_when_str_raises(store):
+    class Bad:
+        def __str__(self):
+            raise Exception("boom")
+
+    assert store._clean_props({"obj": Bad()}) == {}
+
+
+# ------------------------------------------------------------------
+# _run_query
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_query_delegates_to_graph_query_in_thread(mock_falkordb):
+    _, _, mock_graph = mock_falkordb
+    mock_graph.query.return_value = "result"
+    store = FalkorGraphStore()
+
+    result = await store._run_query("MATCH (n) RETURN n", {"a": 1})
+
+    assert result == "result"
+    mock_graph.query.assert_called_once_with("MATCH (n) RETURN n", {"a": 1})

--- a/packages/qdrant-loader-core/tests/test_falkor_store.py
+++ b/packages/qdrant-loader-core/tests/test_falkor_store.py
@@ -221,12 +221,12 @@ def test_edge_payload_falls_back_to_props_project(store):
     assert payload["project"] == "from_props"
 
 
-def test_edge_payload_no_project_at_all(store):
+def test_edge_payload_defaults_to_global_project(store):
     edge = GraphEdge(source="a", target="b", edge_type="LINKS_TO")
 
     payload = store._edge_payload(edge)
 
-    assert payload["project"] is None
+    assert payload["project"] == GLOBAL_PROJECT
 
 
 # ------------------------------------------------------------------
@@ -250,16 +250,16 @@ async def test_upsert_edge_with_project_and_kind(store):
 
 
 @pytest.mark.asyncio
-async def test_upsert_edge_without_project_or_kind(store):
+async def test_upsert_edge_without_explicit_project_defaults_to_global(store):
     store._run_query = AsyncMock()
     edge = GraphEdge(source="a", target="b", edge_type="LINKS_TO")
 
     await store.upsert_edge(edge)
 
     query, payload = store._run_query.await_args.args
-    assert "$project" not in query
+    assert "project: $project" in query
     assert "kind: $props.kind" not in query
-    assert payload["project"] is None
+    assert payload["project"] == GLOBAL_PROJECT
 
 
 @pytest.mark.asyncio

--- a/packages/qdrant-loader-core/tests/test_git_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_git_extractor.py
@@ -32,3 +32,43 @@ async def test_git_commit():
     assert any(n.label == "Container" for n in result.nodes)
     assert any(e.edge_type == "AUTHORED_BY" for e in result.edges)
     assert any(e.edge_type == "BELONGS_TO" for e in result.edges)
+
+
+@pytest.mark.asyncio
+async def test_git_file_without_repository_name_has_no_container():
+    extractor = GitEntityExtractor()
+
+    doc = Document(
+        title="Orphan file",
+        content_type="file",
+        content="content",
+        source_type="git",
+        source="def456",
+        url="http://git/commit/def456",
+        metadata={"last_commit_author": "alice@company.com"},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Container" for n in result.nodes)
+    assert not any(e.edge_type == "BELONGS_TO" for e in result.edges)
+
+
+@pytest.mark.asyncio
+async def test_git_file_without_author_has_no_person():
+    extractor = GitEntityExtractor()
+
+    doc = Document(
+        title="No author commit",
+        content_type="commit",
+        content="content",
+        source_type="git",
+        source="ghi789",
+        url="http://git/commit/ghi789",
+        metadata={"repository_name": "repo"},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Person" for n in result.nodes)
+    assert not any(e.edge_type == "AUTHORED_BY" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_graph_base.py
+++ b/packages/qdrant-loader-core/tests/test_graph_base.py
@@ -1,0 +1,85 @@
+import pytest
+from qdrant_loader_core.graph.base import GraphStore
+from qdrant_loader_core.graph.models import GraphEdge, GraphNode
+
+
+class SuperCallingGraphStore(GraphStore):
+    """Concrete subclass that delegates to the abstract default bodies via super()."""
+
+    async def upsert_node(self, node):
+        return await super().upsert_node(node)
+
+    async def upsert_edge(self, edge):
+        return await super().upsert_edge(edge)
+
+    async def upsert_nodes_batch(self, nodes):
+        return await super().upsert_nodes_batch(nodes)
+
+    async def upsert_edges_batch(self, edges):
+        return await super().upsert_edges_batch(edges)
+
+    async def neighbors(self, node_id, depth, edge_types=None, project=None):
+        return await super().neighbors(
+            node_id, depth, edge_types=edge_types, project=project
+        )
+
+    async def query_cypher(self, cypher, params):
+        return await super().query_cypher(cypher, params)
+
+
+def test_graph_store_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError):
+        GraphStore()
+
+
+def test_graph_store_missing_method_cannot_be_instantiated():
+    class IncompleteGraphStore(GraphStore):
+        async def upsert_node(self, node):
+            return None
+
+    with pytest.raises(TypeError):
+        IncompleteGraphStore()
+
+
+@pytest.mark.asyncio
+async def test_upsert_node_default_raises_not_implemented():
+    store = SuperCallingGraphStore()
+    with pytest.raises(NotImplementedError):
+        await store.upsert_node(GraphNode(id="1", label="Test"))
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_default_raises_not_implemented():
+    store = SuperCallingGraphStore()
+    with pytest.raises(NotImplementedError):
+        await store.upsert_edge(GraphEdge(source="1", target="2", edge_type="REL"))
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_default_raises_not_implemented():
+    store = SuperCallingGraphStore()
+    with pytest.raises(NotImplementedError):
+        await store.upsert_nodes_batch([GraphNode(id="1", label="Test")])
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_default_raises_not_implemented():
+    store = SuperCallingGraphStore()
+    with pytest.raises(NotImplementedError):
+        await store.upsert_edges_batch(
+            [GraphEdge(source="1", target="2", edge_type="REL")]
+        )
+
+
+@pytest.mark.asyncio
+async def test_neighbors_default_raises_not_implemented():
+    store = SuperCallingGraphStore()
+    with pytest.raises(NotImplementedError):
+        await store.neighbors("1", depth=2, edge_types=["REL"], project="test")
+
+
+@pytest.mark.asyncio
+async def test_query_cypher_default_raises_not_implemented():
+    store = SuperCallingGraphStore()
+    with pytest.raises(NotImplementedError):
+        await store.query_cypher("MATCH (n) RETURN n", {})

--- a/packages/qdrant-loader-core/tests/test_graph_init.py
+++ b/packages/qdrant-loader-core/tests/test_graph_init.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import qdrant_loader_core.graph as graph_module
+
+
+@pytest.fixture(autouse=True)
+def reset_graph_store_singleton():
+    graph_module._graph_store = None
+    yield
+    graph_module._graph_store = None
+
+
+@pytest.mark.asyncio
+async def test_get_graph_store_raises_when_falkor_extra_not_installed():
+    with patch.object(graph_module, "FalkorGraphStore", None):
+        with pytest.raises(ModuleNotFoundError, match="requires the 'graph' extra"):
+            await graph_module.get_graph_store()
+
+
+@pytest.mark.asyncio
+async def test_get_graph_store_creates_with_defaults():
+    mock_store = MagicMock()
+    mock_store_cls = MagicMock(return_value=mock_store)
+
+    with (
+        patch.object(graph_module, "FalkorGraphStore", mock_store_cls),
+        patch.object(graph_module, "init_schema", AsyncMock()) as mock_init,
+    ):
+        result = await graph_module.get_graph_store()
+
+    mock_store_cls.assert_called_once_with(
+        host="localhost", port=6379, graph_name="default_graph", max_connections=10
+    )
+    mock_init.assert_awaited_once_with(mock_store)
+    assert result is mock_store
+
+
+@pytest.mark.asyncio
+async def test_get_graph_store_creates_with_custom_params():
+    mock_store = MagicMock()
+    mock_store_cls = MagicMock(return_value=mock_store)
+
+    with (
+        patch.object(graph_module, "FalkorGraphStore", mock_store_cls),
+        patch.object(graph_module, "init_schema", AsyncMock()),
+    ):
+        result = await graph_module.get_graph_store(
+            host="myhost", port=1234, graph_name="mygraph", max_connections=5
+        )
+
+    mock_store_cls.assert_called_once_with(
+        host="myhost", port=1234, graph_name="mygraph", max_connections=5
+    )
+    assert result is mock_store
+
+
+@pytest.mark.asyncio
+async def test_get_graph_store_returns_cached_singleton_on_second_call():
+    mock_store = MagicMock()
+    mock_store_cls = MagicMock(return_value=mock_store)
+
+    with (
+        patch.object(graph_module, "FalkorGraphStore", mock_store_cls),
+        patch.object(graph_module, "init_schema", AsyncMock()),
+    ):
+        first = await graph_module.get_graph_store()
+        second = await graph_module.get_graph_store()
+
+    mock_store_cls.assert_called_once()
+    assert first is second

--- a/packages/qdrant-loader-core/tests/test_graph_init.py
+++ b/packages/qdrant-loader-core/tests/test_graph_init.py
@@ -30,7 +30,11 @@ async def test_get_graph_store_creates_with_defaults():
         result = await graph_module.get_graph_store()
 
     mock_store_cls.assert_called_once_with(
-        host="localhost", port=6379, graph_name="default_graph", max_connections=10
+        host="localhost",
+        port=6379,
+        password=None,
+        graph_name="default_graph",
+        max_connections=10,
     )
     mock_init.assert_awaited_once_with(mock_store)
     assert result is mock_store
@@ -46,11 +50,19 @@ async def test_get_graph_store_creates_with_custom_params():
         patch.object(graph_module, "init_schema", AsyncMock()),
     ):
         result = await graph_module.get_graph_store(
-            host="myhost", port=1234, graph_name="mygraph", max_connections=5
+            host="myhost",
+            port=1234,
+            password="secret",
+            graph_name="mygraph",
+            max_connections=5,
         )
 
     mock_store_cls.assert_called_once_with(
-        host="myhost", port=1234, graph_name="mygraph", max_connections=5
+        host="myhost",
+        port=1234,
+        password="secret",
+        graph_name="mygraph",
+        max_connections=5,
     )
     assert result is mock_store
 

--- a/packages/qdrant-loader-core/tests/test_graph_registry_module.py
+++ b/packages/qdrant-loader-core/tests/test_graph_registry_module.py
@@ -8,6 +8,7 @@ def test_registry_module_registers_all_builtin_extractors():
     module_name = "qdrant_loader_core.graph.registry"
     previous_registry = EntityExtractor._registry.copy()
     previous_module = sys.modules.pop(module_name, None)
+    EntityExtractor._registry.clear()
     try:
         importlib.import_module(module_name)
         assert set(EntityExtractor._registry) == {

--- a/packages/qdrant-loader-core/tests/test_graph_registry_module.py
+++ b/packages/qdrant-loader-core/tests/test_graph_registry_module.py
@@ -1,0 +1,20 @@
+import sys
+
+from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
+
+
+def test_registry_module_registers_all_builtin_extractors():
+    EntityExtractor._registry.clear()
+    sys.modules.pop("qdrant_loader_core.graph.registry", None)
+
+    import qdrant_loader_core.graph.registry  # noqa: F401
+
+    assert set(EntityExtractor._registry.keys()) == {
+        "jira",
+        "confluence",
+        "git",
+        "localfile",
+        "publicdocs",
+    }
+
+    EntityExtractor._registry.clear()

--- a/packages/qdrant-loader-core/tests/test_graph_registry_module.py
+++ b/packages/qdrant-loader-core/tests/test_graph_registry_module.py
@@ -1,20 +1,26 @@
+import importlib
 import sys
 
 from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
 
 
 def test_registry_module_registers_all_builtin_extractors():
-    EntityExtractor._registry.clear()
-    sys.modules.pop("qdrant_loader_core.graph.registry", None)
-
-    import qdrant_loader_core.graph.registry  # noqa: F401
-
-    assert set(EntityExtractor._registry.keys()) == {
-        "jira",
-        "confluence",
-        "git",
-        "localfile",
-        "publicdocs",
-    }
-
-    EntityExtractor._registry.clear()
+    module_name = "qdrant_loader_core.graph.registry"
+    previous_registry = EntityExtractor._registry.copy()
+    previous_module = sys.modules.pop(module_name, None)
+    try:
+        importlib.import_module(module_name)
+        assert set(EntityExtractor._registry) == {
+            "jira",
+            "confluence",
+            "git",
+            "localfile",
+            "publicdocs",
+        }
+    finally:
+        EntityExtractor._registry.clear()
+        EntityExtractor._registry.update(previous_registry)
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module

--- a/packages/qdrant-loader-core/tests/test_jira_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_jira_extractor.py
@@ -168,3 +168,126 @@ async def test_jira_parent_edge_kind_derived_from_issue_type():
 
     assert subtask_edge.properties["kind"] == "subtask"
     assert story_edge.properties["kind"] == "child"
+
+
+@pytest.mark.asyncio
+async def test_jira_reporter_and_assignee_as_plain_strings():
+    extractor = JiraEntityExtractor()
+
+    doc = Document(
+        title="Legacy issue",
+        content_type="issue",
+        content="content",
+        source_type="jira",
+        source="ABC-9",
+        url="http://jira/ABC-9",
+        metadata={
+            "key": "ABC-9",
+            "project_key": "ABC",
+            "reporter": "reporter@company.com",
+            "assignee": "assignee@company.com",
+        },
+    )
+
+    result = await extractor.extract(doc)
+    person_ids = {n.id for n in result.nodes if n.label == "Person"}
+
+    assert person_ids == {"reporter@company.com", "assignee@company.com"}
+
+
+@pytest.mark.asyncio
+async def test_jira_reporter_and_assignee_sharing_id_deduplicated():
+    extractor = JiraEntityExtractor()
+
+    doc = Document(
+        title="Self assigned issue",
+        content_type="issue",
+        content="content",
+        source_type="jira",
+        source="ABC-10",
+        url="http://jira/ABC-10",
+        metadata={
+            "key": "ABC-10",
+            "project_key": "ABC",
+            "reporter": "same@company.com",
+            "assignee": "same@company.com",
+        },
+    )
+
+    result = await extractor.extract(doc)
+    person_nodes = [n for n in result.nodes if n.label == "Person"]
+    authored_by_edges = [e for e in result.edges if e.edge_type == "AUTHORED_BY"]
+
+    assert len(person_nodes) == 1
+    assert len(authored_by_edges) == 1
+
+
+@pytest.mark.asyncio
+async def test_jira_issue_without_project_key_has_no_container():
+    extractor = JiraEntityExtractor()
+
+    doc = Document(
+        title="No project",
+        content_type="issue",
+        content="content",
+        source_type="jira",
+        source="ABC-11",
+        url="http://jira/ABC-11",
+        metadata={"key": "ABC-11"},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Container" for n in result.nodes)
+
+
+@pytest.mark.asyncio
+async def test_jira_description_with_git_url_creates_link():
+    extractor = JiraEntityExtractor()
+
+    doc = Document(
+        title="Issue with git link",
+        content_type="issue",
+        content="content",
+        source_type="jira",
+        source="ABC-12",
+        url="http://jira/ABC-12",
+        metadata={
+            "key": "ABC-12",
+            "project_key": "ABC",
+            "description": "See https://github.com/org/repo for details",
+        },
+    )
+
+    result = await extractor.extract(doc)
+    git_link_edges = [
+        e
+        for e in result.edges
+        if e.edge_type == "LINKS_TO" and e.properties.get("kind") == "git"
+    ]
+
+    assert len(git_link_edges) == 1
+    assert any(n.label == "URL" for n in result.nodes)
+
+
+@pytest.mark.asyncio
+async def test_jira_linked_issue_missing_key_is_skipped():
+    extractor = JiraEntityExtractor()
+
+    doc = Document(
+        title="Malformed link",
+        content_type="issue",
+        content="content",
+        source_type="jira",
+        source="ABC-13",
+        url="http://jira/ABC-13",
+        metadata={
+            "key": "ABC-13",
+            "project_key": "ABC",
+            "linked_issue_details": [{"relation": "clones"}],
+        },
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(e.edge_type == "LINKS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_localfile_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_localfile_extractor.py
@@ -28,3 +28,23 @@ async def test_localfile_basic():
     assert any(n.label == "Document" for n in result.nodes)
     assert any(n.label == "Container" for n in result.nodes)
     assert any(e.edge_type == "BELONGS_TO" for e in result.edges)
+
+
+@pytest.mark.asyncio
+async def test_localfile_without_url_has_no_container():
+    extractor = LocalFileEntityExtractor()
+
+    doc = Document(
+        title="No URL",
+        content_type="page",
+        content="content",
+        source_type="localfile",
+        source="localfile_instance",
+        url="",
+        metadata={"file_name": "notes.md"},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Container" for n in result.nodes)
+    assert not any(e.edge_type == "BELONGS_TO" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
+++ b/packages/qdrant-loader-core/tests/test_publicdocs_extractor.py
@@ -39,3 +39,62 @@ async def test_public_webpage():
     assert any(
         e.edge_type == "HAS_ATTACHMENT" for e in result.edges
     ), "HAS_ATTACHMENT edge missing"
+
+
+@pytest.mark.asyncio
+async def test_public_webpage_without_url_has_no_project_or_container():
+    extractor = PublicDocsEntityExtractor()
+
+    doc = Document(
+        title="No URL page",
+        content_type="page",
+        content="content",
+        source_type="publicdocs",
+        source="no-url-source",
+        url="",
+        metadata={},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Container" for n in result.nodes)
+    assert all(n.project is None for n in result.nodes)
+
+
+@pytest.mark.asyncio
+async def test_public_webpage_with_domain_less_url_has_no_container():
+    extractor = PublicDocsEntityExtractor()
+
+    doc = Document(
+        title="Relative URL page",
+        content_type="page",
+        content="content",
+        source_type="publicdocs",
+        source="relative-source",
+        url="not-a-real-url",
+        metadata={"url": "not-a-real-url"},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Container" for n in result.nodes)
+
+
+@pytest.mark.asyncio
+async def test_public_webpage_attachment_missing_id_is_skipped():
+    extractor = PublicDocsEntityExtractor()
+
+    doc = Document(
+        title="Page with malformed attachment",
+        content_type="page",
+        content="content",
+        source_type="publicdocs",
+        source="https://example.com/page5",
+        url="https://example.com/page5",
+        metadata={"attachments": [{"filename": "no_id.pdf"}]},
+    )
+
+    result = await extractor.extract(doc)
+
+    assert not any(n.label == "Attachment" for n in result.nodes)
+    assert not any(e.edge_type == "HAS_ATTACHMENT" for e in result.edges)

--- a/packages/qdrant-loader-core/tests/test_schema.py
+++ b/packages/qdrant-loader-core/tests/test_schema.py
@@ -64,6 +64,19 @@ async def test_ensure_indexes_ignore_existing():
 
 
 @pytest.mark.asyncio
+async def test_ensure_indexes_reraises_unexpected_errors():
+    graph_store = AsyncMock()
+
+    async def mock_query(query, params):
+        raise Exception("connection refused")
+
+    graph_store.query_cypher.side_effect = mock_query
+
+    with pytest.raises(Exception, match="connection refused"):
+        await _ensure_indexes(graph_store)
+
+
+@pytest.mark.asyncio
 async def test_apply_creates_schema_nodes_and_edges():
     graph_store = AsyncMock()
 

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/fastmcp_app.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/fastmcp_app.py
@@ -32,15 +32,20 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
     Whatever this yields becomes ``ctx.lifespan_context`` inside every tool.
     """
     # Lazy imports keep module import cheap
-    from .config_loader import load_config
+    from .config_loader import load_config, resolve_config_path
     from .mcp.intelligence_handler import IntelligenceHandler
     from .mcp.protocol import MCPProtocol
     from .mcp.search_handler import SearchHandler
     from .search.engine import SearchEngine
     from .search.processor import QueryProcessor
 
-    config_path = os.getenv("MCP_CONFIG")
-    config, _, _ = load_config(Path(config_path) if config_path else None)
+    config_path_env = os.getenv("MCP_CONFIG")
+    cli_config_path = Path(config_path_env) if config_path_env else None
+    # Resolve once so the graph store (initialized lazily, per-request) uses the
+    # exact same config file as the search engine below instead of re-deriving
+    # its own path from Path.cwd(), which can silently diverge from this one.
+    resolved_config_path = resolve_config_path(cli_config_path)
+    config, _, _ = load_config(resolved_config_path or cli_config_path)
 
     search_engine = SearchEngine()
     query_processor = QueryProcessor(config.openai)
@@ -63,7 +68,9 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
         # Stateful: holds the cluster store shared with expand_cluster
         # build one instance for reuse
         intelligence_handler = IntelligenceHandler(
-            search_engine=search_engine, protocol=MCPProtocol()
+            search_engine=search_engine,
+            protocol=MCPProtocol(),
+            config_path=resolved_config_path,
         )
 
         yield {

--- a/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/intelligence_handler.py
+++ b/packages/qdrant-loader-mcp-server/src/qdrant_loader_mcp_server/mcp/intelligence_handler.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from qdrant_loader.config import initialize_config
+from qdrant_loader.config import get_settings, initialize_config
 from qdrant_loader_core.graph import get_graph_store
 
 from ..search.engine import SearchEngine
@@ -26,7 +26,12 @@ logger = LoggingConfig.get_logger("src.mcp.intelligence_handler")
 class IntelligenceHandler:
     """Handler for cross-document intelligence operations."""
 
-    def __init__(self, search_engine: SearchEngine, protocol: MCPProtocol):
+    def __init__(
+        self,
+        search_engine: SearchEngine,
+        protocol: MCPProtocol,
+        config_path: Path | None = None,
+    ):
         """Initialize intelligence handler."""
         self.search_engine = search_engine
         self.protocol = protocol
@@ -37,18 +42,25 @@ class IntelligenceHandler:
         self._lock = asyncio.Lock()
         self._graph_store = None
         self._graph_store_lock = asyncio.Lock()
+        # Resolved by fastmcp_app._lifespan (MCP_CONFIG / --config) so the graph store loads the same config as the search engine.
+        self._config_path = config_path
 
     async def _get_graph_store(self):
         """Lazy-initialize graph store with proper locking."""
         async with self._graph_store_lock:
             if self._graph_store is None:
-                project_root = Path.cwd()
+                config_path = self._config_path or (Path.cwd() / "config.yaml")
+                project_root = config_path.parent
                 initialize_config(
-                    yaml_path=project_root / "config.yaml",
+                    yaml_path=config_path,
                     env_path=project_root / ".env",
                     skip_validation=True,
                 )
-                self._graph_store = await get_graph_store()
+                settings = get_settings()
+                graph_cfg = getattr(settings.global_config, "graph", None)
+                self._graph_store = await get_graph_store(
+                    **(graph_cfg.store_kwargs() if graph_cfg else {})
+                )
             return self._graph_store
 
     async def _run_graph_query(

--- a/packages/qdrant-loader/src/qdrant_loader/config/graph.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/graph.py
@@ -41,6 +41,11 @@ class GraphConfig(BaseModel):
         return {
             "host": self.connection.host,
             "port": self.connection.port,
+            "password": (
+                self.connection.password.get_secret_value()
+                if self.connection.password is not None
+                else None
+            ),
             "graph_name": self.graph_name,
             "max_connections": self.pool.max_connections,
         }

--- a/packages/qdrant-loader/src/qdrant_loader/config/graph.py
+++ b/packages/qdrant-loader/src/qdrant_loader/config/graph.py
@@ -36,6 +36,15 @@ class GraphConfig(BaseModel):
         default_factory=GraphPoolConfig, description="Connection pool settings"
     )
 
+    def store_kwargs(self) -> dict:
+        """Kwargs for qdrant_loader_core.graph.get_graph_store()."""
+        return {
+            "host": self.connection.host,
+            "port": self.connection.port,
+            "graph_name": self.graph_name,
+            "max_connections": self.pool.max_connections,
+        }
+
     def to_dict(self) -> dict:
         """Convert config to dictionary (useful for client init)."""
         return {

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
@@ -169,7 +169,9 @@ class DocumentPipeline:
             return
 
         try:
-            graph_store = await get_graph_store()
+            graph_store = await get_graph_store(
+                **(graph_cfg.store_kwargs() if graph_cfg else {})
+            )
 
             if nodes_batch:
                 await graph_store.upsert_nodes_batch(nodes_batch)

--- a/packages/qdrant-loader/tests/unit/config/test_graph_config.py
+++ b/packages/qdrant-loader/tests/unit/config/test_graph_config.py
@@ -1,0 +1,38 @@
+from qdrant_loader.config.graph import GraphConfig
+
+
+def test_store_kwargs_defaults_password_to_none():
+    config = GraphConfig()
+
+    kwargs = config.store_kwargs()
+
+    assert kwargs == {
+        "host": "localhost",
+        "port": 6379,
+        "password": None,
+        "graph_name": "default_graph",
+        "max_connections": 10,
+    }
+
+
+def test_store_kwargs_unwraps_configured_password():
+    config = GraphConfig(
+        connection={
+            "host": "falkordb.internal",
+            "port": 6380,
+            "password": "s3cret",
+        },
+        graph_name="my_graph",
+        pool={"max_connections": 20},
+    )
+
+    kwargs = config.store_kwargs()
+
+    assert kwargs["password"] == "s3cret"
+    assert kwargs == {
+        "host": "falkordb.internal",
+        "port": 6380,
+        "password": "s3cret",
+        "graph_name": "my_graph",
+        "max_connections": 20,
+    }

--- a/packages/qdrant-loader/tests/unit/core/test_process_graph.py
+++ b/packages/qdrant-loader/tests/unit/core/test_process_graph.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from qdrant_loader.config.graph import GraphConfig
 from qdrant_loader.core.pipeline.document_pipeline import DocumentPipeline
 from qdrant_loader_core.graph.extractor.base_extractor import EntityExtractor
 
@@ -24,10 +25,9 @@ def document():
 
 
 def mock_settings(enabled: bool):
+    graph_cfg = GraphConfig(enabled=enabled)
     return SimpleNamespace(
-        global_config=SimpleNamespace(
-            graph=SimpleNamespace(enabled=enabled),
-        )
+        global_config=SimpleNamespace(graph=graph_cfg),
     )
 
 


### PR DESCRIPTION

# Pull Request

## Summary

Fix decouple graph store config, fix Confluence/Git/MCP graph bugs, and add unit tests raising core graph coverage

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Affected connectors/stages:** Graph ingestion/storage (graph store init + singleton behavior, batching upserts, `neighbors`/`query_cypher`, and node/edge project scoping), Confluence and Git entity extractors, Jira/LocalFile/PublicDocs extractor edge cases, document pipeline graph processing, and MCP server startup (IntelligenceHandler graph-store init/config resolution).
- **Configuration (breaking/additive):** Added `GraphConfig.store_kwargs()` to pass graph-store init args into `get_graph_store`. `get_graph_store()` now accepts `password: str | None`, and graph pool sizing is derived only from `max_connections` (no longer overridden via global settings). `FalkorDB` moved to the optional `graph` extra (was mandatory dependency), so installs without the extra won’t include Falkor support.
- **Tests:** Extensive new/expanded coverage for graph-store behavior, schema migration refactor, extractor missing-metadata cases, and MCP/config path handling.
- **Security/resource safety:** Password is explicitly plumbed; dependency optionality and `max_connections` validation help limit unintended connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->