### PR TITLE
fix: resuming feature not working

### DIFF
--- a/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
+++ b/packages/qdrant-loader/src/qdrant_loader/connectors/jira/connector.py
@@ -300,6 +300,13 @@ class BaseJiraConnector(BaseConnector):
         if updated_after:
             jql += f" AND updated >= '{updated_after.strftime('%Y-%m-%d %H:%M')}'"
 
+        # Pagination (and offset-based checkpoint resume, see
+        # JiraDataCenterConnector.get_issues) relies on a stable row order
+        # across requests; without an explicit ORDER BY, Jira may reorder
+        # results between pages (e.g. new issues created mid-scan), causing
+        # resume to skip or duplicate issues.
+        jql += " ORDER BY key ASC"
+
         return jql
 
     async def __aenter__(self):

--- a/packages/qdrant-loader/src/qdrant_loader/core/document.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/document.py
@@ -160,7 +160,16 @@ class Document(BaseModel):
         # Normalize all inputs
         normalized_content = content.replace("\r\n", "\n")
         normalized_title = title.replace("\r\n", "\n")
-        normalized_metadata = normalize_value(metadata)
+        # Keys prefixed with "__" are connector-internal bookkeeping (e.g.
+        # "__ingestion_checkpoint", a pagination cursor token) rather than
+        # actual document content. They can legitimately differ between two
+        # fetches of the very same, unchanged document, so including them
+        # would make change detection think the document was modified on
+        # every single ingestion run.
+        hashable_metadata = {
+            k: v for k, v in metadata.items() if not k.startswith("__")
+        }
+        normalized_metadata = normalize_value(hashable_metadata)
 
         # Create a consistent string representation
         content_string = json.dumps(

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/document_pipeline.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 from collections import defaultdict
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -197,13 +198,20 @@ class DocumentPipeline:
             )
 
     async def process_batch(
-        self, batch: list[Document], current_project_id: str | None = None
+        self,
+        batch: list[Document],
+        current_project_id: str | None = None,
+        on_document_complete: Callable[[Document, bool], Awaitable[None]] | None = None,
     ) -> BatchResult:
         """Process a bounded batch of documents through the pipeline.
 
         Args:
             batch: List of documents to process (bounded size, typically 256)
             current_project_id: Optional project id context for graph extraction/upsert.
+            on_document_complete: Optional async callback invoked as soon as a
+                document's chunks are all accounted for (success or failure),
+                well before this whole batch finishes. Passed straight through
+                to ``UpsertWorker.process_embedded_chunks``.
 
         Returns:
             BatchResult with processing statistics.
@@ -227,7 +235,9 @@ class DocumentPipeline:
 
             try:
                 pipeline_result = await asyncio.wait_for(
-                    self.upsert_worker.process_embedded_chunks(embedded_chunks_iter),
+                    self.upsert_worker.process_embedded_chunks(
+                        embedded_chunks_iter, on_document_complete=on_document_complete
+                    ),
                     timeout=600.0,  # 10 minute timeout per batch
                 )
             except TimeoutError:

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -377,9 +377,20 @@ class PipelineOrchestrator:
                     if not batch:
                         continue
 
+                    async def _persist_as_completed(
+                        doc: Document, success: bool
+                    ) -> None:
+                        if not success:
+                            return
+                        await self._persist_single_document_state(
+                            doc, current_project_id
+                        )
+
                     batch_result = (
                         await self.components.document_pipeline.process_batch(
-                            batch, current_project_id
+                            batch,
+                            current_project_id,
+                            on_document_complete=_persist_as_completed,
                         )
                     )
                     aggregated_result.success_count += batch_result.success_count
@@ -748,6 +759,36 @@ class PipelineOrchestrator:
                 error_type=type(e).__name__,
             )
             raise
+
+    async def _persist_single_document_state(
+        self,
+        document: Document,
+        project_id: str | None = None,
+    ) -> None:
+        """Persist one document's state as soon as it finishes, not at batch end.
+
+        Streaming batches are bounded at up to 256 documents and state was
+        previously only committed once the *entire* batch finished
+        chunking/embedding/upserting. If the process was interrupted partway
+        through such a batch, documents already durably upserted to Qdrant
+        had no ``DocumentStateRecord`` yet, so a resume would treat them as
+        new and reprocess them. Called from ``UpsertWorker`` the moment a
+        document's last chunk is accounted for, this closes that gap. The
+        end-of-batch ``_update_document_states`` call still runs afterwards
+        as a safety net (idempotent) for anything this callback missed.
+        """
+        try:
+            if not self.components.state_manager._initialized:
+                await self.components.state_manager.initialize()
+            await self.components.state_manager.update_document_states_batch(
+                [document], project_id
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to persist incremental document state for {document.id}: "
+                f"{sanitize_exception_message(e)}",
+                error_type=type(e).__name__,
+            )
 
     async def _update_document_states(
         self,

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py
@@ -71,6 +71,7 @@ class PipelineOrchestrator:
         project_id: str | None = None,
         seen_uris: set[str] | None = None,
         resume: bool = True,
+        force: bool = False,
     ) -> AsyncIterator[list[Document]]:
         """Stream source documents in bounded micro-batches.
 
@@ -100,7 +101,7 @@ class PipelineOrchestrator:
                 # Determine if we should attempt to resume from a checkpoint
                 checkpoint_cursor = None
                 try:
-                    if resume and project_id is not None:
+                    if resume and not force and project_id is not None:
                         # Lazy import to avoid cycles
                         from qdrant_loader.core.state.checkpoint_manager import (
                             CheckpointManager,
@@ -349,6 +350,7 @@ class PipelineOrchestrator:
                     since,
                     project_id=current_project_id,
                     resume=resume,
+                    force=force,
                 )
 
                 async for batch in stream_iter:
@@ -657,97 +659,6 @@ class PipelineOrchestrator:
                 f"Completed processing all projects: {total_processed_count} total documents"
             )
         return total_processed_count
-
-    async def _collect_documents_from_sources(
-        self,
-        filtered_config: SourcesConfig,
-        project_id: str | None = None,
-        resume: bool = True,
-    ) -> list[Document]:
-        """Collect documents from all configured sources."""
-        documents = []
-
-        # Process each source type with project context
-        async def _connector_factory_for_source_type(source_type_name: str):
-            async def _factory(src_config):
-                checkpoint_cursor = None
-                try:
-                    if resume and project_id is not None:
-                        from qdrant_loader.core.state.checkpoint_manager import (
-                            CheckpointManager,
-                        )
-
-                        async with (
-                            await self.components.state_manager.get_session() as session
-                        ):
-                            cp_mgr = CheckpointManager(session)
-                            cp = await cp_mgr.get_checkpoint(
-                                project_id, source_type_name, src_config.source
-                            )
-                            if cp:
-                                checkpoint_cursor = cp.cursor_value
-                except Exception:
-                    logger.debug(
-                        "Checkpoint lookup failed, proceeding without checkpoint",
-                        source_type=source_type_name,
-                        source=getattr(src_config, "source", None),
-                    )
-                return get_connector_instance(
-                    src_config, checkpoint_cursor=checkpoint_cursor
-                )
-
-            return _factory
-
-        if filtered_config.confluence:
-            confluence_docs = (
-                await self.components.source_processor.process_source_type(
-                    filtered_config.confluence,
-                    await _connector_factory_for_source_type("Confluence"),
-                    "Confluence",
-                )
-            )
-            documents.extend(confluence_docs)
-
-        if filtered_config.git:
-            git_docs = await self.components.source_processor.process_source_type(
-                filtered_config.git, get_connector_instance, "Git"
-            )
-            documents.extend(git_docs)
-
-        if filtered_config.jira:
-            jira_docs = await self.components.source_processor.process_source_type(
-                filtered_config.jira,
-                await _connector_factory_for_source_type("Jira"),
-                "Jira",
-            )
-            documents.extend(jira_docs)
-
-        if filtered_config.publicdocs:
-            publicdocs_docs = (
-                await self.components.source_processor.process_source_type(
-                    filtered_config.publicdocs, get_connector_instance, "PublicDocs"
-                )
-            )
-            documents.extend(publicdocs_docs)
-
-        if filtered_config.localfile:
-            localfile_docs = await self.components.source_processor.process_source_type(
-                filtered_config.localfile,
-                await _connector_factory_for_source_type("LocalFile"),
-                "LocalFile",
-            )
-            documents.extend(localfile_docs)
-
-        # Inject project metadata into documents if project context is available
-        if project_id and self.project_manager:
-            for document in documents:
-                enhanced_metadata = self.project_manager.inject_project_metadata(
-                    project_id, document.metadata
-                )
-                document.metadata = enhanced_metadata
-
-        logger.info(f"📄 Collected {len(documents)} documents from all sources")
-        return documents
 
     async def _detect_document_changes(
         self,

--- a/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections import Counter
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 from qdrant_client.http import models
@@ -220,7 +220,7 @@ class UpsertWorker(BaseWorker):
         doc_totals: dict[str, int],
         doc_seen: dict[str, int],
         doc_failed: dict[str, bool],
-    ) -> None:
+    ) -> bool | None:
         """Record one chunk's fate and finalize its document once complete.
 
         A document is only added to ``successfully_processed_documents`` once
@@ -230,10 +230,15 @@ class UpsertWorker(BaseWorker):
         happened to succeed. If any chunk failed (embedding failure, upsert
         failure, or duplicate-id collision), the document lands in
         ``failed_document_ids`` instead so a later incremental run retries it.
+
+        Returns ``None`` while the document still has outstanding chunks, or
+        the document's final success flag (``True``/``False``) the moment it
+        completes — callers use this to persist document state immediately
+        instead of waiting for the whole streaming batch to finish.
         """
         parent_doc = chunk.metadata.get("parent_document")
         if not parent_doc:
-            return
+            return None
 
         doc_id = parent_doc.id
         total = chunk.metadata.get("parent_document_total_chunks") or 1
@@ -248,8 +253,11 @@ class UpsertWorker(BaseWorker):
             if doc_failed.get(doc_id):
                 result.failed_document_ids.add(doc_id)
                 result.successfully_processed_documents.discard(doc_id)
+                return False
             else:
                 result.successfully_processed_documents.add(doc_id)
+                return True
+        return None
 
     def _merge_batch_outcome(
         self,
@@ -261,8 +269,14 @@ class UpsertWorker(BaseWorker):
         doc_totals: dict[str, int],
         doc_seen: dict[str, int],
         doc_failed: dict[str, bool],
-    ) -> None:
-        """Fold one batch's process() outcome into the running PipelineResult."""
+    ) -> list[tuple[Any, bool]]:
+        """Fold one batch's process() outcome into the running PipelineResult.
+
+        Returns the documents that just completed as a result of this batch
+        (parent document object, success flag), so the caller can persist
+        their state right away instead of waiting for the whole streaming
+        batch to finish.
+        """
         success_count, error_count, successful_doc_ids, errors = outcome
 
         if success_count > 0:
@@ -286,16 +300,24 @@ class UpsertWorker(BaseWorker):
         result.error_count += error_count
         result.errors.extend(errors)
 
+        finalized: list[tuple[Any, bool]] = []
         for chunk, _ in batch:
             chunk_failed = (
                 success_count == 0 or str(chunk.id) in dedup["duplicate_chunk_ids"]
             )
-            self._note_chunk_outcome(
+            outcome_flag = self._note_chunk_outcome(
                 chunk, chunk_failed, result, doc_totals, doc_seen, doc_failed
             )
+            if outcome_flag is not None:
+                parent_doc = chunk.metadata.get("parent_document")
+                if parent_doc:
+                    finalized.append((parent_doc, outcome_flag))
+        return finalized
 
     async def process_embedded_chunks(
-        self, embedded_chunks: AsyncIterator[tuple[Any, list[float] | None]]
+        self,
+        embedded_chunks: AsyncIterator[tuple[Any, list[float] | None]],
+        on_document_complete: Callable[[Any, bool], Awaitable[None]] | None = None,
     ) -> PipelineResult:
         """Upsert embedded chunks to Qdrant.
 
@@ -310,10 +332,31 @@ class UpsertWorker(BaseWorker):
 
         Args:
             embedded_chunks: AsyncIterator of (chunk, embedding) tuples
+            on_document_complete: Optional async callback invoked with
+                ``(parent_document, success)`` the moment a document's last
+                chunk is accounted for — before the whole iterator finishes.
+                Lets callers persist document state incrementally, so a
+                mid-run interruption doesn't lose the state of documents
+                that were already fully upserted. Callback failures are
+                logged and never abort the pipeline.
 
         Returns:
             PipelineResult with processing statistics
         """
+
+        async def _notify(parent_doc: Any, success: bool) -> None:
+            if on_document_complete is None:
+                return
+            try:
+                await on_document_complete(parent_doc, success)
+            except Exception as e:
+                logger.error(
+                    "on_document_complete callback failed",
+                    document_id=getattr(parent_doc, "id", None),
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+
         logger.debug("UpsertWorker started")
         logger.info("🔄 Starting upsert processing", max_workers=self.max_workers)
         result = PipelineResult()
@@ -329,7 +372,7 @@ class UpsertWorker(BaseWorker):
         async def drain_oldest() -> None:
             task, task_batch, dedup = pending.pop(0)
             outcome = await task
-            self._merge_batch_outcome(
+            finalized = self._merge_batch_outcome(
                 task_batch,
                 dedup,
                 outcome,
@@ -339,6 +382,8 @@ class UpsertWorker(BaseWorker):
                 doc_seen,
                 doc_failed,
             )
+            for parent_doc, success in finalized:
+                await _notify(parent_doc, success)
 
         def dispatch(batch_to_dispatch: list[tuple[Any, list[float]]]) -> None:
             dedup = self._reserve_chunk_ids(batch_to_dispatch, seen_chunk_ids)
@@ -356,9 +401,13 @@ class UpsertWorker(BaseWorker):
                     result.errors.append(
                         f"Embedding failed for chunk {chunk.id}, skipped upsert"
                     )
-                    self._note_chunk_outcome(
+                    outcome_flag = self._note_chunk_outcome(
                         chunk, True, result, doc_totals, doc_seen, doc_failed
                     )
+                    if outcome_flag is not None:
+                        parent_doc = chunk.metadata.get("parent_document")
+                        if parent_doc:
+                            await _notify(parent_doc, outcome_flag)
                     continue
 
                 batch.append((chunk, embedding))

--- a/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
@@ -274,18 +274,9 @@ class ProjectManager:
                                 CheckpointManager,
                             )
 
-                            try:
-                                await CheckpointManager(session).clear_checkpoint(
-                                    project_id, source_type, source_name
-                                )
-                            except Exception as e:
-                                self.logger.warning(
-                                    "Failed to clear stale checkpoint after "
-                                    "source configuration change",
-                                    source_type=source_type,
-                                    source=source_name,
-                                    error=str(e),
-                                )
+                            await CheckpointManager(session).clear_checkpoint(
+                                project_id, source_type, source_name
+                            )
                 else:
                     # Create new source
                     self.logger.debug(

--- a/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/project_manager.py
@@ -263,6 +263,29 @@ class ProjectManager:
                         )
                         source.config_hash = source_config_hash  # type: ignore
                         source.updated_at = now  # type: ignore
+
+                        # The source config changed (e.g. JQL/project_key/path
+                        # filters), so any saved checkpoint cursor was computed
+                        # against the old query and is no longer meaningful.
+                        # Drop it so the next run starts fresh instead of
+                        # silently resuming mid-page against a different query.
+                        if current_source_config_hash is not None:
+                            from qdrant_loader.core.state.checkpoint_manager import (
+                                CheckpointManager,
+                            )
+
+                            try:
+                                await CheckpointManager(session).clear_checkpoint(
+                                    project_id, source_type, source_name
+                                )
+                            except Exception as e:
+                                self.logger.warning(
+                                    "Failed to clear stale checkpoint after "
+                                    "source configuration change",
+                                    source_type=source_type,
+                                    source=source_name,
+                                    error=str(e),
+                                )
                 else:
                     # Create new source
                     self.logger.debug(

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/semantic_analyzer.py
@@ -1,18 +1,20 @@
 """Semantic analysis module for text processing."""
 
+from __future__ import annotations
+
 import hashlib
 import logging
 import threading
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import spacy
 from gensim import corpora
 from gensim.models import LdaModel
 from gensim.parsing.preprocessing import preprocess_string
 from qdrant_loader.core.text_processing import spacy_model_cache
-from spacy.cli.download import download as spacy_download
-from spacy.tokens import Doc
+
+if TYPE_CHECKING:
+    from spacy.tokens import Doc
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +69,9 @@ class SemanticAnalyzer:
         # ChunkProcessor), and spacy.load() is too expensive to repeat for
         # every one of them.
         def _load_nlp():
+            import spacy
+            from spacy.cli.download import download as spacy_download
+
             try:
                 nlp = spacy.load(spacy_model)
             except OSError:

--- a/packages/qdrant-loader/src/qdrant_loader/core/text_processing/text_processor.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/text_processing/text_processor.py
@@ -1,12 +1,9 @@
 """Text processing module integrating LangChain, spaCy, and NLTK."""
 
 import nltk
-import spacy
-from langchain_text_splitters import RecursiveCharacterTextSplitter
 from qdrant_loader.config import Settings
 from qdrant_loader.core.text_processing import spacy_model_cache
 from qdrant_loader.utils.logging import LoggingConfig
-from spacy.cli.download import download
 
 logger = LoggingConfig.get_logger(__name__)
 
@@ -43,6 +40,9 @@ class TextProcessor:
         spacy_model = settings.global_config.semantic_analysis.spacy_model
 
         def _load_nlp():
+            import spacy
+            from spacy.cli.download import download
+
             try:
                 nlp = spacy.load(spacy_model)
             except OSError:
@@ -62,6 +62,8 @@ class TextProcessor:
         )
 
         # Initialize LangChain text splitter with configuration from settings
+        from langchain_text_splitters import RecursiveCharacterTextSplitter
+
         self.text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=settings.global_config.chunking.chunk_size,
             chunk_overlap=settings.global_config.chunking.chunk_overlap,
@@ -187,6 +189,8 @@ class TextProcessor:
             if chunk_size:
                 # Create a new text splitter with the custom chunk size
                 # Ensure chunk_overlap is smaller than chunk_size
+                from langchain_text_splitters import RecursiveCharacterTextSplitter
+
                 chunk_overlap = min(chunk_size // 4, 50)  # 25% of chunk size, max 50
                 text_splitter = RecursiveCharacterTextSplitter(
                     chunk_size=chunk_size,

--- a/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
+++ b/packages/qdrant-loader/tests/integration/core/worker/test_handler_orchestrator_integration.py
@@ -17,7 +17,7 @@ def _setup_qdrant_loader_core_stubs(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.syspath_prepend(str(core_src))
 
     pkg = types.ModuleType("qdrant_loader_core")
-    pkg.__path__ = []
+    pkg.__path__ = [str(core_src / "qdrant_loader_core")]
     monkeypatch.setitem(sys.modules, "qdrant_loader_core", pkg)
 
     config_mod = types.ModuleType("qdrant_loader_core.config")
@@ -68,6 +68,7 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
         project_id=None,
         seen_uris=None,
         resume=True,
+        force=False,
     ):
         recorded_calls.append(
             {
@@ -77,6 +78,7 @@ async def test_incremental_pull_accepts_since_param(monkeypatch):
                 "project_id": project_id,
                 "seen_uris": seen_uris,
                 "resume": resume,
+                "force": force,
             }
         )
         if False:

--- a/packages/qdrant-loader/tests/unit/connectors/jira/test_checkpoint_propagation.py
+++ b/packages/qdrant-loader/tests/unit/connectors/jira/test_checkpoint_propagation.py
@@ -186,6 +186,58 @@ async def test_checkpoint_not_on_attachment_documents(jira_config):
 
 
 # ---------------------------------------------------------------------------
+# 1b. __ingestion_checkpoint must not affect change detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingestion_checkpoint_does_not_affect_content_hash(jira_config):
+    """A document's content_hash must be identical across two fetches that
+    only differ in their propagated pagination cursor.
+
+    Regression test: Jira's ``nextPageToken`` is an opaque, per-request
+    cursor with no guarantee of being byte-identical across two fetches of
+    the same page. Before this fix, __ingestion_checkpoint (which carries
+    that cursor) was folded into content_hash via Document.__init__, so an
+    unchanged issue would get a different hash — and therefore look
+    "updated" to StateChangeDetector.classify_batch — on every single
+    ingestion run, defeating resume/change-detection entirely.
+    """
+    connector = JiraCloudConnector(jira_config)
+
+    issue_run1 = _make_issue()
+    issue_run1.ingestion_checkpoint = {
+        "cursor_kind": "page_token",
+        "cursor_value": "tok-run-1",
+        "batch_index": 0,
+    }
+    issue_run2 = _make_issue()
+    issue_run2.ingestion_checkpoint = {
+        "cursor_kind": "page_token",
+        "cursor_value": "tok-run-2-completely-different",
+        "batch_index": 0,
+    }
+
+    docs: list[Document] = []
+    for issue in (issue_run1, issue_run2):
+        async for doc in connector._stream_issues_to_documents(
+            [issue], include_attachments=False
+        ):
+            docs.append(doc)
+
+    assert len(docs) == 2
+    assert docs[0].metadata["__ingestion_checkpoint"]["cursor_value"] == "tok-run-1"
+    assert (
+        docs[1].metadata["__ingestion_checkpoint"]["cursor_value"]
+        == "tok-run-2-completely-different"
+    )
+    assert docs[0].content_hash == docs[1].content_hash, (
+        "content_hash must be stable across runs regardless of the "
+        "propagated pagination cursor value"
+    )
+
+
+# ---------------------------------------------------------------------------
 # 2. Resume: saved cursor is passed to the connector factory
 # ---------------------------------------------------------------------------
 

--- a/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
+++ b/packages/qdrant-loader/tests/unit/connectors/jira/test_jira_connector.py
@@ -684,7 +684,14 @@ class TestJiraConnector:
         connector = JiraCloudConnector(jira_cloud_config)
         jql = connector._build_jql_filter()
 
-        assert jql == 'project = "TEST"'
+        assert jql == 'project = "TEST" ORDER BY key ASC'
+
+    def test_jql_filter_build_has_stable_order_by(self, jira_cloud_config):
+        """ORDER BY key ASC keeps pagination/checkpoint offsets stable across requests."""
+        connector = JiraCloudConnector(jira_cloud_config)
+        jql = connector._build_jql_filter()
+
+        assert jql.endswith("ORDER BY key ASC")
 
     def test_escape_jql_literal_handles_quotes_and_backslashes(self):
         """Test JQL literal escaping for unsafe characters."""

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -428,6 +428,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             assert filtered_config_arg is filtered_config
             yield mock_documents
@@ -480,6 +481,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             assert filtered_config_arg is filtered_config
             yield mock_documents

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -1,7 +1,7 @@
 """Tests for PipelineOrchestrator module."""
 
 from typing import cast
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 from qdrant_loader.config import Settings, SourcesConfig
@@ -177,7 +177,7 @@ class TestPipelineOrchestrator:
             self.mock_sources_config, None, None
         )
         self.document_pipeline.process_batch.assert_called_once_with(
-            mock_documents, None
+            mock_documents, None, on_document_complete=ANY
         )
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1", "doc2"}, None
@@ -185,6 +185,103 @@ class TestPipelineOrchestrator:
         mock_change_detector.classify_batch.assert_called_once_with(
             mock_documents, filtered_config, None
         )
+
+    @pytest.mark.asyncio
+    async def test_process_documents_persists_document_state_incrementally(self):
+        """Document state must be persisted as each document finishes inside
+        process_batch, not only once the whole streaming batch returns.
+
+        Regresses the resume bug where an interruption mid-batch (e.g. after
+        only some of ~20 documents in a single sub-256 batch had been
+        embedded/upserted) left no DocumentStateRecord for any of them, so a
+        restart reprocessed documents that had already succeeded. This test
+        drives process_batch's on_document_complete callback *before*
+        process_batch returns, and asserts the state manager was already
+        written to at that point.
+        """
+        mock_documents = cast(
+            list[Document],
+            [
+                Mock(spec=Document, id="doc1", content="content1"),
+                Mock(spec=Document, id="doc2", content="content2"),
+            ],
+        )
+
+        filtered_config = Mock(spec=SourcesConfig)
+        filtered_config.git = ["git_source"]
+        filtered_config.confluence = None
+        filtered_config.jira = None
+        filtered_config.publicdocs = None
+        filtered_config.localfile = None
+
+        self.source_filter.filter_sources.return_value = filtered_config
+
+        async def fake_stream_batches(
+            filtered_config_arg,
+            batch_size=256,
+            since=None,
+            project_id=None,
+            seen_uris=None,
+            resume=True,
+            force=False,
+        ):
+            yield mock_documents
+
+        self.orchestrator._stream_batches_from_sources = fake_stream_batches
+
+        mock_change_detector = AsyncMock()
+        mock_change_detector.classify_batch.return_value = mock_documents
+        state_detector_context = Mock()
+        state_detector_context.__aenter__ = AsyncMock(return_value=mock_change_detector)
+        state_detector_context.__aexit__ = AsyncMock(return_value=None)
+
+        # Snapshot how many documents were already persisted *during* the
+        # process_batch call, before it returns to the orchestrator — this is
+        # exactly the moment an interruption would otherwise lose all state.
+        persisted_count_mid_batch = None
+
+        async def fake_process_batch(batch, project_id, on_document_complete=None):
+            nonlocal persisted_count_mid_batch
+            # Simulate documents completing one at a time *during* the batch,
+            # mirroring UpsertWorker notifying as each document's chunks land.
+            for doc in batch:
+                await on_document_complete(doc, True)
+            persisted_count_mid_batch = (
+                self.state_manager.update_document_states_batch.call_count
+            )
+            mock_result = Mock()
+            mock_result.successfully_processed_documents = {"doc1", "doc2"}
+            mock_result.success_count = 2
+            mock_result.failure_count = 0
+            mock_result.errors = []
+            mock_result.failed_document_ids = set()
+            return mock_result
+
+        self.document_pipeline.process_batch.side_effect = fake_process_batch
+
+        with patch(
+            "qdrant_loader.core.pipeline.orchestrator.StateChangeDetector",
+            return_value=state_detector_context,
+        ):
+            result = await self.orchestrator.process_documents(
+                sources_config=self.mock_sources_config
+            )
+
+        assert result == 2
+        # Both documents were already persisted before process_batch returned
+        # — i.e. incrementally, one single-document write per document.
+        assert persisted_count_mid_batch == 2
+        single_doc_calls = [
+            call
+            for call in self.state_manager.update_document_states_batch.call_args_list
+            if len(call.args[0]) == 1
+        ]
+        assert len(single_doc_calls) == 2
+        persisted_doc_ids = {call.args[0][0].id for call in single_doc_calls}
+        assert persisted_doc_ids == {"doc1", "doc2"}
+        # The end-of-batch call (_update_document_states) still runs afterward
+        # as a safety net, writing both documents together one more time.
+        assert self.state_manager.update_document_states_batch.call_count == 3
 
     @pytest.mark.asyncio
     async def test_process_documents_with_custom_sources_config(self):
@@ -293,7 +390,7 @@ class TestPipelineOrchestrator:
             self.mock_sources_config, "git", "my-repo"
         )
         self.document_pipeline.process_batch.assert_called_once_with(
-            mock_documents, None
+            mock_documents, None, on_document_complete=ANY
         )
         self.orchestrator._update_document_states.assert_called_once_with(
             mock_documents, {"doc1"}, None

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -147,6 +147,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             assert filtered_config_arg is filtered_config
             yield mock_documents
@@ -202,6 +203,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             assert filtered_config_arg is filtered_config
             yield mock_documents
@@ -256,6 +258,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             assert filtered_config_arg is filtered_config
             yield mock_documents
@@ -339,6 +342,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             if False:
                 yield []
@@ -376,6 +380,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             assert filtered_config_arg is filtered_config
             yield mock_documents
@@ -438,6 +443,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             assert filtered_config_arg is filtered_config
             yield [doc]
@@ -498,94 +504,6 @@ class TestPipelineOrchestrator:
                     sources_config=self.mock_sources_config
                 )
 
-    @pytest.mark.asyncio
-    async def test_collect_documents_from_sources_all_types(self):
-        """Test collecting documents from all source types."""
-        # Setup filtered config with all source types
-        filtered_config = Mock(spec=SourcesConfig)
-        filtered_config.confluence = ["confluence_source"]
-        filtered_config.git = ["git_source"]
-        filtered_config.jira = ["jira_source"]
-        filtered_config.publicdocs = ["publicdocs_source"]
-        filtered_config.localfile = ["localfile_source"]
-
-        # Setup mock documents for each source type
-        confluence_docs = [Mock(spec=Document, id="confluence_doc")]
-        git_docs = [Mock(spec=Document, id="git_doc")]
-        jira_docs = [Mock(spec=Document, id="jira_doc")]
-        publicdocs_docs = [Mock(spec=Document, id="publicdocs_doc")]
-        localfile_docs = [Mock(spec=Document, id="localfile_doc")]
-
-        # Configure source processor mock
-        self.source_processor.process_source_type.side_effect = [
-            confluence_docs,
-            git_docs,
-            jira_docs,
-            publicdocs_docs,
-            localfile_docs,
-        ]
-
-        # Execute
-        result = await self.orchestrator._collect_documents_from_sources(
-            filtered_config, None
-        )
-
-        # Verify
-        expected_docs = (
-            confluence_docs + git_docs + jira_docs + publicdocs_docs + localfile_docs
-        )
-        assert result == expected_docs
-        assert self.source_processor.process_source_type.call_count == 5
-
-    @pytest.mark.asyncio
-    async def test_collect_documents_from_sources_selective(self):
-        """Test collecting documents from selective source types."""
-        # Setup filtered config with only git and confluence
-        filtered_config = Mock(spec=SourcesConfig)
-        filtered_config.confluence = ["confluence_source"]
-        filtered_config.git = ["git_source"]
-        filtered_config.jira = None
-        filtered_config.publicdocs = None
-        filtered_config.localfile = None
-
-        # Setup mock documents
-        confluence_docs = [Mock(spec=Document, id="confluence_doc")]
-        git_docs = [Mock(spec=Document, id="git_doc")]
-
-        self.source_processor.process_source_type.side_effect = [
-            confluence_docs,
-            git_docs,
-        ]
-
-        # Execute
-        result = await self.orchestrator._collect_documents_from_sources(
-            filtered_config, None
-        )
-
-        # Verify
-        expected_docs = confluence_docs + git_docs
-        assert result == expected_docs
-        assert self.source_processor.process_source_type.call_count == 2
-
-    @pytest.mark.asyncio
-    async def test_collect_documents_from_sources_empty(self):
-        """Test collecting documents when no sources are configured."""
-        # Setup filtered config with no sources
-        filtered_config = Mock(spec=SourcesConfig)
-        filtered_config.confluence = None
-        filtered_config.git = None
-        filtered_config.jira = None
-        filtered_config.publicdocs = None
-        filtered_config.localfile = None
-
-        # Execute
-        result = await self.orchestrator._collect_documents_from_sources(
-            filtered_config, None
-        )
-
-        # Verify
-        assert result == []
-        self.source_processor.process_source_type.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_detect_document_changes_success(self):
@@ -1051,6 +969,7 @@ class TestPipelineOrchestrator:
             project_id=None,
             seen_uris=None,
             resume=True,
+            force=False,
         ):
             if False:
                 yield []
@@ -1246,3 +1165,137 @@ class TestStreamBatchesCheckpointBehavior:
         assert len(batches[1]) == 2
         for doc in batches[1]:
             assert doc.metadata.get("__ingestion_checkpoint") is not None
+
+
+class TestStreamBatchesForceDisablesCheckpointLookup:
+    """force=True must bypass any saved checkpoint, even when resume=True.
+
+    This is the BULK_INGEST contract (CLI --force, worker BULK_INGEST jobs):
+    a forced run reprocesses everything and must not silently resume mid-page
+    from a checkpoint saved by a prior (possibly interrupted) run.
+    """
+
+    def _make_orchestrator(self) -> PipelineOrchestrator:
+        settings = Mock(spec=Settings)
+        source_processor = AsyncMock(spec=SourceProcessor)
+        source_filter = Mock(spec=SourceFilter)
+        state_manager = AsyncMock(spec=StateManager)
+        state_manager._initialized = True
+        qdrant_manager = AsyncMock(spec=QdrantManager)
+        components = PipelineComponents(
+            document_pipeline=AsyncMock(spec=DocumentPipeline),
+            source_processor=source_processor,
+            source_filter=source_filter,
+            state_manager=state_manager,
+            qdrant_manager=qdrant_manager,
+        )
+        return PipelineOrchestrator(settings, components)
+
+    def _jira_filtered_config(self) -> Mock:
+        cfg = Mock(spec=SourcesConfig)
+        cfg.confluence = None
+        cfg.git = None
+        cfg.jira = {"jira-main": Mock(source="jira-main")}
+        cfg.publicdocs = None
+        cfg.localfile = None
+        return cfg
+
+    def _install_stream_that_calls_factory(self, orchestrator: PipelineOrchestrator):
+        """Replace stream_source_documents with a fake that actually invokes the
+        connector factory per source config, then yields a single document."""
+
+        async def fake_stream(
+            source_configs, connector_factory, source_type, since=None
+        ):
+            for src_config in source_configs.values():
+                await connector_factory(src_config)
+            doc = Mock(spec=Document)
+            doc.id = "d1"
+            doc.source_type = source_type
+            doc.source = "jira-main"
+            doc.url = "https://example.com/doc"
+            doc.metadata = {}
+            yield doc
+
+        orchestrator.components.source_processor.stream_source_documents = fake_stream
+
+    def _patch_saved_checkpoint(self, orchestrator: PipelineOrchestrator):
+        """Make the checkpoint DB lookup return a stale checkpoint if queried."""
+        session = object()
+        session_context = Mock()
+        session_context.__aenter__ = AsyncMock(return_value=session)
+        session_context.__aexit__ = AsyncMock(return_value=None)
+        orchestrator.components.state_manager.get_session = AsyncMock(
+            return_value=session_context
+        )
+
+        stale_checkpoint = Mock(cursor_value="stale-cursor")
+        get_checkpoint = AsyncMock(return_value=stale_checkpoint)
+        return get_checkpoint
+
+    @pytest.mark.asyncio
+    async def test_force_true_bypasses_saved_checkpoint(self):
+        orchestrator = self._make_orchestrator()
+        self._install_stream_that_calls_factory(orchestrator)
+        get_checkpoint = self._patch_saved_checkpoint(orchestrator)
+
+        with (
+            patch(
+                "qdrant_loader.core.state.checkpoint_manager.CheckpointManager"
+            ) as checkpoint_manager_cls,
+            patch(
+                "qdrant_loader.core.pipeline.orchestrator.get_connector_instance"
+            ) as get_connector_instance,
+        ):
+            checkpoint_manager_cls.return_value.get_checkpoint = get_checkpoint
+            get_connector_instance.return_value = Mock()
+
+            batches = [
+                batch
+                async for batch in orchestrator._stream_batches_from_sources(
+                    self._jira_filtered_config(),
+                    project_id="project-1",
+                    resume=True,
+                    force=True,
+                )
+            ]
+
+        assert len(batches) == 1
+        get_checkpoint.assert_not_awaited()
+        _, kwargs = get_connector_instance.call_args
+        assert kwargs["checkpoint_cursor"] is None
+
+    @pytest.mark.asyncio
+    async def test_resume_without_force_uses_saved_checkpoint(self):
+        """Sanity check: the normal (non-forced) resume path is unaffected."""
+        orchestrator = self._make_orchestrator()
+        self._install_stream_that_calls_factory(orchestrator)
+        get_checkpoint = self._patch_saved_checkpoint(orchestrator)
+
+        with (
+            patch(
+                "qdrant_loader.core.state.checkpoint_manager.CheckpointManager"
+            ) as checkpoint_manager_cls,
+            patch(
+                "qdrant_loader.core.pipeline.orchestrator.get_connector_instance"
+            ) as get_connector_instance,
+        ):
+            checkpoint_manager_cls.return_value.get_checkpoint = get_checkpoint
+            get_connector_instance.return_value = Mock()
+
+            batches = [
+                batch
+                async for batch in orchestrator._stream_batches_from_sources(
+                    self._jira_filtered_config(),
+                    project_id="project-1",
+                    resume=True,
+                    force=False,
+                )
+            ]
+
+        assert len(batches) == 1
+        get_checkpoint.assert_awaited_once_with(
+            "project-1", "Jira", "jira-main"
+        )
+        _, kwargs = get_connector_instance.call_args
+        assert kwargs["checkpoint_cursor"] == "stale-cursor"

--- a/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/workers/test_upsert_worker.py
@@ -1161,3 +1161,107 @@ class TestUpsertWorker:
         assert self.mock_qdrant_manager.upsert_points.call_count == 2
         assert "doc3" not in result.successfully_processed_documents
         assert "doc3" not in result.failed_document_ids
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_notifies_on_document_complete_incrementally(
+        self,
+    ):
+        """on_document_complete must fire per-document as each one finishes,
+        not only once the whole iterator has been consumed.
+
+        This is what lets a caller persist document state (e.g. for resume)
+        as documents complete, so a mid-run interruption doesn't lose state
+        for documents that were already durably upserted.
+        """
+        worker = UpsertWorker(
+            qdrant_manager=self.mock_qdrant_manager,
+            batch_size=1,
+            max_workers=1,
+            queue_size=1000,
+            shutdown_event=self.mock_shutdown_event,
+        )
+        self.mock_qdrant_manager.upsert_points = AsyncMock()
+
+        doc1, doc2 = Mock(id="doc1"), Mock(id="doc2")
+        chunk1 = _make_chunk("chunk1", doc1, total_chunks=1)
+        chunk2 = _make_chunk("chunk2", doc2, total_chunks=1)
+
+        notified: list[tuple[str, bool]] = []
+        notified_before_iterator_done: list[bool] = []
+        iterator_done = False
+
+        async def on_document_complete(doc, success):
+            notified.append((doc.id, success))
+            notified_before_iterator_done.append(not iterator_done)
+
+        async def embedded_chunks_iterator():
+            nonlocal iterator_done
+            yield (chunk1, [0.1, 0.2, 0.3])
+            yield (chunk2, [0.4, 0.5, 0.6])
+            iterator_done = True
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            result = await worker.process_embedded_chunks(
+                embedded_chunks_iterator(), on_document_complete=on_document_complete
+            )
+
+        assert result.successfully_processed_documents == {"doc1", "doc2"}
+        assert notified == [("doc1", True), ("doc2", True)]
+        # doc1's callback must have fired while the iterator was still being
+        # consumed (batch_size=1 dispatches+drains doc1 before doc2 arrives).
+        assert notified_before_iterator_done == [True, False]
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_notifies_failure_on_embedding_failure(self):
+        """A document whose embedding failed must notify with success=False."""
+        mock_chunk = Mock()
+        mock_chunk.id = "chunk1"
+        mock_chunk.metadata = {"parent_document": Mock(id="doc1")}
+
+        notified: list[tuple[str, bool]] = []
+
+        async def on_document_complete(doc, success):
+            notified.append((doc.id, success))
+
+        async def embedded_chunks_iterator():
+            yield (mock_chunk, None)
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            await self.upsert_worker.process_embedded_chunks(
+                embedded_chunks_iterator(), on_document_complete=on_document_complete
+            )
+
+        assert notified == [("doc1", False)]
+
+    @pytest.mark.asyncio
+    async def test_process_embedded_chunks_survives_on_document_complete_exception(
+        self,
+    ):
+        """A failing callback must be logged, not crash the pipeline."""
+        doc1, doc2 = Mock(id="doc1"), Mock(id="doc2")
+        chunk1 = _make_chunk("chunk1", doc1, total_chunks=1)
+        chunk2 = _make_chunk("chunk2", doc2, total_chunks=1)
+
+        async def on_document_complete(doc, success):
+            raise RuntimeError("state DB unavailable")
+
+        async def embedded_chunks_iterator():
+            yield (chunk1, [0.1, 0.2, 0.3])
+            yield (chunk2, [0.4, 0.5, 0.6])
+
+        self.upsert_worker.batch_size = 1
+
+        with patch(
+            "qdrant_loader.core.pipeline.workers.upsert_worker.prometheus_metrics"
+        ):
+            result = await self.upsert_worker.process_embedded_chunks(
+                embedded_chunks_iterator(), on_document_complete=on_document_complete
+            )
+
+        # Both documents still end up successful in the result even though
+        # their state-persistence callback blew up.
+        assert result.successfully_processed_documents == {"doc1", "doc2"}

--- a/packages/qdrant-loader/tests/unit/core/test_project_manager.py
+++ b/packages/qdrant-loader/tests/unit/core/test_project_manager.py
@@ -289,3 +289,109 @@ async def test_outdated_state_db_error_surfaces_actionable_hint(project_manager)
         )
 
     mock_session.rollback.assert_awaited_once()
+
+
+def _session_with_existing_sources(existing_sources):
+    """Build a mocked AsyncSession whose select().scalars().all() returns
+    the given ProjectSource-like rows."""
+    session = AsyncMock(spec=AsyncSession)
+    execute_result = MagicMock()
+    execute_result.scalars.return_value.all.return_value = existing_sources
+    session.execute.return_value = execute_result
+    return session
+
+
+@pytest.mark.asyncio
+async def test_update_project_sources_clears_checkpoint_on_config_change(
+    project_manager, sample_projects_config
+):
+    """When a source's configuration hash changes, any saved checkpoint for that
+    source must be dropped — it was computed against the old query/config and
+    would otherwise silently resume the new run mid-page against stale state."""
+    from unittest.mock import patch
+
+    from qdrant_loader.core.state.models import ProjectSource
+
+    project_id = "test-project"
+    config = sample_projects_config.projects[project_id]
+
+    existing_source = MagicMock(spec=ProjectSource)
+    existing_source.source_type = "git"
+    existing_source.source_name = "test-repo"
+    existing_source.config_hash = "stale-hash-that-will-not-match"
+
+    session = _session_with_existing_sources([existing_source])
+
+    with patch(
+        "qdrant_loader.core.state.checkpoint_manager.CheckpointManager"
+    ) as checkpoint_manager_cls:
+        clear_checkpoint = AsyncMock()
+        checkpoint_manager_cls.return_value.clear_checkpoint = clear_checkpoint
+
+        await project_manager._update_project_sources(session, project_id, config)
+
+    clear_checkpoint.assert_awaited_once_with(project_id, "git", "test-repo")
+
+
+@pytest.mark.asyncio
+async def test_update_project_sources_keeps_checkpoint_when_config_unchanged(
+    project_manager, sample_projects_config
+):
+    """No config change → no checkpoint should be touched."""
+    from unittest.mock import patch
+
+    from qdrant_loader.core.state.models import ProjectSource
+
+    project_id = "test-project"
+    config = sample_projects_config.projects[project_id]
+    git_source_config = config.sources.git["test-repo"]
+    real_hash = project_manager._calculate_source_config_hash(git_source_config)
+
+    existing_source = MagicMock(spec=ProjectSource)
+    existing_source.source_type = "git"
+    existing_source.source_name = "test-repo"
+    existing_source.config_hash = real_hash
+
+    session = _session_with_existing_sources([existing_source])
+
+    with patch(
+        "qdrant_loader.core.state.checkpoint_manager.CheckpointManager"
+    ) as checkpoint_manager_cls:
+        clear_checkpoint = AsyncMock()
+        checkpoint_manager_cls.return_value.clear_checkpoint = clear_checkpoint
+
+        await project_manager._update_project_sources(session, project_id, config)
+
+    clear_checkpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_project_sources_keeps_checkpoint_for_legacy_row_without_hash(
+    project_manager, sample_projects_config
+):
+    """A pre-existing source that never had a config_hash computed (legacy DB
+    row, upgrading into hash tracking for the first time) should not have its
+    checkpoint wiped just because the hash column is being populated now."""
+    from unittest.mock import patch
+
+    from qdrant_loader.core.state.models import ProjectSource
+
+    project_id = "test-project"
+    config = sample_projects_config.projects[project_id]
+
+    existing_source = MagicMock(spec=ProjectSource)
+    existing_source.source_type = "git"
+    existing_source.source_name = "test-repo"
+    existing_source.config_hash = None
+
+    session = _session_with_existing_sources([existing_source])
+
+    with patch(
+        "qdrant_loader.core.state.checkpoint_manager.CheckpointManager"
+    ) as checkpoint_manager_cls:
+        clear_checkpoint = AsyncMock()
+        checkpoint_manager_cls.return_value.clear_checkpoint = clear_checkpoint
+
+        await project_manager._update_project_sources(session, project_id, config)
+
+    clear_checkpoint.assert_not_awaited()

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_semantic_analyzer.py
@@ -223,12 +223,8 @@ class TestSemanticAnalyzer:
     def test_initialization_model_download(self):
         """Test SemanticAnalyzer initialization with model download."""
         with (
-            patch(
-                "qdrant_loader.core.text_processing.semantic_analyzer.spacy.load"
-            ) as mock_load,
-            patch(
-                "qdrant_loader.core.text_processing.semantic_analyzer.spacy_download"
-            ) as mock_download,
+            patch("spacy.load") as mock_load,
+            patch("spacy.cli.download.download") as mock_download,
         ):
             # First call raises OSError, second call succeeds
             mock_nlp = Mock()

--- a/packages/qdrant-loader/tests/unit/core/text_processing/test_text_processor.py
+++ b/packages/qdrant-loader/tests/unit/core/text_processing/test_text_processor.py
@@ -54,10 +54,8 @@ class TestTextProcessor:
             return_value=["chunk1", "chunk2"]
         )
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_init_successful_spacy_load(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -82,11 +80,9 @@ class TestTextProcessor:
         mock_text_splitter_class.assert_called_once()
         assert processor.text_splitter == self.mock_text_splitter
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch("qdrant_loader.core.text_processing.text_processor.download")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("spacy.cli.download.download")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_init_spacy_model_download(
         self,
@@ -113,10 +109,8 @@ class TestTextProcessor:
         assert mock_spacy_load.call_count == 2
         assert processor.nlp == self.mock_nlp
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_init_nltk_data_download(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -139,10 +133,8 @@ class TestTextProcessor:
         mock_nltk.download.assert_any_call("punkt")
         mock_nltk.download.assert_any_call("stopwords")
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_process_text_success(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -188,10 +180,8 @@ class TestTextProcessor:
         assert result["pos_tags"] == [("Hello", "INTJ"), ("world", "NOUN")]
         assert result["chunks"] == ["chunk1", "chunk2"]
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_process_text_long_text_truncation(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -216,10 +206,8 @@ class TestTextProcessor:
         # Verify text was truncated
         self.mock_nlp.assert_called_with("a" * MAX_TEXT_LENGTH_FOR_SPACY)
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_process_text_exception_handling(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -245,10 +233,8 @@ class TestTextProcessor:
         assert result["pos_tags"] == []
         assert result["chunks"] == ["test text"]
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_get_entities_success(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -278,10 +264,8 @@ class TestTextProcessor:
         # Verify results
         assert result == [("John", "PERSON"), ("New York", "GPE")]
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_get_entities_limit(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -311,10 +295,8 @@ class TestTextProcessor:
         # Verify limit is respected
         assert len(result) == MAX_ENTITIES_TO_EXTRACT
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_get_entities_exception_handling(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -337,10 +319,8 @@ class TestTextProcessor:
         # Verify empty result
         assert result == []
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_get_pos_tags_success(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -372,10 +352,8 @@ class TestTextProcessor:
         # Verify results
         assert result == [("Hello", "INTJ"), ("world", "NOUN")]
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_get_pos_tags_limit(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -405,10 +383,8 @@ class TestTextProcessor:
         # Verify limit is respected
         assert len(result) == MAX_POS_TAGS_TO_EXTRACT
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_get_pos_tags_exception_handling(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -431,10 +407,8 @@ class TestTextProcessor:
         # Verify empty result
         assert result == []
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_split_into_chunks_default(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -457,10 +431,8 @@ class TestTextProcessor:
         )
         assert result == ["chunk1", "chunk2"]
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_split_into_chunks_custom_size(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -504,10 +476,8 @@ class TestTextProcessor:
         )
         assert result == ["custom_chunk1", "custom_chunk2"]
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_split_into_chunks_exception_handling(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -530,10 +500,8 @@ class TestTextProcessor:
         # Verify fallback result
         assert result == ["test text"]
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_split_into_chunks_empty_text(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -556,10 +524,8 @@ class TestTextProcessor:
         # Verify empty result
         assert result == []
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_pipeline_optimization_no_parser(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings
@@ -579,10 +545,8 @@ class TestTextProcessor:
         # Verify select_pipes was not called (no parser to remove)
         self.mock_nlp.select_pipes.assert_not_called()
 
-    @patch("qdrant_loader.core.text_processing.text_processor.spacy.load")
-    @patch(
-        "qdrant_loader.core.text_processing.text_processor.RecursiveCharacterTextSplitter"
-    )
+    @patch("spacy.load")
+    @patch("langchain_text_splitters.RecursiveCharacterTextSplitter")
     @patch("qdrant_loader.core.text_processing.text_processor.nltk")
     def test_custom_chunk_size_overlap_calculation(
         self, mock_nltk, mock_text_splitter_class, mock_spacy_load, mock_settings


### PR DESCRIPTION
# Pull Request

## Summary

Fix resuming feature not working when re-ingest a disrupted ingestion flow

## Type of change

- [ ] Feature
- [X] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")


## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Affected areas:** Jira connector JQL generation (`_build_jql_filter`) now appends deterministic `ORDER BY key ASC`; ingestion/resume flow in `PipelineOrchestrator` now routes forced runs through the streaming+checkpoint-resume path without checkpoint lookup (`force=True` bypasses resume cursor); checkpoint invalidation in `ProjectManager` clears saved checkpoints when a `ProjectSource` config hash changes; change detection is stabilized by `calculate_content_hash` ignoring connector-internal `__*` metadata; document upsert completion now propagates incremental per-document callbacks via `DocumentPipeline` → `UpsertWorker` (`on_document_complete`) to persist state as documents complete; NLP dependencies (`spaCy`) are lazily imported in `SemanticAnalyzer`/`TextProcessor`.
- **Config schema:** No schema changes.
- **Test coverage:** Yes—updated Jira JQL/unit expectations; added orchestrator tests for `force` vs `resume` checkpoint lookup; added project-manager checkpoint-clearing tests; regression tests ensure Jira checkpoint cursors don’t affect `content_hash`; unit tests for `on_document_complete` success/failure and callback exception containment.
- **Security/resource safety:** Callback exceptions are contained to logging; lazy imports reduce module-load side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->