### PR TITLE
fix(orchestrator): fail no-change jobs when qdrant collection is unav…

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -12,6 +12,7 @@ from qdrant_loader.core.project_manager import ProjectManager
 from qdrant_loader.core.qdrant_manager import QdrantManager
 from qdrant_loader.core.state.state_change_detector import StateChangeDetector
 from qdrant_loader.core.state.state_manager import StateManager
+from qdrant_loader.core.worker.handlers import PermanentJobError
 from qdrant_loader.utils.logging import LoggingConfig
 from qdrant_loader.utils.sensitive import sanitize_exception_message
 
@@ -322,6 +323,16 @@ class PipelineOrchestrator:
             ):
                 raise ValueError(f"No sources found for type '{source_type}'")
 
+            # Fail fast when destination collection is unavailable. Without this
+            # preflight, a job with no changed documents would incorrectly return
+            # success even while Qdrant is misconfigured/unreachable.
+            try:
+                self.components.qdrant_manager.assert_collection_accessible()
+            except Exception as e:
+                raise PermanentJobError(
+                    f"Qdrant collection is unavailable: {sanitize_exception_message(e)}"
+                ) from e
+
             # Stream documents in bounded micro-batches and process each batch
             total_documents = 0
             processed_count = 0
@@ -531,11 +542,24 @@ class PipelineOrchestrator:
                             "No documents were successfully processed",
                             error_count=aggregated_result.error_count,
                         )
+                        raise PermanentJobError(
+                            self._format_indexing_failure_message(aggregated_result)
+                        )
                     else:
                         logger.info("No new or updated documents to process")
                     return 0
 
                 self.last_pipeline_result = aggregated_result
+                if aggregated_result.error_count > 0:
+                    logger.error(
+                        f"Ingestion completed with failures: "
+                        f"{aggregated_result.success_count} succeeded, "
+                        f"{aggregated_result.error_count} failed",
+                        error_count=aggregated_result.error_count,
+                    )
+                    raise PermanentJobError(
+                        self._format_indexing_failure_message(aggregated_result)
+                    )
                 logger.info(
                     f"✅ Ingestion completed: {aggregated_result.success_count} chunks processed successfully"
                 )
@@ -551,6 +575,15 @@ class PipelineOrchestrator:
                 sanitized_traceback=sanitize_exception_message(traceback.format_exc()),
             )
             raise
+
+    @staticmethod
+    def _format_indexing_failure_message(result: PipelineResult) -> str:
+        """Build an error message summarizing chunk-level indexing failures."""
+        error_summary = "; ".join(result.errors[:5])
+        return (
+            f"{result.error_count} chunk(s) failed to index into Qdrant "
+            f"(out of {result.success_count + result.error_count}): {error_summary}"
+        )
 
     async def _process_all_projects(
         self,
@@ -600,6 +633,9 @@ class PipelineOrchestrator:
                 logger.debug(
                     f"Processed {project_documents} documents from project: {project_id}"
                 )
+            except PermanentJobError:
+                # PermanentJobError from process_documents should propagate
+                raise
             except ConnectorConfigurationError as e:
                 logger.error(
                     f"Configuration error in project {project_id}: "

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -327,7 +327,7 @@ class PipelineOrchestrator:
             # preflight, a job with no changed documents would incorrectly return
             # success even while Qdrant is misconfigured/unreachable.
             try:
-                self.components.qdrant_manager.assert_collection_accessible()
+                await self.components.qdrant_manager.assert_collection_accessible()
             except Exception as e:
                 raise PermanentJobError(
                     f"Qdrant collection is unavailable: {sanitize_exception_message(e)}"
@@ -579,7 +579,9 @@ class PipelineOrchestrator:
     @staticmethod
     def _format_indexing_failure_message(result: PipelineResult) -> str:
         """Build an error message summarizing chunk-level indexing failures."""
-        error_summary = "; ".join(result.errors[:5])
+        error_summary = "; ".join(
+            sanitize_exception_message(error) for error in result.errors[:5]
+        )
         return (
             f"{result.error_count} chunk(s) failed to index into Qdrant "
             f"(out of {result.success_count + result.error_count}): {error_summary}"

--- a/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
@@ -205,6 +205,14 @@ class QdrantManager:
             )
         return cast(QdrantClient, self.client)
 
+    def assert_collection_accessible(self) -> None:
+        """Validate that the configured collection is reachable.
+
+        Raises when the collection does not exist or Qdrant is unavailable.
+        """
+        client = self._ensure_client_connected()
+        client.get_collection(collection_name=self.collection_name)
+
     # Indexes that filter-based deletes (delete_points_by_document_id, etc.)
     # depend on. A silent failure here would surface later as a confusing
     # Qdrant error mid-delete, so these must raise instead of just warning.

--- a/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/qdrant_manager.py
@@ -205,13 +205,15 @@ class QdrantManager:
             )
         return cast(QdrantClient, self.client)
 
-    def assert_collection_accessible(self) -> None:
+    async def assert_collection_accessible(self) -> None:
         """Validate that the configured collection is reachable.
 
         Raises when the collection does not exist or Qdrant is unavailable.
         """
         client = self._ensure_client_connected()
-        client.get_collection(collection_name=self.collection_name)
+        await asyncio.to_thread(
+            client.get_collection, collection_name=self.collection_name
+        )
 
     # Indexes that filter-based deletes (delete_points_by_document_id, etc.)
     # depend on. A silent failure here would surface later as a confusing

--- a/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/worker/pool.py
@@ -6,7 +6,7 @@ import time
 from json import JSONDecodeError
 from typing import Any
 
-from qdrant_loader.core.worker.handlers import JobHandler
+from qdrant_loader.core.worker.handlers import JobHandler, PermanentJobError
 from qdrant_loader.core.worker.queue import JobQueue
 from qdrant_loader.utils.logging import LoggingConfig
 
@@ -237,7 +237,11 @@ class QueueWorkerPool:
                         )
                     elif handler_exc is not None:
                         duration_ms = round((time.monotonic() - t0) * 1000)
-                        is_retry = job.attempts < self._max_attempts
+                        # PermanentJobError always fails immediately, never retries
+                        is_retry = (
+                            not isinstance(handler_exc, PermanentJobError)
+                            and job.attempts < self._max_attempts
+                        )
                         retry_after_seconds = 0
                         if is_retry and self._retry_backoff_base_seconds > 0:
                             retry_after_seconds = self._retry_backoff_base_seconds * (

--- a/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
+++ b/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
@@ -38,6 +38,36 @@ def _setup_qdrant_loader_core_stubs(monkeypatch: pytest.MonkeyPatch):
     sparse_mod.get_sparse_encoder = _get_sparse_encoder
     monkeypatch.setitem(sys.modules, "qdrant_loader_core.sparse", sparse_mod)
 
+    graph_pkg = types.ModuleType("qdrant_loader_core.graph")
+    graph_pkg.__path__ = []
+    graph_pkg.get_graph_store = lambda *_args, **_kwargs: None
+    monkeypatch.setitem(sys.modules, "qdrant_loader_core.graph", graph_pkg)
+
+    graph_registry_mod = types.ModuleType("qdrant_loader_core.graph.registry")
+    monkeypatch.setitem(
+        sys.modules, "qdrant_loader_core.graph.registry", graph_registry_mod
+    )
+
+    graph_extractor_pkg = types.ModuleType("qdrant_loader_core.graph.extractor")
+    graph_extractor_pkg.__path__ = []
+    monkeypatch.setitem(
+        sys.modules, "qdrant_loader_core.graph.extractor", graph_extractor_pkg
+    )
+
+    base_extractor_mod = types.ModuleType(
+        "qdrant_loader_core.graph.extractor.base_extractor"
+    )
+
+    class _EntityExtractor:
+        pass
+
+    base_extractor_mod.EntityExtractor = _EntityExtractor
+    monkeypatch.setitem(
+        sys.modules,
+        "qdrant_loader_core.graph.extractor.base_extractor",
+        base_extractor_mod,
+    )
+
 
 @pytest.mark.asyncio
 async def test_incremental_pull_accepts_since_param(monkeypatch):
@@ -52,9 +82,14 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
 
     from qdrant_loader.core.pipeline.orchestrator import PipelineOrchestrator
 
+    components = MagicMock()
+    components.qdrant_manager.assert_collection_accessible = AsyncMock(
+        return_value=None
+    )
+
     orchestrator = PipelineOrchestrator(
         settings=MagicMock(),
-        components=MagicMock(),
+        components=components,
         project_manager=MagicMock(),
     )
     # Stub deep enough so orchestrator.process_documents reaches

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -16,6 +16,7 @@ from qdrant_loader.core.pipeline.source_filter import SourceFilter
 from qdrant_loader.core.pipeline.source_processor import SourceProcessor
 from qdrant_loader.core.qdrant_manager import QdrantManager
 from qdrant_loader.core.state.state_manager import StateManager
+from qdrant_loader.core.worker.handlers import PermanentJobError
 
 
 def make_rich_compatible_mock(*args, **kwargs):
@@ -298,6 +299,163 @@ class TestPipelineOrchestrator:
         mock_change_detector.classify_batch.assert_called_once_with(
             mock_documents, filtered_config, None
         )
+
+    @pytest.mark.asyncio
+    async def test_process_documents_raises_when_indexing_fails(self):
+        """A batch with indexing (upsert) failures must fail the whole job, not report success."""
+        mock_documents = cast(
+            list[Document],
+            [
+                Mock(spec=Document, id="doc1", content="content1"),
+                Mock(spec=Document, id="doc2", content="content2"),
+            ],
+        )
+
+        filtered_config = Mock(spec=SourcesConfig)
+        filtered_config.git = ["git_source"]
+        filtered_config.confluence = None
+        filtered_config.jira = None
+        filtered_config.publicdocs = None
+        filtered_config.localfile = None
+
+        self.source_filter.filter_sources.return_value = filtered_config
+        self.orchestrator._update_document_states = AsyncMock()
+
+        async def fake_stream_batches(
+            filtered_config_arg,
+            batch_size=256,
+            since=None,
+            project_id=None,
+            seen_uris=None,
+            resume=True,
+        ):
+            assert filtered_config_arg is filtered_config
+            yield mock_documents
+
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = mock_documents
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            mock_result = Mock()
+            mock_result.successfully_processed_documents = {"doc1"}
+            mock_result.success_count = 1
+            mock_result.failure_count = 1
+            mock_result.errors = ["Upsert failed for chunk doc2: connection refused"]
+            mock_result.failed_document_ids = {"doc2"}
+            self.document_pipeline.process_batch.return_value = mock_result
+
+            with pytest.raises(PermanentJobError, match="failed to index into Qdrant"):
+                await self.orchestrator.process_documents(
+                    sources_config=self.mock_sources_config
+                )
+
+        assert self.orchestrator.last_pipeline_result.error_count == 1
+        assert self.orchestrator.last_pipeline_result.success_count == 1
+
+    @pytest.mark.asyncio
+    async def test_process_documents_raises_when_all_documents_fail_to_index(self):
+        """If every document in the run fails to index, the job must still fail (not return [])."""
+        mock_documents = [Mock(spec=Document, id="doc1", content="content1")]
+        filtered_config = Mock(spec=SourcesConfig)
+        filtered_config.git = ["git_source"]
+        filtered_config.confluence = None
+        filtered_config.jira = None
+        filtered_config.publicdocs = None
+        filtered_config.localfile = None
+
+        self.source_filter.filter_sources.return_value = filtered_config
+
+        async def fake_stream_batches(
+            filtered_config_arg,
+            batch_size=256,
+            since=None,
+            project_id=None,
+            seen_uris=None,
+            resume=True,
+        ):
+            assert filtered_config_arg is filtered_config
+            yield mock_documents
+
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = mock_documents
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            mock_result = Mock()
+            mock_result.successfully_processed_documents = set()
+            mock_result.success_count = 0
+            mock_result.failure_count = 1
+            mock_result.errors = ["Upsert failed for chunk doc1: connection refused"]
+            mock_result.failed_document_ids = {"doc1"}
+            self.document_pipeline.process_batch.return_value = mock_result
+
+            with pytest.raises(PermanentJobError, match="failed to index into Qdrant"):
+                await self.orchestrator.process_documents(
+                    sources_config=self.mock_sources_config
+                )
+
+        assert self.orchestrator.last_pipeline_result.error_count == 1
+        assert self.orchestrator.last_pipeline_result.success_count == 0
+
+    @pytest.mark.asyncio
+    async def test_process_documents_raises_when_qdrant_collection_unavailable_even_if_no_changes(
+        self,
+    ):
+        """A no-change run must still fail when Qdrant collection is unavailable."""
+        mock_documents = cast(
+            list[Document],
+            [
+                Mock(spec=Document, id="doc1", content="content1"),
+                Mock(spec=Document, id="doc2", content="content2"),
+            ],
+        )
+
+        filtered_config = Mock(spec=SourcesConfig)
+        filtered_config.git = ["git_source"]
+        filtered_config.confluence = None
+        filtered_config.jira = None
+        filtered_config.publicdocs = None
+        filtered_config.localfile = None
+
+        self.source_filter.filter_sources.return_value = filtered_config
+        self.qdrant_manager.assert_collection_accessible.side_effect = Exception(
+            "Unexpected Response: 404 (Not Found): Collection does not exist"
+        )
+
+        async def fake_stream_batches(
+            filtered_config_arg,
+            batch_size=256,
+            since=None,
+            project_id=None,
+            seen_uris=None,
+            resume=True,
+        ):
+            assert filtered_config_arg is filtered_config
+            yield mock_documents
+
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        with pytest.raises(PermanentJobError, match="Qdrant collection is unavailable"):
+            await self.orchestrator.process_documents(
+                sources_config=self.mock_sources_config
+            )
+
+        self.document_pipeline.process_batch.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_process_documents_no_sources_found(self):

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_embedding_worker.py
@@ -602,7 +602,7 @@ class TestEmbeddingWorker:
             consumer.cancel()
             try:
                 await asyncio.wait_for(consumer, timeout=5)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
+            except (TimeoutError, asyncio.CancelledError):
                 pass
 
     @pytest.mark.asyncio

--- a/packages/qdrant-loader/tests/unit/core/state/test_queries.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_queries.py
@@ -1,0 +1,82 @@
+from qdrant_loader.core.state.queries import (
+    select_document_state,
+    select_ingestion_history,
+    select_last_ingestion,
+)
+from sqlalchemy.dialects import sqlite
+
+
+def _to_sql(statement) -> str:
+    return str(
+        statement.compile(
+            dialect=sqlite.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def test_select_ingestion_history_without_project_id():
+    stmt = select_ingestion_history(source_type="jira", source="proj-a")
+    sql = _to_sql(stmt)
+
+    assert "FROM ingestion_history" in sql
+    assert "ingestion_history.source_type = 'jira'" in sql
+    assert "ingestion_history.source = 'proj-a'" in sql
+    assert "AND ingestion_history.project_id =" not in sql
+
+
+def test_select_ingestion_history_with_project_id():
+    stmt = select_ingestion_history(
+        source_type="jira", source="proj-a", project_id="project-1"
+    )
+    sql = _to_sql(stmt)
+
+    assert "ingestion_history.source_type = 'jira'" in sql
+    assert "ingestion_history.source = 'proj-a'" in sql
+    assert "ingestion_history.project_id = 'project-1'" in sql
+
+
+def test_select_last_ingestion_orders_desc_by_last_successful_ingestion():
+    stmt = select_last_ingestion(source_type="git", source="repo-1")
+    sql = _to_sql(stmt)
+
+    assert "FROM ingestion_history" in sql
+    assert "ingestion_history.source_type = 'git'" in sql
+    assert "ingestion_history.source = 'repo-1'" in sql
+    assert "ORDER BY ingestion_history.last_successful_ingestion DESC" in sql
+
+
+def test_select_last_ingestion_with_project_id():
+    stmt = select_last_ingestion(
+        source_type="git", source="repo-1", project_id="project-2"
+    )
+    sql = _to_sql(stmt)
+
+    assert "ingestion_history.project_id = 'project-2'" in sql
+    assert "ORDER BY ingestion_history.last_successful_ingestion DESC" in sql
+
+
+def test_select_document_state_without_optional_filters():
+    stmt = select_document_state(source_type="confluence", source="space-a")
+    sql = _to_sql(stmt)
+
+    assert "FROM document_states" in sql
+    assert "document_states.source_type = 'confluence'" in sql
+    assert "document_states.source = 'space-a'" in sql
+    assert "AND document_states.document_id =" not in sql
+    assert "AND document_states.project_id =" not in sql
+
+
+def test_select_document_state_with_document_id_and_project_id():
+    stmt = select_document_state(
+        source_type="confluence",
+        source="space-a",
+        document_id="doc-123",
+        project_id="project-3",
+    )
+    sql = _to_sql(stmt)
+
+    assert "document_states.source_type = 'confluence'" in sql
+    assert "document_states.source = 'space-a'" in sql
+    assert "document_states.document_id = 'doc-123'" in sql
+    assert "document_states.project_id = 'project-3'" in sql


### PR DESCRIPTION
…ailable

# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Affected areas:** Qdrant destination collection preflight (`PipelineOrchestrator.process_documents` via new `QdrantManager.assert_collection_accessible()`), indexing/upsert failure handling (raise `PermanentJobError` with formatted, sanitized message instead of logging/continuing), and multi-project orchestration (`_process_all_projects` explicitly re-raises `PermanentJobError`). Worker retry behavior is also updated so `PermanentJobError` is non-retryable (`QueueWorkerPool`).
- **Configuration:** No config schema changes.
- **Tests:** Yes—unit tests now cover (a) partial indexing failures, (b) all-documents-failed-to-index failures, and (c) no-change runs failing when the Qdrant collection is unavailable. Integration test stubs `assert_collection_accessible`, plus existing cancellation/timeout assertion adjustments.
- **Security/resource safety:** Fail-fast validation prevents wasted ingestion attempts; `sanitize_exception_message` limits leakage in `PermanentJobError`; treating permanent errors as non-retryable reduces resource churn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->