### PR TITLE
test: add unit tests to cover test coverage

### DIFF
--- a/packages/qdrant-loader-core/tests/test_bm25.py
+++ b/packages/qdrant-loader-core/tests/test_bm25.py
@@ -1,0 +1,159 @@
+"""Unit tests for qdrant_loader_core.sparse.bm25."""
+
+import math
+
+import pytest
+from qdrant_loader_core.sparse.bm25 import (
+    BM25SparseEncoder,
+    SparseVectorData,
+    get_sparse_encoder,
+)
+
+
+def test_sparse_vector_data_is_empty_and_frozen() -> None:
+    assert SparseVectorData(indices=[], values=[]).is_empty() is True
+    assert SparseVectorData(indices=[1], values=[1.0]).is_empty() is False
+
+    vec = SparseVectorData(indices=[1], values=[1.0])
+    with pytest.raises((AttributeError, TypeError)):
+        vec.indices = [2]  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "model,expected_k1",
+    [
+        ("bm25", 1.2),
+        ("custom", 1.2),
+        ("bm25_lite", 0.9),
+        ("bm25-lite", 0.9),
+        ("BM25_LITE", 0.9),
+    ],
+)
+def test_encoder_model_and_k1(model: str, expected_k1: float) -> None:
+    enc = BM25SparseEncoder(model=model)
+    assert enc.k1 == expected_k1
+
+
+def test_encoder_normalization_and_limits() -> None:
+    assert BM25SparseEncoder(model="  BM25  ").model == "bm25"
+    assert BM25SparseEncoder(hash_mod=1).hash_mod == 10_000
+    assert BM25SparseEncoder(hash_mod=500_000).hash_mod == 500_000
+
+
+@pytest.mark.parametrize(
+    "text,stop_words,expected_tokens",
+    [
+        ("", None, []),
+        ("Hello World", set(), ["hello", "world"]),
+        ("the quick brown fox", None, ["quick", "brown", "fox"]),
+        ("a b c go", set(), ["go"]),
+        ("hello, world! foo.", set(), ["hello", "world", "foo"]),
+        ("snake_case", set(), ["snake_case"]),
+        ("version 42 release", set(), ["version", "42", "release"]),
+    ],
+)
+def test_tokenize(
+    text: str, stop_words: set[str] | None, expected_tokens: list[str]
+) -> None:
+    enc = BM25SparseEncoder(stop_words=stop_words)
+    assert enc._tokenize(text) == expected_tokens
+
+
+def test_stop_words_default_and_custom() -> None:
+    default_enc = BM25SparseEncoder()
+    assert "the" in default_enc.stop_words
+
+    custom = BM25SparseEncoder(stop_words={"FOO", " Bar "})
+    assert custom.stop_words == frozenset({"foo", "bar"})
+    assert "the" not in custom.stop_words
+
+
+def test_token_to_index_is_stable_and_in_bounds() -> None:
+    enc = BM25SparseEncoder(hash_mod=100_000)
+    idx = enc._token_to_index("hello")
+    assert 1 <= idx <= 100_000
+    assert idx == enc._token_to_index("hello")
+
+
+def test_token_to_index_has_reasonable_diversity() -> None:
+    enc = BM25SparseEncoder()
+    indices = {enc._token_to_index(f"token_{i}") for i in range(100)}
+    assert len(indices) > 90
+
+
+def test_encode_document_empty_and_stop_words() -> None:
+    enc = BM25SparseEncoder()
+    assert enc.encode_document("").is_empty()
+    assert enc.encode_document("the and is with").is_empty()
+
+
+def test_encode_document_weights_and_shape() -> None:
+    enc = BM25SparseEncoder(stop_words=set())
+    result = enc.encode_document("one two three one two one")
+
+    assert result.indices == sorted(result.indices)
+    assert len(result.indices) == len(result.values)
+    assert all(v > 0 for v in result.values)
+
+
+def test_encode_document_repeated_tokens_increase_weight() -> None:
+    enc = BM25SparseEncoder(stop_words=set())
+    single = enc.encode_document("hello")
+    repeated = enc.encode_document("hello hello hello")
+    assert repeated.values[0] > single.values[0]
+
+
+def test_encode_document_bm25_formula() -> None:
+    enc = BM25SparseEncoder(stop_words=set())
+    tf = 3.0
+    expected = (tf * (enc.k1 + 1.0)) / (tf + enc.k1)
+
+    result = enc.encode_document("hello hello hello")
+    hello_idx = enc._token_to_index("hello")
+    pos = result.indices.index(hello_idx)
+    assert abs(result.values[pos] - expected) < 1e-9
+
+
+def test_encode_document_hash_collisions_merge_weights() -> None:
+    enc = BM25SparseEncoder(hash_mod=10_000, stop_words=set())
+    text = " ".join(f"word{i}" for i in range(200))
+    result = enc.encode_document(text)
+
+    assert len(result.indices) <= 200
+    assert len(result.indices) == len(set(result.indices))
+
+
+def test_encode_query_empty() -> None:
+    enc = BM25SparseEncoder()
+    assert enc.encode_query("").is_empty()
+
+
+def test_encode_query_formula_and_difference_from_doc_mode() -> None:
+    enc = BM25SparseEncoder(stop_words=set())
+
+    query = enc.encode_query("hello hello hello")
+    hello_idx = enc._token_to_index("hello")
+    pos = query.indices.index(hello_idx)
+    assert abs(query.values[pos] - (1.0 + math.log(3.0))) < 1e-9
+
+    tf1 = enc.encode_query("hello")
+    assert abs(tf1.values[0] - 1.0) < 1e-9
+
+    doc = enc.encode_document("hello hello")
+    qry = enc.encode_query("hello hello")
+    assert doc.values != qry.values
+    assert qry.indices == sorted(qry.indices)
+
+
+@pytest.mark.parametrize("variant", ["bm25", "BM25", " bm25 ", "Bm25", None])
+def test_get_sparse_encoder_normalizes_equivalent_names(variant: str | None) -> None:
+    canonical = get_sparse_encoder("bm25")
+    current = get_sparse_encoder(variant)  # type: ignore[arg-type]
+    assert current is canonical
+    assert current.model == "bm25"
+
+
+def test_get_sparse_encoder_different_models_get_different_instances() -> None:
+    a = get_sparse_encoder("bm25")
+    b = get_sparse_encoder("bm25_lite")
+    assert a is not b

--- a/packages/qdrant-loader-core/tests/test_gemini_provider.py
+++ b/packages/qdrant-loader-core/tests/test_gemini_provider.py
@@ -1,0 +1,361 @@
+"""Unit tests for qdrant_loader_core.llm.providers.gemini."""
+
+import importlib
+import sys
+import types
+from importlib import import_module
+
+import pytest
+
+
+def _make_llm_settings(
+    *,
+    embeddings_model: str = "gemini-embedding-2",
+    chat_model: str = "gemini-2.0-flash",
+    vector_size: int | None = 768,
+):
+    settings_mod = import_module("qdrant_loader_core.llm.settings")
+    return settings_mod.LLMSettings(
+        provider="gemini",
+        base_url=None,
+        api_key="fake-key",
+        api_version=None,
+        headers=None,
+        models={"embeddings": embeddings_model, "chat": chat_model},
+        tokenizer="none",
+        request=settings_mod.RequestPolicy(),
+        rate_limits=settings_mod.RateLimitPolicy(),
+        embeddings=settings_mod.EmbeddingPolicy(vector_size=vector_size),
+        provider_options=None,
+    )
+
+
+def _make_genai_stub(
+    *,
+    embed_result=None,
+    embed_exc=None,
+    chat_text="hello",
+    chat_exc=None,
+    token_count=42,
+):
+    state: dict[str, object] = {
+        "client_kwargs": None,
+        "embed_kwargs": None,
+        "chat_kwargs": None,
+    }
+
+    types_mod = types.SimpleNamespace()
+
+    class Content:
+        def __init__(self, *, role="user", parts=None):
+            self.role = role
+            self.parts = parts or []
+
+    class Part:
+        def __init__(self, text=""):
+            self.text = text
+
+        @staticmethod
+        def from_text(*, text: str) -> "Part":
+            return Part(text=text)
+
+    class EmbedContentConfig:
+        def __init__(self, *, output_dimensionality=None):
+            self.output_dimensionality = output_dimensionality
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    types_mod.Content = Content
+    types_mod.Part = Part
+    types_mod.EmbedContentConfig = EmbedContentConfig
+    types_mod.GenerateContentConfig = GenerateContentConfig
+
+    errors_mod = types.SimpleNamespace()
+
+    class APIError(Exception):
+        def __init__(self, msg="", *, code=None):
+            super().__init__(msg)
+            self.code = code
+
+    errors_mod.APIError = APIError
+
+    vectors = embed_result if embed_result is not None else [[0.1, 0.2], [0.3, 0.4]]
+
+    class _EmbedItem:
+        def __init__(self, values):
+            self.values = values
+
+    class _EmbedResponse:
+        def __init__(self, vals):
+            self.embeddings = [_EmbedItem(v) for v in vals]
+
+    class _Usage:
+        prompt_token_count = 10
+        candidates_token_count = 5
+        total_token_count = 15
+
+    class _ChatResponse:
+        def __init__(self):
+            self.text = chat_text
+            self.usage_metadata = _Usage()
+            self.model_version = "gemini-2.0-flash-001"
+
+    class _CountTokensResponse:
+        total_tokens = token_count
+
+    class _Models:
+        def embed_content(self, **kwargs):
+            state["embed_kwargs"] = kwargs
+            if embed_exc is not None:
+                raise embed_exc
+            n = len(kwargs.get("contents", []))
+            out = vectors[:n] if len(vectors) >= n else vectors
+            return _EmbedResponse(out)
+
+        def generate_content(self, **kwargs):
+            state["chat_kwargs"] = kwargs
+            if chat_exc is not None:
+                raise chat_exc
+            return _ChatResponse()
+
+        def count_tokens(self, model, contents):
+            return _CountTokensResponse()
+
+    class Client:
+        def __init__(self, **kwargs):
+            state["client_kwargs"] = kwargs
+            self.models = _Models()
+
+    genai_mod = types.ModuleType("google.genai")
+    genai_mod.Client = Client
+    genai_mod.types = types_mod
+    genai_mod.errors = errors_mod
+
+    return genai_mod, types_mod, errors_mod, state
+
+
+def _reload_gemini(monkeypatch, **kwargs):
+    genai_mod, types_mod, errors_mod, state = _make_genai_stub(**kwargs)
+    google_pkg = sys.modules.get("google") or types.ModuleType("google")
+    google_pkg.__path__ = []  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "google", google_pkg)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_mod)
+    monkeypatch.setitem(sys.modules, "google.genai.types", types_mod)  # type: ignore[arg-type]
+    monkeypatch.setitem(sys.modules, "google.genai.errors", errors_mod)  # type: ignore[arg-type]
+
+    target = "qdrant_loader_core.llm.providers.gemini"
+    if target in sys.modules:
+        del sys.modules[target]
+    return importlib.import_module(target), state
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (408, "TimeoutError"),
+        (504, "TimeoutError"),
+        (429, "RateLimitedError"),
+        (401, "AuthError"),
+        (403, "AuthError"),
+        (400, "InvalidRequestError"),
+        (500, "ServerError"),
+    ],
+)
+def test_map_gemini_exception_by_status(monkeypatch, status, expected):
+    mod, _ = _reload_gemini(monkeypatch)
+    exc = Exception("boom")
+    exc.status_code = status  # type: ignore[attr-defined]
+    mapped = mod._map_gemini_exception(exc)
+    assert mapped.__class__.__name__ == expected
+
+
+def test_map_gemini_exception_special_cases(monkeypatch):
+    mod, _ = _reload_gemini(monkeypatch)
+
+    assert (
+        mod._map_gemini_exception(TimeoutError("t")).__class__.__name__
+        == "TimeoutError"
+    )
+    assert (
+        mod._map_gemini_exception(ValueError("x")).__class__.__name__ == "ServerError"
+    )
+
+    genai_errors = sys.modules["google.genai.errors"]
+    api_exc = genai_errors.APIError("rl", code=429)  # type: ignore[attr-defined]
+    assert mod._map_gemini_exception(api_exc).__class__.__name__ == "RateLimitedError"
+
+
+def test_messages_to_contents_and_fallback(monkeypatch):
+    mod, _ = _reload_gemini(monkeypatch)
+
+    system, contents = mod._messages_to_contents(
+        [
+            {"role": "system", "content": "S1"},
+            {"role": "system", "content": "S2"},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": 42},
+            {"role": "user", "content": None},
+        ]
+    )
+    assert system == "S1\nS2"
+    assert len(contents) == 2
+    assert contents[0].role == "model"
+    assert contents[1].role == "user"
+
+    # Cover genai_types=None branch
+    original_types = mod.genai_types
+    mod.genai_types = None
+    try:
+        system2, contents2 = mod._messages_to_contents(
+            [{"role": "user", "content": "x"}]
+        )
+        assert system2 is None
+        assert contents2 == [{"role": "user", "parts": [{"text": "x"}]}]
+    finally:
+        mod.genai_types = original_types
+
+
+def test_token_counter_paths(monkeypatch):
+    mod, _ = _reload_gemini(monkeypatch, token_count=99)
+    client = sys.modules["google.genai"].Client()
+
+    c = mod._GeminiTokenCounter(client, "m")
+    assert c.count("abc") == 99
+
+    c2 = mod._GeminiTokenCounter(None, "m")
+    assert c2.count("abc") == 3
+
+
+@pytest.mark.asyncio
+async def test_embeddings_success_and_config(monkeypatch):
+    mod, state = _reload_gemini(monkeypatch, embed_result=[[0.1, 0.2]])
+    client = sys.modules["google.genai"].Client()
+
+    emb = mod.GeminiEmbeddings(client, "gemini-embedding-2", output_dimensionality=256)
+    out = await emb.embed(["doc"])
+    assert out == [[0.1, 0.2]]
+
+    kwargs = state["embed_kwargs"]
+    assert kwargs is not None
+    assert kwargs["model"] == "gemini-embedding-2"
+    assert "config" in kwargs
+
+
+@pytest.mark.asyncio
+async def test_embeddings_validation_and_errors(monkeypatch):
+    mod, _ = _reload_gemini(monkeypatch)
+    client = sys.modules["google.genai"].Client()
+
+    with pytest.raises(NotImplementedError):
+        await mod.GeminiEmbeddings(None, "m").embed(["x"])
+
+    with pytest.raises(mod.InvalidRequestError):
+        await mod.GeminiEmbeddings(client, "").embed(["x"])
+
+    assert await mod.GeminiEmbeddings(client, "m").embed([]) == []
+
+    exc = Exception("down")
+    exc.status_code = 500  # type: ignore[attr-defined]
+    mod2, _ = _reload_gemini(monkeypatch, embed_exc=exc)
+    client2 = sys.modules["google.genai"].Client()
+    with pytest.raises(mod2.ServerError):
+        await mod2.GeminiEmbeddings(client2, "m").embed(["x"])
+
+    mod3, _ = _reload_gemini(monkeypatch, embed_result=[[0.1, 0.2]])
+    client3 = sys.modules["google.genai"].Client()
+    with pytest.raises(mod3.ServerError, match="expected 1:1"):
+        await mod3.GeminiEmbeddings(client3, "m").embed(["a", "b"])
+
+
+@pytest.mark.asyncio
+async def test_chat_success_and_forwarding(monkeypatch):
+    mod, state = _reload_gemini(monkeypatch, chat_text="ok")
+    client = sys.modules["google.genai"].Client()
+
+    chat = mod.GeminiChat(client, "gemini-2.0-flash")
+    result = await chat.chat(
+        [{"role": "system", "content": "S"}, {"role": "user", "content": "Hi"}],
+        model="gemini-pro",
+        temperature=0.7,
+        top_p=0.8,
+        max_tokens=100,
+    )
+
+    assert result["text"] == "ok"
+    assert result["usage"]["total_tokens"] == 15
+    assert result["model"] == "gemini-2.0-flash-001"
+
+    kwargs = state["chat_kwargs"]
+    assert kwargs is not None
+    assert kwargs["model"] == "gemini-pro"
+    assert "config" in kwargs
+
+
+@pytest.mark.asyncio
+async def test_chat_validation_and_errors(monkeypatch):
+    mod, _ = _reload_gemini(monkeypatch)
+    client = sys.modules["google.genai"].Client()
+
+    with pytest.raises(NotImplementedError):
+        await mod.GeminiChat(None, "m").chat([{"role": "user", "content": "x"}])
+
+    with pytest.raises(mod.InvalidRequestError):
+        await mod.GeminiChat(client, "").chat([{"role": "user", "content": "x"}])
+
+    exc = Exception("rl")
+    exc.status_code = 429  # type: ignore[attr-defined]
+    mod2, _ = _reload_gemini(monkeypatch, chat_exc=exc)
+    client2 = sys.modules["google.genai"].Client()
+    with pytest.raises(mod2.RateLimitedError):
+        await mod2.GeminiChat(client2, "m").chat([{"role": "user", "content": "x"}])
+
+
+def test_provider_clients_tokenizer_and_vertex_options(monkeypatch):
+    mod, state = _reload_gemini(monkeypatch)
+
+    settings = _make_llm_settings()
+    settings.provider_options = {
+        "vertexai": True,
+        "project": "p1",
+        "location": "us-central1",
+    }
+    provider = mod.GeminiProvider(settings)
+
+    assert isinstance(provider.embeddings(), mod.GeminiEmbeddings)
+    assert isinstance(provider.chat(), mod.GeminiChat)
+    assert isinstance(provider.tokenizer(), mod._GeminiTokenCounter)
+
+    kwargs = state["client_kwargs"]
+    assert kwargs is not None
+    assert kwargs["api_key"] == "fake-key"
+    assert kwargs["vertexai"] is True
+    assert kwargs["project"] == "p1"
+    assert kwargs["location"] == "us-central1"
+
+
+def test_provider_when_genai_unavailable(monkeypatch):
+    mod, _ = _reload_gemini(monkeypatch)
+    original_genai = mod.genai
+    mod.genai = None
+    try:
+        provider = mod.GeminiProvider(_make_llm_settings())
+        assert provider._client is None
+    finally:
+        mod.genai = original_genai
+
+
+@pytest.mark.asyncio
+async def test_provider_roundtrip_embed_and_chat(monkeypatch):
+    mod, _ = _reload_gemini(
+        monkeypatch, embed_result=[[1.0, 2.0, 3.0]], chat_text="pong"
+    )
+    provider = mod.GeminiProvider(_make_llm_settings())
+
+    vectors = await provider.embeddings().embed(["hello"])
+    assert vectors == [[1.0, 2.0, 3.0]]
+
+    resp = await provider.chat().chat([{"role": "user", "content": "ping"}])
+    assert resp["text"] == "pong"

--- a/packages/qdrant-loader-core/tests/test_logging_config.py
+++ b/packages/qdrant-loader-core/tests/test_logging_config.py
@@ -1,0 +1,174 @@
+import logging
+from importlib import import_module
+
+import pytest
+
+
+@pytest.fixture
+def isolated_logging_state():
+    """Isolate root logger + LoggingConfig class state for each test."""
+    logging_mod = import_module("qdrant_loader_core.logging")
+    LoggingConfig = logging_mod.LoggingConfig
+
+    root = logging.getLogger()
+    prev_handlers = list(root.handlers)
+    prev_filters = list(root.filters)
+    prev_level = root.level
+
+    prev_initialized = LoggingConfig._initialized
+    prev_installed_handlers = list(LoggingConfig._installed_handlers)
+    prev_file_handler = LoggingConfig._file_handler
+    prev_current_config = LoggingConfig._current_config
+
+    # Start from clean state for deterministic assertions
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    for f in list(root.filters):
+        root.removeFilter(f)
+
+    LoggingConfig._initialized = False
+    LoggingConfig._installed_handlers = []
+    LoggingConfig._file_handler = None
+    LoggingConfig._current_config = None
+
+    try:
+        yield logging_mod
+    finally:
+        # Close handlers added during test
+        for h in list(root.handlers):
+            root.removeHandler(h)
+            try:
+                h.close()
+            except Exception:
+                pass
+        for f in list(root.filters):
+            root.removeFilter(f)
+
+        # Restore root logger
+        for h in prev_handlers:
+            root.addHandler(h)
+        for f in prev_filters:
+            root.addFilter(f)
+        root.setLevel(prev_level)
+
+        # Restore LoggingConfig state
+        LoggingConfig._initialized = prev_initialized
+        LoggingConfig._installed_handlers = prev_installed_handlers
+        LoggingConfig._file_handler = prev_file_handler
+        LoggingConfig._current_config = prev_current_config
+
+
+def test_setup_invalid_log_level_raises_value_error(isolated_logging_state):
+    LoggingConfig = isolated_logging_state.LoggingConfig
+
+    with pytest.raises(ValueError, match="Invalid log level"):
+        LoggingConfig.setup(level="NOT_A_LEVEL")
+
+
+def test_setup_disable_console_via_env(monkeypatch, isolated_logging_state):
+    logging_mod = isolated_logging_state
+    LoggingConfig = logging_mod.LoggingConfig
+
+    monkeypatch.setenv("MCP_DISABLE_CONSOLE_LOGGING", "true")
+    LoggingConfig.setup()
+
+    root = logging.getLogger()
+    # No console/file handler should be attached when console disabled and no file set
+    assert len(root.handlers) == 0
+    assert LoggingConfig._initialized is True
+
+
+def test_setup_short_circuits_when_config_unchanged(
+    monkeypatch, isolated_logging_state
+):
+    logging_mod = isolated_logging_state
+    LoggingConfig = logging_mod.LoggingConfig
+
+    reset_calls = []
+
+    def fake_reset_defaults():
+        reset_calls.append("called")
+
+    monkeypatch.setattr(logging_mod.structlog, "reset_defaults", fake_reset_defaults)
+
+    LoggingConfig.setup(level="INFO", format="console", disable_console=True)
+    LoggingConfig.setup(level="INFO", format="console", disable_console=True)
+
+    # Second call should short-circuit before structlog.reset_defaults
+    assert len(reset_calls) == 1
+
+
+def test_setup_adds_file_handler_and_tracks_current_config(
+    tmp_path, isolated_logging_state
+):
+    LoggingConfig = isolated_logging_state.LoggingConfig
+
+    log_file = tmp_path / "app.log"
+    LoggingConfig.setup(file=str(log_file), disable_console=True)
+
+    root = logging.getLogger()
+    file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+
+    assert len(file_handlers) == 1
+    assert LoggingConfig._file_handler is file_handlers[0]
+    assert LoggingConfig._current_config is not None
+    assert LoggingConfig._current_config[2] == str(log_file)
+
+
+def test_get_logger_calls_setup_when_uninitialized(monkeypatch, isolated_logging_state):
+    logging_mod = isolated_logging_state
+    LoggingConfig = logging_mod.LoggingConfig
+
+    called = []
+
+    original_setup = LoggingConfig.setup
+
+    def wrapped_setup(*args, **kwargs):
+        called.append(True)
+        return original_setup(*args, **kwargs)
+
+    monkeypatch.setattr(LoggingConfig, "setup", wrapped_setup)
+
+    logger = LoggingConfig.get_logger("unit-test")
+
+    assert called
+    assert logger is not None
+
+
+def test_reconfigure_invalid_level_raises_value_error(isolated_logging_state):
+    LoggingConfig = isolated_logging_state.LoggingConfig
+
+    with pytest.raises(ValueError, match="Invalid log level"):
+        LoggingConfig.reconfigure(level="NOPE")
+
+
+def test_reconfigure_replaces_file_handler(tmp_path, isolated_logging_state):
+    LoggingConfig = isolated_logging_state.LoggingConfig
+
+    first_file = tmp_path / "first.log"
+    second_file = tmp_path / "second.log"
+
+    LoggingConfig.setup(file=str(first_file), disable_console=True)
+    first_handler = LoggingConfig._file_handler
+    assert first_handler is not None
+
+    LoggingConfig.reconfigure(file=str(second_file))
+
+    assert LoggingConfig._file_handler is not None
+    assert LoggingConfig._file_handler is not first_handler
+    assert LoggingConfig._current_config is not None
+    assert LoggingConfig._current_config[2] == str(second_file)
+
+
+def test_reconfigure_updates_level_and_current_config(tmp_path, isolated_logging_state):
+    LoggingConfig = isolated_logging_state.LoggingConfig
+
+    log_file = tmp_path / "level.log"
+    LoggingConfig.setup(file=str(log_file), disable_console=True)
+
+    LoggingConfig.reconfigure(level="DEBUG", file=str(log_file))
+
+    root = logging.getLogger()
+    assert root.level == logging.DEBUG
+    assert LoggingConfig._current_config is not None
+    assert LoggingConfig._current_config[0] == "DEBUG"


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds unit-test coverage for Qdrant’s BM25 sparse encoding, Gemini LLM provider, and logging configuration stages. Tests cover tokenization, hashing, weighting, provider validation/error handling, embeddings, chat, client wiring, logging setup, reconfiguration, and handler management.

No connector or pipeline implementation changes are introduced, and there are no breaking or additive configuration-schema changes. The changed code paths are comprehensively exercised through pytest unit tests, including dependency-unavailable and error scenarios. No new security or resource-safety concerns are apparent; tests isolate global logging state and stub external Gemini dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->