### PR TITLE
chore: refine docker files for v1.0.4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,8 @@ OPENAI_API_KEY=your-openai-api-key
 MCP_LOG_LEVEL=INFO
 MCP_LOG_FILE=mcp.log
 MCP_DISABLE_CONSOLE_LOGGING=false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Falkor database
+# ─────────────────────────────────────────────────────────────────────────────
+FALKORDB_PASSWORD=change-me-since-this-is-fake

--- a/.env.example
+++ b/.env.example
@@ -47,4 +47,4 @@ MCP_DISABLE_CONSOLE_LOGGING=false
 # ─────────────────────────────────────────────────────────────────────────────
 # Falkor database
 # ─────────────────────────────────────────────────────────────────────────────
-FALKORDB_PASSWORD=change-me-since-this-is-fake
+FALKORDB_PASSWORD=

--- a/docker/Dockerfile.dev.qdrant-loader
+++ b/docker/Dockerfile.dev.qdrant-loader
@@ -49,4 +49,4 @@ EXPOSE 8081
 # The init command is safe to run on every startup.
 # It checks if the collection already exists and skips creation if it does,
 # so it does not drop or recreate existing data.
-CMD ["sh", "-c", "qdrant-loader init --config config.yaml --env .env && qdrant-loader serve --config config.yaml --env .env --host 0.0.0.0"]
+CMD ["sh", "-c", "qdrant-loader init --config config.yaml --env .env && exec qdrant-loader serve --config config.yaml --env .env --host 0.0.0.0"]

--- a/docker/Dockerfile.qdrant-loader
+++ b/docker/Dockerfile.qdrant-loader
@@ -39,4 +39,4 @@ EXPOSE 8081
 # The init command is safe to run on every startup.
 # It checks if the collection already exists and skips creation if it does,
 # so it does not drop or recreate existing data.
-CMD ["sh", "-c", "qdrant-loader init --config config.yaml --env .env && qdrant-loader serve --config config.yaml --env .env --host 0.0.0.0"]
+CMD ["sh", "-c", "qdrant-loader init --config config.yaml --env .env && exec qdrant-loader serve --config config.yaml --env .env --host 0.0.0.0"]

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -190,6 +190,8 @@ services:
     ports:
       - "6379:6379"
       - "3000:3000"
+    environment:
+      - REDIS_ARGS=--requirepass ${FALKORDB_PASSWORD:?FALKORDB_PASSWORD must be set}
     volumes:
       - falkordb_data:/var/lib/falkordb
     restart: unless-stopped
@@ -212,27 +214,27 @@ services:
   #   ollama pull llama3.2
   #
   # ==============================================================================
-  # ollama:
-  #   image: ollama/ollama:latest
-  #   ports:
-  #     - 11434:11434
-  #   volumes:
-  #     - ollama:/root/.ollama
-  #   container_name: ollama
-  #   tty: true
-  #   restart: always
-  #   environment:
-  #     - OLLAMA_KEEP_ALIVE=24h
-  #     - OLLAMA_HOST=0.0.0.0
-  #   command: ["serve"]
-  #   networks:
-  #     - qdrant-net
-  #   healthcheck:
-  #     test: ["CMD", "ollama", "ps"]
-  #     interval: 30s
-  #     timeout: 10s
-  #     retries: 3
-  #     start_period: 40s
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - 11434:11434
+    volumes:
+      - ollama:/root/.ollama
+    container_name: ollama
+    tty: true
+    restart: always
+    environment:
+      - OLLAMA_KEEP_ALIVE=24h
+      - OLLAMA_HOST=0.0.0.0
+    command: ["serve"]
+    networks:
+      - qdrant-net
+    healthcheck:
+      test: ["CMD", "ollama", "ps"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 volumes:
   qdrant_data:
@@ -241,8 +243,8 @@ volumes:
     driver: local
   falkordb_data:
     driver: local
-  # ollama:
-  #   driver: local
+  ollama:
+    driver: local
 
 networks:
   qdrant-net:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -190,6 +190,8 @@ services:
     ports:
       - "6379:6379"
       - "3000:3000"
+    environment:
+      - REDIS_ARGS=--requirepass ${FALKORDB_PASSWORD:?FALKORDB_PASSWORD must be set}
     volumes:
       - falkordb_data:/var/lib/falkordb
     restart: unless-stopped


### PR DESCRIPTION
# Pull Request

## Summary

Use exec for the serving process and add password for FalkorDB

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [x] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Affected components:** Qdrant Loader container startup (`init`/`serve` in `docker/Dockerfile*.qdrant-loader`) and the FalkorDB + Ollama services in Docker Compose (`docker/docker-compose*.yaml`).
- **Configuration changes (additive/breaking):** Additive template entry `FALKORDB_PASSWORD` in `.env.example`. FalkorDB is now started with Redis `--requirepass ${FALKORDB_PASSWORD:?FALKORDB_PASSWORD must be set}` (so deployments must define the variable; leaving it empty effectively configures an empty password). Dev Compose additionally enables the previously commented-out Ollama service and adds a named volume for persistence.
- **Testing:** No test coverage or validation results for these Docker/config changes are specified.
- **Security/resource-safety:** `exec` is used so the server process replaces the shell process (better signal/process lifecycle handling). FalkorDB password enforcement is added, but the example/template permits an empty password, which weakens protection if not overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->