### PR TITLE
fix(state): serialize SQLite document-state writes to prevent first-i…

### DIFF
--- a/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/utils.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/graph/schema/utils.py
@@ -7,6 +7,7 @@ from .versioning import get_version_query, set_version_query
 
 logger = logging.getLogger(__name__)
 
+
 async def _apply_v1(graph_store) -> None:
     await _ensure_indexes(graph_store)
     await apply(graph_store)
@@ -16,6 +17,7 @@ MIGRATIONS = {
     1: _apply_v1,
 }
 LATEST_VERSION = max(MIGRATIONS)
+
 
 # ------------------------
 # ENTRY POINT

--- a/packages/qdrant-loader-core/tests/test_falkor_store.py
+++ b/packages/qdrant-loader-core/tests/test_falkor_store.py
@@ -96,7 +96,9 @@ def test_validate_edge_invalid_type_raises(store):
 
 
 def test_node_payload_uses_node_project(store):
-    node = GraphNode(id="1", label="Document", project="proj", properties={"title": "t"})
+    node = GraphNode(
+        id="1", label="Document", project="proj", properties={"title": "t"}
+    )
 
     payload = store._node_payload(node)
 
@@ -198,7 +200,11 @@ async def test_upsert_nodes_batch_invalid_label_raises(store):
 
 def test_edge_payload_with_project_and_kind(store):
     edge = GraphEdge(
-        source="a", target="b", edge_type="LINKS_TO", project="p", properties={"kind": "x"}
+        source="a",
+        target="b",
+        edge_type="LINKS_TO",
+        project="p",
+        properties={"kind": "x"},
     )
 
     payload = store._edge_payload(edge)
@@ -238,7 +244,11 @@ def test_edge_payload_defaults_to_global_project(store):
 async def test_upsert_edge_with_project_and_kind(store):
     store._run_query = AsyncMock()
     edge = GraphEdge(
-        source="a", target="b", edge_type="LINKS_TO", project="p", properties={"kind": "related"}
+        source="a",
+        target="b",
+        edge_type="LINKS_TO",
+        project="p",
+        properties={"kind": "related"},
     )
 
     await store.upsert_edge(edge)
@@ -306,11 +316,17 @@ async def test_upsert_edges_batch_empty_list_returns_immediately(store):
 
 
 @pytest.mark.asyncio
-async def test_upsert_edges_batch_groups_typed_and_untyped_with_and_without_project(store):
+async def test_upsert_edges_batch_groups_typed_and_untyped_with_and_without_project(
+    store,
+):
     store._run_query = AsyncMock()
     edges = [
         GraphEdge(
-            source="a", target="b", edge_type="LINKS_TO", project="p", properties={"kind": "x"}
+            source="a",
+            target="b",
+            edge_type="LINKS_TO",
+            project="p",
+            properties={"kind": "x"},
         ),
         GraphEdge(source="c", target="d", edge_type="LINKS_TO", properties={}),
     ]
@@ -325,7 +341,9 @@ async def test_upsert_edges_batch_invalid_type_raises(store):
     store._run_query = AsyncMock()
 
     with pytest.raises(ValueError):
-        await store.upsert_edges_batch([GraphEdge(source="a", target="b", edge_type="BOGUS")])
+        await store.upsert_edges_batch(
+            [GraphEdge(source="a", target="b", edge_type="BOGUS")]
+        )
 
     store._run_query.assert_not_awaited()
 
@@ -345,7 +363,9 @@ async def test_neighbors_invalid_edge_type_raises(store):
 async def test_neighbors_with_project_and_edge_types_extracts_falkor_objects(store):
     n = FakeFalkorNode(id=1, labels=["Document"], properties={"id": "doc1"})
     m = FakeFalkorNode(id=2, labels=["Person"], properties={"id": "person1"})
-    rel = FakeFalkorRel(src_node=1, dest_node=2, relation="AUTHORED_BY", properties={"role": "author"})
+    rel = FakeFalkorRel(
+        src_node=1, dest_node=2, relation="AUTHORED_BY", properties={"role": "author"}
+    )
     store._run_query = AsyncMock(return_value=_fake_result([[n, rel, m]]))
 
     subgraph = await store.neighbors(
@@ -381,7 +401,12 @@ async def test_neighbors_without_project_builds_unscoped_query(store):
 async def test_neighbors_extracts_dict_nodes_and_edges(store):
     n = {"id": "doc1", "label": "Document"}
     m = {"id": "person1", "label": "Person"}
-    rel = {"source": "doc1", "target": "person1", "edge_type": "AUTHORED_BY", "properties": {}}
+    rel = {
+        "source": "doc1",
+        "target": "person1",
+        "edge_type": "AUTHORED_BY",
+        "properties": {},
+    }
     store._run_query = AsyncMock(return_value=_fake_result([[n, [rel], m]]))
 
     subgraph = await store.neighbors(node_id="doc1", depth=1)
@@ -399,7 +424,10 @@ async def test_neighbors_extracts_fallback_scalar_nodes(store):
 
     subgraph = await store.neighbors(node_id="1", depth=1)
 
-    assert {node.id for node in subgraph.nodes} == {"raw_node_value", "raw_target_value"}
+    assert {node.id for node in subgraph.nodes} == {
+        "raw_node_value",
+        "raw_target_value",
+    }
     assert subgraph.edges == []
 
 

--- a/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
+++ b/packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py
@@ -34,6 +34,7 @@ class StateManager:
         """Initialize the state manager with configuration."""
         self.config = config
         self._initialized = False
+        self._is_sqlite_backend = False
         self._engine: AsyncEngine | None = None
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
         self._queue_db_op_lock = asyncio.Lock()
@@ -107,6 +108,7 @@ class StateManager:
             # Handle special databases and generate URL
             database_url = _gen_url(db_path_str)
             self.logger.debug(f"Generated database URL: {database_url}")
+            self._is_sqlite_backend = database_url.startswith("sqlite")
 
             # Create database engine and session factory
             self.logger.debug("Creating database engine and session factory")
@@ -455,6 +457,14 @@ class StateManager:
             f"Updating document state for {document.source_type}:{document.source}:{document.id} (project: {project_id})"
         )
         try:
+            if self._is_sqlite_backend:
+                async with self._queue_db_op_lock:
+                    return await _transitions.update_document_state(
+                        self._session_factory,  # type: ignore[arg-type]
+                        document=document,
+                        project_id=project_id,
+                    )
+
             return await _transitions.update_document_state(
                 self._session_factory,  # type: ignore[arg-type]
                 document=document,
@@ -490,6 +500,14 @@ class StateManager:
             f"Updating document state for {len(documents)} documents in one batch "
             f"(project: {project_id})"
         )
+        if self._is_sqlite_backend:
+            async with self._queue_db_op_lock:
+                return await _transitions.update_document_states_batch(
+                    self._session_factory,  # type: ignore[arg-type]
+                    documents=documents,
+                    project_id=project_id,
+                )
+
         return await _transitions.update_document_states_batch(
             self._session_factory,  # type: ignore[arg-type]
             documents=documents,

--- a/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
+++ b/packages/qdrant-loader/tests/unit/core/pipeline/test_orchestrator.py
@@ -761,7 +761,6 @@ class TestPipelineOrchestrator:
                     sources_config=self.mock_sources_config
                 )
 
-
     @pytest.mark.asyncio
     async def test_detect_document_changes_success(self):
         """Test successful document change detection."""
@@ -1551,8 +1550,6 @@ class TestStreamBatchesForceDisablesCheckpointLookup:
             ]
 
         assert len(batches) == 1
-        get_checkpoint.assert_awaited_once_with(
-            "project-1", "Jira", "jira-main"
-        )
+        get_checkpoint.assert_awaited_once_with("project-1", "Jira", "jira-main")
         _, kwargs = get_connector_instance.call_args
         assert kwargs["checkpoint_cursor"] == "stale-cursor"

--- a/packages/qdrant-loader/tests/unit/core/state/test_state_manager.py
+++ b/packages/qdrant-loader/tests/unit/core/state/test_state_manager.py
@@ -154,6 +154,54 @@ async def test_update_document_state(state_manager, sample_document):
 
 
 @pytest.mark.asyncio
+async def test_update_document_state_serialized_for_sqlite(state_manager):
+    """Concurrent single-document updates should be serialized for SQLite backends."""
+    from qdrant_loader.core.state import transitions as _transitions
+
+    doc1 = Document(
+        id="sqlite-lock-doc-1",
+        title="Doc 1",
+        content="Content 1",
+        content_type="text/plain",
+        source_type="test",
+        source="test-source",
+        url="http://test.com/doc1",
+        metadata={},
+    )
+    doc2 = Document(
+        id="sqlite-lock-doc-2",
+        title="Doc 2",
+        content="Content 2",
+        content_type="text/plain",
+        source_type="test",
+        source="test-source",
+        url="http://test.com/doc2",
+        metadata={},
+    )
+
+    active_calls = 0
+    max_concurrent_calls = 0
+
+    async def delayed_update(session_factory, *, document, project_id):
+        nonlocal active_calls, max_concurrent_calls
+        active_calls += 1
+        max_concurrent_calls = max(max_concurrent_calls, active_calls)
+        await asyncio.sleep(0.05)
+        active_calls -= 1
+        return MagicMock(document_id=document.id)
+
+    with patch.object(
+        _transitions, "update_document_state", side_effect=delayed_update
+    ):
+        await asyncio.gather(
+            state_manager.update_document_state(doc1),
+            state_manager.update_document_state(doc2),
+        )
+
+    assert max_concurrent_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_update_document_states_batch_success(state_manager):
     """A batch update commits all documents and returns their records."""
     documents = [
@@ -183,6 +231,60 @@ async def test_update_document_states_batch_success(state_manager):
             source_type="test", source="test-source", document_id=doc.id
         )
         assert stored is not None
+
+
+@pytest.mark.asyncio
+async def test_update_document_states_batch_serialized_for_sqlite(state_manager):
+    """Concurrent batch updates should be serialized for SQLite backends."""
+    from qdrant_loader.core.state import transitions as _transitions
+
+    documents_a = [
+        Document(
+            id="sqlite-batch-a-1",
+            title="A1",
+            content="Content A1",
+            content_type="text/plain",
+            source_type="test",
+            source="test-source",
+            url="http://test.com/a1",
+            metadata={},
+        )
+    ]
+    documents_b = [
+        Document(
+            id="sqlite-batch-b-1",
+            title="B1",
+            content="Content B1",
+            content_type="text/plain",
+            source_type="test",
+            source="test-source",
+            url="http://test.com/b1",
+            metadata={},
+        )
+    ]
+
+    active_calls = 0
+    max_concurrent_calls = 0
+
+    async def delayed_batch_update(session_factory, *, documents, project_id):
+        nonlocal active_calls, max_concurrent_calls
+        active_calls += 1
+        max_concurrent_calls = max(max_concurrent_calls, active_calls)
+        await asyncio.sleep(0.05)
+        active_calls -= 1
+        return [(doc, MagicMock(document_id=doc.id), None) for doc in documents]
+
+    with patch.object(
+        _transitions,
+        "update_document_states_batch",
+        side_effect=delayed_batch_update,
+    ):
+        await asyncio.gather(
+            state_manager.update_document_states_batch(documents_a),
+            state_manager.update_document_states_batch(documents_b),
+        )
+
+    assert max_concurrent_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…ngest DB lock; add regression tests

# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Affected pipeline stages:** Document-state updates during ingestion, specifically single and batch writes through `StateManager` when using SQLite. No connector-specific behavior changes.
- **Configuration schema:** No breaking or additive configuration changes.
- **Test coverage:** Added regression tests covering serialization of concurrent SQLite single-document and batch state updates.
- **Security/resource safety:** Shared locking prevents SQLite database-lock failures during initial ingestion. Serialization may reduce write concurrency for SQLite, while non-SQLite backends retain existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->