### PR TITLE
Hotfix: Release v1.0.4

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -10,6 +10,7 @@
    - Data Sources (`docs/users/detailed-guides/data-sources/`)
    - File Conversion (`docs/users/detailed-guides/file-conversion/`)
    - MCP Server (`docs/users/detailed-guides/mcp-server/`)
+   - Incremental Ingestion & Resume (`docs/users/detailed-guides/incremental-ingestion/`)
    - Workflows (`docs/users/workflows/`)
    - Troubleshooting (`docs/users/troubleshooting/`)
 

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -21,6 +21,7 @@
 
 1. **Developer Docs**
    - Architecture (`docs/developers/architecture/`)
+   - Graph Module (`docs/developers/architecture/graph-module.md`)
    - Extending (`docs/developers/extending/`)
    - Testing (`docs/developers/testing/`)
    - Deployment (`docs/developers/deployment/`)

--- a/docs/developers/architecture/README.md
+++ b/docs/developers/architecture/README.md
@@ -202,6 +202,29 @@ Implementation: `qdrant_loader/core/state/state_manager.py`
 - Metadata handling
 - Connection management with retry logic
 
+### Graph Module
+
+**Purpose**: Extract, store, and traverse knowledge graphs from various data sources
+
+**Key Features**:
+
+- Backend-agnostic graph store interface (FalkorDB, Neptune, etc.)
+- Source-specific entity extractors (Jira, Confluence, Git, etc.)
+- Node and edge management with batch operations
+- Graph traversal and querying capabilities
+- Multi-project isolation and scoping
+- Async-first API for scalable operations
+
+**Supported Operations**:
+
+- Extract entities and relationships from documents
+- Upsert nodes and edges in graph databases
+- Traverse graphs up to specified depth with optional edge filtering
+- Execute custom Cypher queries for advanced patterns
+- Manage entity metadata (people, containers, labels, concepts)
+
+For detailed information, see [Graph Module Documentation](./graph-module.md)
+
 ## 🧪 Data Flow
 
 ### Ingestion Pipeline
@@ -236,7 +259,7 @@ Implementation: `qdrant_loader/core/state/state_manager.py`
 
 QDrant Loader uses a connector-based architecture for extensibility. Connectors are resolved through the connector factory in the pipeline orchestrator:
 
-Implementation citation: [PipelineOrchestrator._collect_documents_from_sources](../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py#L278)
+Implementation citation: [PipelineOrchestrator.\_collect_documents_from_sources](../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py#L278)
 
 ### Available Connectors
 
@@ -264,7 +287,7 @@ Implementation citation: [StateManager.update_document_state](../../../packages/
 Two separate mechanisms cooperate here and are easy to conflate — keep them distinct when touching this code:
 
 - **`DocumentStateRecord`** ([models.py](../../../packages/qdrant-loader/src/qdrant_loader/core/state/models.py#L146)) is the per-document ledger `StateChangeDetector.classify_batch` ([state_change_detector.py#L116](../../../packages/qdrant-loader/src/qdrant_loader/core/state/state_change_detector.py#L116)) compares against to decide "already processed, skip it". It's keyed on content hash, not on when ingestion happened.
-- **`IngestionCheckpoint`** ([checkpoint_manager.py#L53](../../../packages/qdrant-loader/src/qdrant_loader/core/state/checkpoint_manager.py#L53)) is a per-source pagination cursor (page token / JQL window / commit / timestamp) that lets a connector resume *fetching* roughly where it left off. It has no per-document granularity.
+- **`IngestionCheckpoint`** ([checkpoint_manager.py#L53](../../../packages/qdrant-loader/src/qdrant_loader/core/state/checkpoint_manager.py#L53)) is a per-source pagination cursor (page token / JQL window / commit / timestamp) that lets a connector resume _fetching_ roughly where it left off. It has no per-document granularity.
 
 Streaming batches documents in bounded chunks of up to 256 (`PipelineOrchestrator.process_documents`, [orchestrator.py#L242](../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py#L242)) that each go through `DocumentPipeline.process_batch`. Two correctness properties matter for resume and are easy to accidentally regress:
 
@@ -290,7 +313,7 @@ Implementation citation: [QdrantManager.upsert_points](../../../packages/qdrant-
 
 Each connector handles its own authentication:
 
-Implementation citation: [ConfluenceConnector._setup_authentication](../../../packages/qdrant-loader/src/qdrant_loader/connectors/confluence/connector.py#L114)
+Implementation citation: [ConfluenceConnector.\_setup_authentication](../../../packages/qdrant-loader/src/qdrant_loader/connectors/confluence/connector.py#L114)
 
 ### Data Privacy
 

--- a/docs/developers/architecture/README.md
+++ b/docs/developers/architecture/README.md
@@ -259,6 +259,19 @@ QDrant Loader uses SQLite with SQLAlchemy for state management:
 
 Implementation citation: [StateManager.update_document_state](../../../packages/qdrant-loader/src/qdrant_loader/core/state/state_manager.py#L314)
 
+### Resuming an Interrupted Run
+
+Two separate mechanisms cooperate here and are easy to conflate — keep them distinct when touching this code:
+
+- **`DocumentStateRecord`** ([models.py](../../../packages/qdrant-loader/src/qdrant_loader/core/state/models.py#L146)) is the per-document ledger `StateChangeDetector.classify_batch` ([state_change_detector.py#L116](../../../packages/qdrant-loader/src/qdrant_loader/core/state/state_change_detector.py#L116)) compares against to decide "already processed, skip it". It's keyed on content hash, not on when ingestion happened.
+- **`IngestionCheckpoint`** ([checkpoint_manager.py#L53](../../../packages/qdrant-loader/src/qdrant_loader/core/state/checkpoint_manager.py#L53)) is a per-source pagination cursor (page token / JQL window / commit / timestamp) that lets a connector resume *fetching* roughly where it left off. It has no per-document granularity.
+
+Streaming batches documents in bounded chunks of up to 256 (`PipelineOrchestrator.process_documents`, [orchestrator.py#L242](../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py#L242)) that each go through `DocumentPipeline.process_batch`. Two correctness properties matter for resume and are easy to accidentally regress:
+
+1. **State must be persisted per document, not per batch.** `UpsertWorker.process_embedded_chunks` ([upsert_worker.py#L317](../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py#L317)) invokes an `on_document_complete` callback the instant a document's last chunk is accounted for — before the rest of the batch (up to 256 documents) finishes. `PipelineOrchestrator._persist_single_document_state` ([orchestrator.py#L763](../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py#L763)) is wired to that callback and writes the `DocumentStateRecord` immediately. Before this existed, state was only written once the entire batch finished (`_update_document_states`, still present as an idempotent end-of-batch safety net), so an interruption mid-batch lost state for documents that had already been durably upserted to QDrant, and a restart reprocessed them.
+2. **A callback failure must not be swallowed.** If persisting a document's state raises, `UpsertWorker` collects it and re-raises once all pending upserts have drained, instead of logging and continuing. `document_pipeline.process_batch`'s catch-all turns that into a failed `BatchResult` for the whole streaming batch, which keeps `PipelineOrchestrator.process_documents` from advancing the `IngestionCheckpoint` past documents whose state was never actually written — a batch reported successful must mean its state really landed in the database.
+3. **`Document.calculate_content_hash`** ([document.py#L132](../../../packages/qdrant-loader/src/qdrant_loader/core/document.py#L132)) excludes any metadata key prefixed with `__` (e.g. `__ingestion_checkpoint`, the pagination cursor JIRA connectors attach to documents) from the hash. That prefix is the established convention for connector-internal bookkeeping — never fold it into content identity, since a cursor token has no guarantee of being stable across two fetches of the same, unchanged page, and doing so makes every document on that page look "updated" on every single run.
+
 ## 🚀 Performance Considerations
 
 ### Asynchronous Processing

--- a/docs/developers/architecture/graph-module.md
+++ b/docs/developers/architecture/graph-module.md
@@ -1,0 +1,469 @@
+# Graph Module Documentation
+
+## 📋 Overview
+
+The **Graph Module** is a core component of QDrant Loader that enables extraction, storage, and traversal of knowledge graphs from various data sources. It provides a backend-agnostic interface for building entity-relationship graphs from documents, allowing developers to:
+
+- Extract structured entities (documents, people, containers, concepts) from unstructured data
+- Create relationships between entities (authored_by, belongs_to, has_label, etc.)
+- Store graphs in graph databases like FalkorDB or Neptune
+- Query and traverse graph relationships for enhanced semantic search
+
+### Key Benefits
+
+- **Backend-Agnostic Design**: Pluggable graph store implementations (FalkorDB, Neptune, etc.)
+- **Source-Specific Extractors**: Built-in extractors for Jira, Confluence, Git, and local files
+- **Batch Operations**: Efficient bulk insert/update operations for high-throughput ingestion
+- **Project Isolation**: Multi-project support with automatic project-scoped queries
+- **Async-First**: Non-blocking I/O for scalable graph operations
+
+### Use Cases
+
+- **Enterprise Knowledge Graphs**: Build comprehensive entity networks from Jira, Confluence, and Git repositories
+- **Entity Linking**: Connect documents, people, and topics across multiple data sources
+- **Semantic Search Enhancement**: Use graph relationships to expand and contextualize search queries
+- **Relationship Discovery**: Find connections between entities that would be hidden in linear document search
+
+## 🏗️ Architecture
+
+### Component Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Graph Module (qdrant_loader_core.graph)                      │
+├─────────────────────────────────────────────────────────────┤
+│                                                               │
+│  ┌──────────────────────┐        ┌──────────────────────┐   │
+│  │   Graph Interface    │        │  Entity Extractors   │   │
+│  ├──────────────────────┤        ├──────────────────────┤   │
+│  │ - GraphStore (ABC)   │        │ - EntityExtractor    │   │
+│  │ - Models             │        │ - BaseEntityExtractor│   │
+│  │ - FalkorGraphStore   │        │ - JiraEntityExtractor│   │
+│  │                      │        │ - ConfluenceExtractor│   │
+│  └──────────────────────┘        │ - GitEntityExtractor │   │
+│                                  │ - LocalFileExtractor │   │
+│                                  │ - PublicDocsExtractor│   │
+│                                  └──────────────────────┘   │
+│                                                               │
+│  ┌──────────────────────┐        ┌──────────────────────┐   │
+│  │   Data Models        │        │  Schema Utilities    │   │
+│  ├──────────────────────┤        ├──────────────────────┤   │
+│  │ - GraphNode          │        │ - Schema initialization
+│  │ - GraphEdge          │        │ - Node label enums   │   │
+│  │ - SubGraph           │        │ - Edge type enums    │   │
+│  │ - PersonInfo         │        │                      │   │
+│  └──────────────────────┘        └──────────────────────┘   │
+│                                                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Data Model
+
+#### GraphNode
+
+Represents an entity in the graph with a unique identity and properties.
+
+```python
+@dataclass
+class GraphNode:
+    id: str                           # Unique node identifier
+    label: str                        # Node type (Document, Person, etc.)
+    project: str | None = None        # Project namespace (multi-project support)
+    properties: dict[str, Any] = {}   # Custom properties (content, metadata, etc.)
+```
+
+**Supported Node Labels** (CoreNodeLabel):
+
+- `DOCUMENT` - Represents a document/content item
+- `PERSON` - Represents a user or author
+- `CONTAINER` - Project/space/repository (logical grouping)
+- `LABEL` - Tags or categories
+- `CONCEPT` - Abstract concepts or entities
+- `CHUNK` - Text segments or paragraphs
+- `URL` - External URL references
+- `ATTACHMENT` - File attachments
+
+#### GraphEdge
+
+Represents a directed relationship between two nodes.
+
+```python
+@dataclass
+class GraphEdge:
+    source: str                       # Source node ID
+    target: str                       # Target node ID
+    edge_type: str                    # Relationship type
+    project: str | None = None        # Project namespace
+    properties: dict[str, Any] = {}   # Relationship metadata (role, kind, etc.)
+```
+
+**Supported Edge Types** (CoreEdgeType):
+
+- `AUTHORED_BY` - Person created/wrote the document (properties: `role`)
+- `BELONGS_TO` - Document belongs to a container/project
+- `HAS_LABEL` - Document has a label/tag
+- `LINKS_TO` - Document links to external URL
+- `PART_OF` - Hierarchical containment (section → document)
+- `HAS_CHUNK` - Document contains a text chunk
+- `HAS_CHILD` - Parent-child relationships
+- `HAS_ATTACHMENT` - Document has attached files
+
+#### SubGraph
+
+A collection of nodes and edges forming a connected component.
+
+```python
+@dataclass
+class SubGraph:
+    nodes: list[GraphNode] = []       # Graph nodes
+    edges: list[GraphEdge] = []       # Graph edges
+```
+
+#### PersonInfo
+
+Represents author/contributor metadata.
+
+```python
+@dataclass
+class PersonInfo:
+    id: str                           # Unique person identifier
+    display_name: str                 # Full display name
+    email: str | None = None          # Email address
+    username: str | None = None       # Username/handle
+    source_type: str | None = None    # Source system (jira, confluence, etc.)
+    source_id: str | None = None      # Source-specific ID
+```
+
+## 🔌 Core Components
+
+### GraphStore Interface
+
+Abstract interface defining the graph storage contract. All graph backends must implement this interface.
+
+**Key Methods:**
+
+```python
+class GraphStore(ABC):
+    # Node operations
+    async def upsert_node(node: GraphNode) -> None
+    async def upsert_nodes_batch(nodes: list[GraphNode]) -> None
+
+    # Edge operations
+    async def upsert_edge(edge: GraphEdge) -> None
+    async def upsert_edges_batch(edges: list[GraphEdge]) -> None
+
+    # Query operations
+    async def neighbors(
+        node_id: str,
+        depth: int,
+        edge_types: list[str] | None = None,
+        project: str | None = None,
+    ) -> SubGraph
+
+    async def query_cypher(
+        cypher: str,
+        params: dict[str, Any],
+    ) -> list[list[Any]]
+```
+
+**Implementation:**
+
+- **FalkorGraphStore** - FalkorDB implementation (Redis-based graph database)
+  - Uses Cypher query language
+  - Supports connection pooling and async operations
+  - Multi-project isolation via project field
+
+### EntityExtractor Interface
+
+Abstract interface for source-specific entity extraction. Each data source has a dedicated extractor.
+
+**Key Methods:**
+
+```python
+class EntityExtractor(ABC):
+    async def extract(doc: Document) -> SubGraph
+
+    @classmethod
+    def register_extractor(source_type: str, extractor_cls: type)
+
+    @classmethod
+    def for_source(source_type: str) -> EntityExtractor
+```
+
+**Built-in Extractors:**
+
+| Extractor                   | Source      | Extracts                                           |
+| --------------------------- | ----------- | -------------------------------------------------- |
+| `JiraEntityExtractor`       | Jira        | Issues, assignees, reporters, projects, components |
+| `ConfluenceEntityExtractor` | Confluence  | Pages, authors, spaces, child pages                |
+| `GitEntityExtractor`        | Git         | Commits, authors, files, repositories              |
+| `LocalFileEntityExtractor`  | Local files | Files, folders, metadata                           |
+| `PublicDocsEntityExtractor` | Public docs | Pages, links, metadata                             |
+
+### FalkorGraphStore
+
+Concrete implementation using FalkorDB (Redis-based graph database).
+
+**Features:**
+
+- Connection pooling with configurable max connections
+- Batch insert optimization (groups by label/type)
+- Project-based multi-tenancy
+- Cypher query support
+- Automatic node/edge validation
+
+**Configuration:**
+
+```python
+store = FalkorGraphStore(
+    host="localhost",           # FalkorDB host
+    port=6379,                  # FalkorDB port
+    password=None,              # Optional password
+    graph_name="default_graph", # Graph name
+    max_connections=10          # Connection pool size
+)
+```
+
+## 📖 API Reference
+
+### Core Methods
+
+#### Upserting Nodes
+
+```python
+# Single node
+node = GraphNode(
+    id="doc-123",
+    label="Document",
+    project="project-a",
+    properties={
+        "title": "Quarterly Report",
+        "created_at": "2026-01-15",
+        "author_count": 3
+    }
+)
+await store.upsert_node(node)
+
+# Batch insert
+nodes = [
+    GraphNode(id="doc-1", label="Document", project="proj-a"),
+    GraphNode(id="doc-2", label="Document", project="proj-a"),
+    GraphNode(id="person-1", label="Person", project="proj-a"),
+]
+await store.upsert_nodes_batch(nodes)
+```
+
+#### Upserting Edges
+
+```python
+# Single edge
+edge = GraphEdge(
+    source="doc-123",
+    target="person-1",
+    edge_type="AUTHORED_BY",
+    project="project-a",
+    properties={"role": "author"}
+)
+await store.upsert_edge(edge)
+
+# Batch insert
+edges = [
+    GraphEdge(source="doc-1", target="person-1", edge_type="AUTHORED_BY"),
+    GraphEdge(source="doc-1", target="proj-a", edge_type="BELONGS_TO"),
+]
+await store.upsert_edges_batch(edges)
+```
+
+#### Traversing the Graph
+
+```python
+# Get all neighbors up to depth 2
+subgraph = await store.neighbors(
+    node_id="doc-123",
+    depth=2,
+    project="project-a"
+)
+
+# Get only specific relationship types
+subgraph = await store.neighbors(
+    node_id="person-1",
+    depth=1,
+    edge_types=["AUTHORED_BY", "BELONGS_TO"],
+    project="project-a"
+)
+
+# Process results
+for node in subgraph.nodes:
+    print(f"Node: {node.id} ({node.label})")
+for edge in subgraph.edges:
+    print(f"Edge: {edge.source} -[{edge.edge_type}]-> {edge.target}")
+```
+
+#### Custom Cypher Queries
+
+```python
+# Execute raw Cypher for advanced patterns
+result = await store.query_cypher(
+    cypher="""
+    MATCH (doc:Document)-[r:AUTHORED_BY]->(person:Person)
+    WHERE doc.project = $project
+    RETURN doc.id, person.display_name, r.role
+    """,
+    params={"project": "project-a"}
+)
+
+for row in result:
+    doc_id, author_name, role = row
+    print(f"{doc_id} written by {author_name} as {role}")
+```
+
+## 🔧 Configuration
+
+### Environment Variables
+
+| Variable                | Type   | Default         | Description                  |
+| ----------------------- | ------ | --------------- | ---------------------------- |
+| `GRAPH_HOST`            | string | `localhost`     | FalkorDB host address        |
+| `GRAPH_PORT`            | int    | `6379`          | FalkorDB port number         |
+| `GRAPH_PASSWORD`        | string | -               | FalkorDB password (optional) |
+| `GRAPH_NAME`            | string | `default_graph` | Graph database name          |
+| `GRAPH_MAX_CONNECTIONS` | int    | `10`            | Connection pool size         |
+
+### Configuration File (config.yaml)
+
+```yaml
+global:
+  graph:
+    enabled: true # Enable graph extraction
+    backend: falkordb # Graph store backend
+    host: "localhost" # FalkorDB host
+    port: 6379 # FalkorDB port
+    password: null # FalkorDB password
+    graph_name: "default_graph" # Graph name
+    max_connections: 10 # Connection pool size
+    extraction:
+      enabled: true # Enable automatic extraction
+      sources:
+        - jira
+        - confluence
+        - git
+        - localfile
+```
+
+### FalkorDB Setup
+
+```bash
+# Start FalkorDB via Docker
+docker run -d -p 6379:6379 falkordb/falkordb:latest
+```
+
+## 🚀 Usage Examples
+
+```python
+# Initialize and extract from Jira
+store = await get_graph_store(host="localhost", port=6379)
+extractor = EntityExtractor.for_source("jira")
+subgraph = await extractor.extract(doc)
+
+# Store extracted entities
+await store.upsert_nodes_batch(subgraph.nodes)
+await store.upsert_edges_batch(subgraph.edges)
+
+# Query the graph
+result = await store.neighbors(
+    node_id="jira-PROJ-123",
+    depth=2,
+    project="my-project"
+)
+```
+
+## 🔌 Extending the Graph Module
+
+### Custom Entity Extractor
+
+Extend `BaseEntityExtractor` and implement the `extract()` method to support new data sources:
+
+```python
+from qdrant_loader_core.graph.extractor.base_extractor import BaseEntityExtractor
+
+class CustomExtractor(BaseEntityExtractor):
+    source_type = "custom"
+    async def extract(self, doc: Document) -> SubGraph:
+        # Build nodes and edges from doc
+        return SubGraph(nodes=[...], edges=[...])
+
+EntityExtractor.register_extractor("custom", CustomExtractor)
+```
+
+### Custom Graph Backend
+
+Implement the `GraphStore` interface for new database backends:
+
+```python
+from qdrant_loader_core.graph.base import GraphStore
+
+class CustomGraphStore(GraphStore):
+    async def upsert_node(self, node: GraphNode) -> None: ...
+    async def upsert_nodes_batch(self, nodes: list[GraphNode]) -> None: ...
+    async def upsert_edge(self, edge: GraphEdge) -> None: ...
+    async def upsert_edges_batch(self, edges: list[GraphEdge]) -> None: ...
+    async def neighbors(self, node_id: str, depth: int, ...) -> SubGraph: ...
+    async def query_cypher(self, cypher: str, params: dict) -> list[list[Any]]: ...
+```
+
+## ⚙️ Best Practices
+
+1. **Batch Operations** - Use batch methods for better performance than individual inserts
+2. **Project Isolation** - Always specify `project` parameter for multi-project queries
+3. **Node ID Uniqueness** - Use prefixed IDs like `source:source_id` (e.g., `jira:PROJ-123`)
+4. **Error Handling** - Only use labels from `CoreNodeLabel` enum for node validation
+5. **Connection Management** - Initialize graph store once and reuse across operations
+
+## 🧪 Testing
+
+Tests are in `packages/qdrant-loader-core/tests/`:
+
+- `test_graph_base.py`, `test_falkor_store.py`, `test_graph_init.py`
+- `test_*_extractor.py` - source-specific extractors
+
+```bash
+cd packages/qdrant-loader-core
+pytest tests/test_graph*.py -v
+```
+
+## 🔍 Troubleshooting
+
+**Connection Errors**: Verify FalkorDB is running with `redis-cli ping`. Check host/port in configuration.
+
+**Invalid Node Label**: Only use labels from `CoreNodeLabel` enum (DOCUMENT, PERSON, CONTAINER, LABEL, CONCEPT, CHUNK, URL, ATTACHMENT).
+
+**Project Scope Issues**: Always pass `project` parameter to `neighbors()` queries for correct scoping.
+
+**Memory Issues**: Reduce batch size or process data in smaller chunks during bulk imports.
+
+## 📚 Related Documentation
+
+- [Architecture Overview](README.md) - System-wide architecture
+- [Entity Extraction Guide](../extending/README.md) - Extending entity extractors
+- [Cross-Document Intelligence](../users/detailed-guides/mcp-server.md) - Using graphs in search
+- [Configuration Reference](../users/configuration/README.md) - All configuration options
+
+## 🤝 Contributing
+
+To contribute graph-related improvements:
+
+1. Add new extractors in `packages/qdrant-loader-core/src/qdrant_loader_core/graph/extractor/`
+2. Register extractors in `packages/qdrant-loader-core/src/qdrant_loader_core/graph/registry.py`
+3. Add comprehensive unit tests in `packages/qdrant-loader-core/tests/`
+4. Update this documentation with new patterns and examples
+
+## 📖 API Versioning
+
+Current API Version: **1.0**
+
+The Graph Module API is stable and production-ready. Breaking changes will be announced in the CHANGELOG with migration guides.
+
+---
+
+Last Updated: 2026-07-20  
+Maintainer: Qdrant Loader Team

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -13,6 +13,7 @@ This documentation is organized to help you accomplish specific tasks and unders
 - **[Data Sources](./detailed-guides/data-sources/)** - Complete guides for all supported data sources
 - **[File Conversion](./detailed-guides/file-conversion/)** - Everything about processing different file types
 - **[MCP Server](./detailed-guides/mcp-server/)** - AI development integration and search capabilities
+- **[Incremental Ingestion & Resume](./detailed-guides/incremental-ingestion/)** - How re-ingestion skips unchanged content and recovers from interrupted runs
 - **[Workflows](./workflows/)** - Common, CI/CD, content management, development, and team collaboration
 
 ### 🔧 Configuration
@@ -45,6 +46,10 @@ This documentation is organized to help you accomplish specific tasks and unders
 #### 📝 **Process different file types**
 
 - [File conversion guide](./detailed-guides/file-conversion/) - Comprehensive file type support
+
+#### 🔁 **Re-run ingestion safely or recover from an interruption**
+
+- [Incremental ingestion & resume](./detailed-guides/incremental-ingestion/) - What gets skipped, what resumes, and how to force a full re-ingest
 
 #### 🤖 **Integrate with AI tools**
 

--- a/docs/users/detailed-guides/incremental-ingestion/README.md
+++ b/docs/users/detailed-guides/incremental-ingestion/README.md
@@ -1,0 +1,55 @@
+# Incremental Ingestion & Resuming Interrupted Runs
+
+QDrant Loader is designed so that re-running `ingest` never starts from zero: it skips documents that haven't changed, and it can pick a source back up close to where an interrupted run left off. This guide explains how that works, what to expect if a run gets interrupted, and how to reason about the behavior when troubleshooting.
+
+## 🎯 What Gets Skipped on Re-ingestion
+
+Every document QDrant Loader processes gets a **content hash** (derived from its content, title, and metadata) and a state record is saved once the document has been embedded and upserted into QDrant. On the next `ingest` run, each document fetched from a source is compared against its stored state:
+
+- **Unchanged** (same content hash) → skipped entirely, no re-embedding or re-upsert.
+- **New or changed** (no stored state, or a different content hash) → processed normally.
+- **No longer present at the source** → marked deleted in QDrant.
+
+This is why you can run `qdrant-loader ingest` repeatedly (e.g. on a schedule, or in CI) without worrying about wasted embedding calls for content that hasn't changed.
+
+Implementation: [`StateChangeDetector.classify_batch`](../../../../packages/qdrant-loader/src/qdrant_loader/core/state/state_change_detector.py#L116), [`Document.calculate_content_hash`](../../../../packages/qdrant-loader/src/qdrant_loader/core/document.py#L132)
+
+## ⏸️ What Happens When a Run Is Interrupted
+
+If `ingest` is stopped partway through (Ctrl+C, process kill, machine restart, etc.), QDrant Loader aims to make the next run pick up cleanly rather than reprocess everything from the beginning:
+
+- **Documents already embedded and upserted before the interruption** have their processed-state recorded as soon as each one finishes — not only once an entire internal batch completes. A restart will not re-embed or re-upsert those documents.
+- **Connectors that page through large result sets** (currently JIRA) save a pagination cursor (an *ingestion checkpoint*) as they go, so a restart can resume fetching from roughly where it left off instead of re-listing every page from the start.
+- **In-flight work at the exact moment of interruption** (the small batch of documents actively being embedded/upserted when the process died) may be reprocessed on the next run — this is expected and safe: re-upserting a document is idempotent, it just overwrites the same vector points.
+
+In short: an interrupted run should cost you, at most, re-processing a small window of in-flight documents — not the whole ingestion.
+
+Implementation: [`UpsertWorker.process_embedded_chunks`](../../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/workers/upsert_worker.py#L317) (notifies as each document finishes, rather than waiting for the whole batch), [`PipelineOrchestrator._persist_single_document_state`](../../../../packages/qdrant-loader/src/qdrant_loader/core/pipeline/orchestrator.py#L763), [`CheckpointManager`](../../../../packages/qdrant-loader/src/qdrant_loader/core/state/checkpoint_manager.py#L53)
+
+## 🔁 Forcing a Full Re-ingestion
+
+If you need every document reprocessed regardless of its stored state (for example, after changing chunking or embedding settings), use `--force`:
+
+```bash
+qdrant-loader ingest --workspace . --force
+```
+
+`--force` bypasses both change detection and any saved ingestion checkpoints, so every document is fetched and reprocessed from scratch.
+
+## 🧭 Things to Know
+
+- **A document's state write must actually succeed for it to be skipped next time.** If persisting a document's state fails (e.g. the local state database is locked or unreachable), that failure is surfaced rather than silently ignored — the affected batch is reported as failed instead of falsely reported as successful, and no checkpoint is advanced past it. You'll see this in the logs as a failed batch; re-running `ingest` will simply retry those documents.
+- **Change detection is based on content, not on when you happen to run ingestion.** A pagination cursor or other connector-internal bookkeeping is never treated as part of a document's content — only the actual title, body, and content-relevant metadata affect whether a document is considered changed.
+- **Deleting a document from the source** is detected on the next full scan of that source and the corresponding vectors are removed from QDrant.
+
+## 🔧 Troubleshooting
+
+**Symptom**: the same documents keep getting reprocessed on every run, even though nothing changed at the source.
+
+- Confirm you're not passing `--force` (which always bypasses change detection).
+- Check that the state database path (`global.state_management.database_path`, default `./state.db`) is stable across runs — if it points somewhere that gets wiped or regenerated between runs (e.g. a different workspace directory, or `--force` on `init`), stored state won't be found.
+- Run with `--log-level DEBUG` and look for `Batch classification completed` log lines — they report how many documents were considered new/updated versus skipped, which helps narrow down whether the state database is being read at all versus every document genuinely looking changed.
+
+---
+
+**Related reading**: [Data Sources](../data-sources/) for source-specific setup, [Configuration Reference](../../configuration/) for `state_management` and other global settings.

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/logging.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/logging.py
@@ -14,7 +14,12 @@ import os
 import structlog
 from structlog.stdlib import LoggerFactory
 
-from .logging_filters import ApplicationFilter, QdrantVersionFilter, RedactionFilter
+from .logging_filters import (
+    ApplicationFilter,
+    QdrantVersionFilter,
+    RedactionFilter,
+    UvicornAccessRedactFilter,
+)
 from .logging_processors import CleanFormatter, redact_processor
 
 try:
@@ -160,6 +165,17 @@ class LoggingConfig:
         )
         if not has_app_filter:
             root_logger.addFilter(ApplicationFilter())
+
+        # uvicorn.access has propagate=False in uvicorn's own logging config, so
+        # it bypasses the root logger's RedactionFilter above. Attach directly
+        # so webhook secrets/tokens in the request query string aren't logged
+        # in plaintext (see UvicornAccessRedactFilter docstring for details).
+        uvicorn_access_logger = logging.getLogger("uvicorn.access")
+        if not any(
+            isinstance(f, UvicornAccessRedactFilter)
+            for f in uvicorn_access_logger.filters
+        ):
+            uvicorn_access_logger.addFilter(UvicornAccessRedactFilter())
 
         # Optional suppressions
         if suppress_qdrant_warnings:

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/logging_filters.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/logging_filters.py
@@ -20,6 +20,45 @@ class ApplicationFilter(logging.Filter):
         return True
 
 
+class UvicornAccessRedactFilter(logging.Filter):
+    """Redacts secret/token query-string values from uvicorn's access log line.
+
+    uvicorn logs the raw request line (including the query string) via
+    ``record.args`` on the "uvicorn.access" logger, e.g.
+    ``args = (client_addr, method, "/path?token=abc123", http_version, status)``.
+    That logger has ``propagate=False`` in uvicorn's default logging config, so
+    it never reaches the root logger's handlers/filters (including
+    :class:`RedactionFilter`) — the secret would otherwise be written to the
+    access log in plaintext. Attach this filter directly to the
+    "uvicorn.access" logger; per-logger filters run in ``Logger.handle()``
+    before any handler, so this applies regardless of what handlers uvicorn's
+    own dictConfig installs (dictConfig only replaces handlers, not filters).
+    """
+
+    _SENSITIVE_QUERY_PARAM = re.compile(
+        r"(?i)([?&](?:token|secret|signature|password|api[_-]?key|access[_-]?token)=)[^&\s\"]+"
+    )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            if isinstance(record.args, tuple) and len(record.args) >= 3:
+                path = record.args[2]
+                if isinstance(path, str) and "?" in path:
+                    redacted = self._SENSITIVE_QUERY_PARAM.sub(
+                        r"\1***REDACTED***", path
+                    )
+                    if redacted != path:
+                        record.args = (
+                            record.args[0],
+                            record.args[1],
+                            redacted,
+                            *record.args[3:],
+                        )
+        except Exception:
+            pass
+        return True
+
+
 class RedactionFilter(logging.Filter):
     """Redacts obvious secrets from stdlib log records."""
 

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/logging_filters.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/logging_filters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from urllib.parse import unquote_plus
 
 
 class QdrantVersionFilter(logging.Filter):
@@ -35,19 +36,41 @@ class UvicornAccessRedactFilter(logging.Filter):
     own dictConfig installs (dictConfig only replaces handlers, not filters).
     """
 
-    _SENSITIVE_QUERY_PARAM = re.compile(
-        r"(?i)([?&](?:token|secret|signature|password|authorization|"
-        r"(?:api|access|private)[_-]?key|access[_-]?token)=)[^&\s\"]+"
-    )
+    _SENSITIVE_QUERY_KEYS = {
+        "token",
+        "secret",
+        "signature",
+        "password",
+        "authorization",
+        "api_key",
+        "api-key",
+        "access_key",
+        "access-key",
+        "private_key",
+        "private-key",
+        "access_token",
+        "access-token",
+    }
+    _QUERY_PAIR = re.compile(r'([?&])([^=&\s"]+)=([^&\s"]*)')
+
+    @classmethod
+    def _redact_query_pair(cls, match: re.Match[str]) -> str:
+        sep, raw_key, _value = match.groups()
+        # uvicorn logs the raw, still percent-encoded request line, so a key
+        # like "sec%72et" would slip past a literal match while Starlette/
+        # FastAPI (which percent-decodes query keys during parsing) still
+        # resolves it to "secret" and accepts it as the webhook secret.
+        # Decode before comparing so encoded keys are caught too.
+        if unquote_plus(raw_key).lower() in cls._SENSITIVE_QUERY_KEYS:
+            return f"{sep}{raw_key}=***REDACTED***"
+        return match.group(0)
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:
             if isinstance(record.args, tuple) and len(record.args) >= 3:
                 path = record.args[2]
                 if isinstance(path, str) and "?" in path:
-                    redacted = self._SENSITIVE_QUERY_PARAM.sub(
-                        r"\1***REDACTED***", path
-                    )
+                    redacted = self._QUERY_PAIR.sub(self._redact_query_pair, path)
                     if redacted != path:
                         record.args = (
                             record.args[0],

--- a/packages/qdrant-loader-core/src/qdrant_loader_core/logging_filters.py
+++ b/packages/qdrant-loader-core/src/qdrant_loader_core/logging_filters.py
@@ -36,7 +36,8 @@ class UvicornAccessRedactFilter(logging.Filter):
     """
 
     _SENSITIVE_QUERY_PARAM = re.compile(
-        r"(?i)([?&](?:token|secret|signature|password|api[_-]?key|access[_-]?token)=)[^&\s\"]+"
+        r"(?i)([?&](?:token|secret|signature|password|authorization|"
+        r"(?:api|access|private)[_-]?key|access[_-]?token)=)[^&\s\"]+"
     )
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/packages/qdrant-loader-core/tests/test_logging_core.py
+++ b/packages/qdrant-loader-core/tests/test_logging_core.py
@@ -119,6 +119,63 @@ def test_uvicorn_access_redact_filter_masks_query_secret():
         access_logger.propagate = prev_propagate
 
 
+def test_uvicorn_access_redact_filter_masks_additional_credential_params():
+    """access_key, private_key and authorization query params must also be masked."""
+    logging_mod = import_module("qdrant_loader_core.logging")
+    UvicornAccessRedactFilter = logging_mod.UvicornAccessRedactFilter
+
+    captured_messages = []
+
+    class TestHandler(logging.Handler):
+        def emit(self, record):
+            captured_messages.append(self.format(record))
+
+    access_logger = logging.getLogger("uvicorn.access")
+    prev_handlers = list(access_logger.handlers)
+    prev_filters = list(access_logger.filters)
+    prev_propagate = access_logger.propagate
+
+    try:
+        for h in list(access_logger.handlers):
+            access_logger.removeHandler(h)
+        for f in list(access_logger.filters):
+            access_logger.removeFilter(f)
+
+        test_handler = TestHandler()
+        access_logger.addHandler(test_handler)
+        access_logger.addFilter(UvicornAccessRedactFilter())
+        access_logger.setLevel(logging.INFO)
+        access_logger.propagate = False
+
+        access_logger.info(
+            '%s - "%s %s HTTP/%s" %d',
+            "127.0.0.1:0",
+            "GET",
+            "/path?access_key=AKIAABCDEF&private_key=PRIVATEKEY123&authorization=Bearer123",
+            "1.1",
+            200,
+        )
+
+        assert len(captured_messages) == 1
+        message = captured_messages[0]
+        assert "AKIAABCDEF" not in message
+        assert "PRIVATEKEY123" not in message
+        assert "Bearer123" not in message
+        assert "access_key=***REDACTED***" in message
+        assert "private_key=***REDACTED***" in message
+        assert "authorization=***REDACTED***" in message
+    finally:
+        for f in list(access_logger.filters):
+            access_logger.removeFilter(f)
+        for h in list(access_logger.handlers):
+            access_logger.removeHandler(h)
+        for f in prev_filters:
+            access_logger.addFilter(f)
+        for h in prev_handlers:
+            access_logger.addHandler(h)
+        access_logger.propagate = prev_propagate
+
+
 def test_setup_attaches_uvicorn_access_redact_filter_once():
     logging_mod = import_module("qdrant_loader_core.logging")
     LoggingConfig = logging_mod.LoggingConfig

--- a/packages/qdrant-loader-core/tests/test_logging_core.py
+++ b/packages/qdrant-loader-core/tests/test_logging_core.py
@@ -176,6 +176,65 @@ def test_uvicorn_access_redact_filter_masks_additional_credential_params():
         access_logger.propagate = prev_propagate
 
 
+def test_uvicorn_access_redact_filter_masks_percent_encoded_key():
+    """A percent-encoded query key must still be redacted.
+
+    Starlette/FastAPI percent-decode query keys during parsing, so
+    "sec%72et=<value>" is accepted as "secret=<value>" by the app while the
+    raw request line uvicorn logs keeps it percent-encoded. A literal-match
+    filter would miss it and leak the secret in plaintext.
+    """
+    logging_mod = import_module("qdrant_loader_core.logging")
+    UvicornAccessRedactFilter = logging_mod.UvicornAccessRedactFilter
+
+    captured_messages = []
+
+    class TestHandler(logging.Handler):
+        def emit(self, record):
+            captured_messages.append(self.format(record))
+
+    access_logger = logging.getLogger("uvicorn.access")
+    prev_handlers = list(access_logger.handlers)
+    prev_filters = list(access_logger.filters)
+    prev_propagate = access_logger.propagate
+
+    try:
+        for h in list(access_logger.handlers):
+            access_logger.removeHandler(h)
+        for f in list(access_logger.filters):
+            access_logger.removeFilter(f)
+
+        test_handler = TestHandler()
+        access_logger.addHandler(test_handler)
+        access_logger.addFilter(UvicornAccessRedactFilter())
+        access_logger.setLevel(logging.INFO)
+        access_logger.propagate = False
+
+        access_logger.info(
+            '%s - "%s %s HTTP/%s" %d',
+            "127.0.0.1:0",
+            "POST",
+            "/webhooks/projects/my-project/jira/source?sec%72et=NJF36cwbnGwQNp1QSbAo",
+            "1.1",
+            401,
+        )
+
+        assert len(captured_messages) == 1
+        message = captured_messages[0]
+        assert "NJF36cwbnGwQNp1QSbAo" not in message
+        assert "sec%72et=***REDACTED***" in message
+    finally:
+        for f in list(access_logger.filters):
+            access_logger.removeFilter(f)
+        for h in list(access_logger.handlers):
+            access_logger.removeHandler(h)
+        for f in prev_filters:
+            access_logger.addFilter(f)
+        for h in prev_handlers:
+            access_logger.addHandler(h)
+        access_logger.propagate = prev_propagate
+
+
 def test_setup_attaches_uvicorn_access_redact_filter_once():
     logging_mod = import_module("qdrant_loader_core.logging")
     LoggingConfig = logging_mod.LoggingConfig

--- a/packages/qdrant-loader-core/tests/test_logging_core.py
+++ b/packages/qdrant-loader-core/tests/test_logging_core.py
@@ -61,6 +61,87 @@ def test_redaction_filter_masks_and_marks(caplog):
             root.addHandler(h)
 
 
+def test_uvicorn_access_redact_filter_masks_query_secret():
+    """uvicorn.access logs the raw request line (with query string) via args.
+
+    Regression test for a webhook secret/token passed as a query param (the
+    "simple" auth scheme) being written verbatim into uvicorn's access log,
+    e.g.: '%s - "%s %s HTTP/%s" %d' % (client_addr, method, path, version, status)
+    """
+    logging_mod = import_module("qdrant_loader_core.logging")
+    UvicornAccessRedactFilter = logging_mod.UvicornAccessRedactFilter
+
+    captured_messages = []
+
+    class TestHandler(logging.Handler):
+        def emit(self, record):
+            captured_messages.append(self.format(record))
+
+    access_logger = logging.getLogger("uvicorn.access")
+    prev_handlers = list(access_logger.handlers)
+    prev_filters = list(access_logger.filters)
+    prev_propagate = access_logger.propagate
+
+    try:
+        for h in list(access_logger.handlers):
+            access_logger.removeHandler(h)
+        for f in list(access_logger.filters):
+            access_logger.removeFilter(f)
+
+        test_handler = TestHandler()
+        access_logger.addHandler(test_handler)
+        access_logger.addFilter(UvicornAccessRedactFilter())
+        access_logger.setLevel(logging.INFO)
+        access_logger.propagate = False
+
+        access_logger.info(
+            '%s - "%s %s HTTP/%s" %d',
+            "127.0.0.1:0",
+            "POST",
+            "/webhooks/projects/my-project/jira/source?token=NJF36cwbnGwQNp1QSbAo",
+            "1.1",
+            401,
+        )
+
+        assert len(captured_messages) == 1
+        message = captured_messages[0]
+        assert "NJF36cwbnGwQNp1QSbAo" not in message
+        assert "token=***REDACTED***" in message
+    finally:
+        for f in list(access_logger.filters):
+            access_logger.removeFilter(f)
+        for h in list(access_logger.handlers):
+            access_logger.removeHandler(h)
+        for f in prev_filters:
+            access_logger.addFilter(f)
+        for h in prev_handlers:
+            access_logger.addHandler(h)
+        access_logger.propagate = prev_propagate
+
+
+def test_setup_attaches_uvicorn_access_redact_filter_once():
+    logging_mod = import_module("qdrant_loader_core.logging")
+    LoggingConfig = logging_mod.LoggingConfig
+    UvicornAccessRedactFilter = logging_mod.UvicornAccessRedactFilter
+
+    access_logger = logging.getLogger("uvicorn.access")
+    prev_filters = list(access_logger.filters)
+
+    try:
+        LoggingConfig.setup(level="DEBUG", disable_console=True)
+        LoggingConfig.setup(level="INFO", disable_console=True)
+
+        redact_filters = [
+            f for f in access_logger.filters if isinstance(f, UvicornAccessRedactFilter)
+        ]
+        assert len(redact_filters) == 1
+    finally:
+        for f in list(access_logger.filters):
+            access_logger.removeFilter(f)
+        for f in prev_filters:
+            access_logger.addFilter(f)
+
+
 def test_clean_formatter_strips_ansi(tmp_path):
     logging_mod = import_module("qdrant_loader_core.logging")
     CleanFormatter = logging_mod.CleanFormatter

--- a/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
+++ b/packages/qdrant-loader/src/qdrant_loader/cli/commands/serve_cmd.py
@@ -101,6 +101,10 @@ async def _serve_main(
     from qdrant_loader.core.worker.queue import SQLiteJobQueue
     from qdrant_loader.core.worker.scheduler import IncrementalPullScheduler
     from qdrant_loader.utils.logging import LoggingConfig
+    from qdrant_loader.webhooks.auth import (
+        WEBHOOK_AUTH_NOT_CONFIGURED_MESSAGE,
+        webhook_auth_configured,
+    )
     from qdrant_loader.webhooks.queue_backend import (
         QueueBackendManager,
         SQLiteChangeEventQueue,
@@ -125,6 +129,14 @@ async def _serve_main(
 
     # Load configuration (required before get_global_config / get_settings)
     load_config_with_workspace(workspace_config, config, env)
+
+    # Fail closed on missing webhook auth BEFORE any DB engine/uvicorn/asyncio
+    # resources are created, so misconfiguration exits cleanly instead of
+    # surfacing as an unhandled SystemExit deep inside uvicorn's lifespan
+    # (which otherwise races with StateManager teardown and leaves a dangling
+    # aiosqlite task at interpreter shutdown).
+    if not webhook_auth_configured():
+        raise click.ClickException(WEBHOOK_AUTH_NOT_CONFIGURED_MESSAGE)
 
     # Setup graceful shutdown
     stop_event = asyncio.Event()

--- a/packages/qdrant-loader/src/qdrant_loader/utils/logging.py
+++ b/packages/qdrant-loader/src/qdrant_loader/utils/logging.py
@@ -89,6 +89,45 @@ class VerbosityFilter(logging.Filter):
         return not any(pattern in message for pattern in verbose_patterns)
 
 
+class UvicornAccessRedactFilter(logging.Filter):
+    """Redacts secret/token query-string values from uvicorn's access log line.
+
+    uvicorn logs the raw request line (including the query string) via
+    ``record.args`` on the "uvicorn.access" logger, e.g.
+    ``args = (client_addr, method, "/path?token=abc123", http_version, status)``.
+    That logger has ``propagate=False`` in uvicorn's default logging config, so
+    it never reaches the root logger's handlers/filters — the secret would
+    otherwise be written to the access log in plaintext. Attach this filter
+    directly to the "uvicorn.access" logger; per-logger filters run in
+    ``Logger.handle()`` before any handler, so this applies regardless of what
+    handlers uvicorn's own dictConfig installs (dictConfig only replaces
+    handlers, not filters).
+    """
+
+    _SENSITIVE_QUERY_PARAM = re.compile(
+        r"(?i)([?&](?:token|secret|signature|password|api[_-]?key|access[_-]?token)=)[^&\s\"]+"
+    )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            if isinstance(record.args, tuple) and len(record.args) >= 3:
+                path = record.args[2]
+                if isinstance(path, str) and "?" in path:
+                    redacted = self._SENSITIVE_QUERY_PARAM.sub(
+                        r"\1***REDACTED***", path
+                    )
+                    if redacted != path:
+                        record.args = (
+                            record.args[0],
+                            record.args[1],
+                            redacted,
+                            *record.args[3:],
+                        )
+        except Exception:
+            pass
+        return True
+
+
 class WindowsSafeConsoleHandler(logging.StreamHandler):
     """Custom console handler that handles Windows encoding issues."""
 
@@ -475,6 +514,17 @@ class LoggingConfig:
         root_logger = logging.getLogger()
         for handler in root_logger.handlers:
             handler.addFilter(SQLiteFilter())
+
+        # uvicorn.access has propagate=False in uvicorn's own logging config, so
+        # it bypasses the root logger's redaction above. Attach directly so
+        # webhook secrets/tokens in the request query string aren't logged in
+        # plaintext (see UvicornAccessRedactFilter docstring for details).
+        uvicorn_access_logger = logging.getLogger("uvicorn.access")
+        if not any(
+            isinstance(f, UvicornAccessRedactFilter)
+            for f in uvicorn_access_logger.filters
+        ):
+            uvicorn_access_logger.addFilter(UvicornAccessRedactFilter())
 
         # Add filter to suppress Qdrant version check warnings
         if suppress_qdrant_warnings:

--- a/packages/qdrant-loader/src/qdrant_loader/utils/logging.py
+++ b/packages/qdrant-loader/src/qdrant_loader/utils/logging.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from urllib.parse import unquote_plus
 
 import structlog
 
@@ -104,19 +105,41 @@ class UvicornAccessRedactFilter(logging.Filter):
     handlers, not filters).
     """
 
-    _SENSITIVE_QUERY_PARAM = re.compile(
-        r"(?i)([?&](?:token|secret|signature|password|authorization|"
-        r"(?:api|access|private)[_-]?key|access[_-]?token)=)[^&\s\"]+"
-    )
+    _SENSITIVE_QUERY_KEYS = {
+        "token",
+        "secret",
+        "signature",
+        "password",
+        "authorization",
+        "api_key",
+        "api-key",
+        "access_key",
+        "access-key",
+        "private_key",
+        "private-key",
+        "access_token",
+        "access-token",
+    }
+    _QUERY_PAIR = re.compile(r'([?&])([^=&\s"]+)=([^&\s"]*)')
+
+    @classmethod
+    def _redact_query_pair(cls, match: re.Match[str]) -> str:
+        sep, raw_key, _value = match.groups()
+        # uvicorn logs the raw, still percent-encoded request line, so a key
+        # like "sec%72et" would slip past a literal match while Starlette/
+        # FastAPI (which percent-decodes query keys during parsing) still
+        # resolves it to "secret" and accepts it as the webhook secret.
+        # Decode before comparing so encoded keys are caught too.
+        if unquote_plus(raw_key).lower() in cls._SENSITIVE_QUERY_KEYS:
+            return f"{sep}{raw_key}=***REDACTED***"
+        return match.group(0)
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:
             if isinstance(record.args, tuple) and len(record.args) >= 3:
                 path = record.args[2]
                 if isinstance(path, str) and "?" in path:
-                    redacted = self._SENSITIVE_QUERY_PARAM.sub(
-                        r"\1***REDACTED***", path
-                    )
+                    redacted = self._QUERY_PAIR.sub(self._redact_query_pair, path)
                     if redacted != path:
                         record.args = (
                             record.args[0],

--- a/packages/qdrant-loader/src/qdrant_loader/utils/logging.py
+++ b/packages/qdrant-loader/src/qdrant_loader/utils/logging.py
@@ -105,7 +105,8 @@ class UvicornAccessRedactFilter(logging.Filter):
     """
 
     _SENSITIVE_QUERY_PARAM = re.compile(
-        r"(?i)([?&](?:token|secret|signature|password|api[_-]?key|access[_-]?token)=)[^&\s\"]+"
+        r"(?i)([?&](?:token|secret|signature|password|authorization|"
+        r"(?:api|access|private)[_-]?key|access[_-]?token)=)[^&\s\"]+"
     )
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/packages/qdrant-loader/src/qdrant_loader/webhooks/auth.py
+++ b/packages/qdrant-loader/src/qdrant_loader/webhooks/auth.py
@@ -49,6 +49,36 @@ def _load_project_secrets() -> dict[str, str]:
     return {}
 
 
+def webhook_auth_configured() -> bool:
+    """Return True if at least one webhook authentication method is configured.
+
+    Checked at server startup so misconfiguration fails closed instead of
+    silently accepting unauthenticated requests.
+    """
+    has_global_secret = bool(os.getenv(WEBHOOK_SECRET_ENV_VAR)) or bool(
+        os.getenv("WEBHOOK_SECRETS")
+    )
+    has_project_secret = any(
+        key.startswith("WEBHOOK_SECRET_") and bool(value)
+        for key, value in os.environ.items()
+    )
+    # Read fresh rather than trusting the import-time WEBHOOK_ENABLE_COGNITO_JWT
+    # constant: this is called before .env may have been loaded into os.environ.
+    cognito_enabled = os.getenv("WEBHOOK_ENABLE_COGNITO_JWT", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    return has_global_secret or has_project_secret or cognito_enabled
+
+
+WEBHOOK_AUTH_NOT_CONFIGURED_MESSAGE = (
+    "Webhook authentication is not configured. Set WEBHOOK_SECRET, "
+    "WEBHOOK_SECRETS, WEBHOOK_SECRET_<PROJECT_ID>, or enable Cognito JWT "
+    "(WEBHOOK_ENABLE_COGNITO_JWT=true)."
+)
+
+
 async def get_webhook_secret(
     project_id: str | None = None,
     workspace_id: str | None = None,

--- a/packages/qdrant-loader/src/qdrant_loader/webhooks/auth.py
+++ b/packages/qdrant-loader/src/qdrant_loader/webhooks/auth.py
@@ -20,10 +20,6 @@ WEBHOOK_USE_SECRETS_MANAGER = os.getenv(
     "WEBHOOK_USE_SECRETS_MANAGER", "false"
 ).lower() in ("true", "1", "yes")
 
-WEBHOOK_ENABLE_COGNITO_JWT = os.getenv(
-    "WEBHOOK_ENABLE_COGNITO_JWT", "false"
-).lower() in ("true", "1", "yes")
-
 WEBHOOK_TRUSTED_PROXY = os.getenv("WEBHOOK_TRUSTED_PROXY", None)
 
 COGNITO_REGION = os.getenv("COGNITO_REGION", "")
@@ -49,27 +45,34 @@ def _load_project_secrets() -> dict[str, str]:
     return {}
 
 
+def _cognito_jwt_enabled() -> bool:
+    # Read fresh rather than trusting the import-time WEBHOOK_ENABLE_COGNITO_JWT
+    # constant: callers may run before .env has been loaded into os.environ.
+    return os.getenv("WEBHOOK_ENABLE_COGNITO_JWT", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
 def webhook_auth_configured() -> bool:
     """Return True if at least one webhook authentication method is configured.
 
     Checked at server startup so misconfiguration fails closed instead of
     silently accepting unauthenticated requests.
     """
-    has_global_secret = bool(os.getenv(WEBHOOK_SECRET_ENV_VAR)) or bool(
-        os.getenv("WEBHOOK_SECRETS")
-    )
+    has_global_secret = bool(os.getenv(WEBHOOK_SECRET_ENV_VAR))
+    has_json_project_secret = any(_load_project_secrets().values())
     has_project_secret = any(
         key.startswith("WEBHOOK_SECRET_") and bool(value)
         for key, value in os.environ.items()
     )
-    # Read fresh rather than trusting the import-time WEBHOOK_ENABLE_COGNITO_JWT
-    # constant: this is called before .env may have been loaded into os.environ.
-    cognito_enabled = os.getenv("WEBHOOK_ENABLE_COGNITO_JWT", "false").lower() in (
-        "true",
-        "1",
-        "yes",
+    return (
+        has_global_secret
+        or has_json_project_secret
+        or has_project_secret
+        or _cognito_jwt_enabled()
     )
-    return has_global_secret or has_project_secret or cognito_enabled
 
 
 WEBHOOK_AUTH_NOT_CONFIGURED_MESSAGE = (
@@ -154,7 +157,7 @@ class CognitoJWTValidator:
 
     @classmethod
     async def validate_token(cls, token: str) -> dict[str, Any]:
-        if not WEBHOOK_ENABLE_COGNITO_JWT:
+        if not _cognito_jwt_enabled():
             return {"sub": "local-dev"}
 
         try:
@@ -207,7 +210,7 @@ async def verify_webhook_token(
     secret = await get_webhook_secret(project_id=project_id)
     token_value = _extract_bearer_token(authorization) or webhook_token
 
-    if WEBHOOK_ENABLE_COGNITO_JWT and token_value and _looks_like_jwt(token_value):
+    if _cognito_jwt_enabled() and token_value and _looks_like_jwt(token_value):
         await CognitoJWTValidator.validate_token(token_value)
         return
 

--- a/packages/qdrant-loader/src/qdrant_loader/webhooks/auth.py
+++ b/packages/qdrant-loader/src/qdrant_loader/webhooks/auth.py
@@ -14,7 +14,7 @@ from qdrant_loader.utils.logging import LoggingConfig
 logger = LoggingConfig.get_logger(__name__)
 
 WEBHOOK_SECRET_ENV_VAR = "WEBHOOK_SECRET"
-WEBHOOK_QUERY_PARAM = "token"
+WEBHOOK_QUERY_PARAM = "secret"
 
 WEBHOOK_USE_SECRETS_MANAGER = os.getenv(
     "WEBHOOK_USE_SECRETS_MANAGER", "false"
@@ -171,7 +171,7 @@ async def verify_webhook_token(
     """Verify webhook access for Jira-compatible endpoints.
 
     Jira Cloud only supports shared-secret query tokens, so webhook routes accept
-    the project-scoped WEBHOOK_SECRET via Bearer header or ?token= query param.
+    the project-scoped WEBHOOK_SECRET via Bearer header or ?secret= query param.
     Cognito JWT is validated when enabled and the bearer token is a JWT.
     """
     secret = await get_webhook_secret(project_id=project_id)

--- a/packages/qdrant-loader/src/qdrant_loader/webhooks/server.py
+++ b/packages/qdrant-loader/src/qdrant_loader/webhooks/server.py
@@ -11,11 +11,12 @@ from fastapi.responses import JSONResponse
 
 from qdrant_loader.utils.logging import LoggingConfig
 from qdrant_loader.webhooks.auth import (
-    WEBHOOK_SECRET_ENV_VAR,
+    WEBHOOK_AUTH_NOT_CONFIGURED_MESSAGE,
     get_client_ip,
     verify_cognito_token,
     verify_ingest_auth,
     verify_webhook_token,
+    webhook_auth_configured,
 )
 from qdrant_loader.webhooks.handlers import (
     INGEST_SUPPORTED_SOURCE_TYPES,
@@ -55,23 +56,8 @@ _request_timestamps: dict[str, list[float]] = {}
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    has_global_secret = bool(os.getenv(WEBHOOK_SECRET_ENV_VAR)) or bool(
-        os.getenv("WEBHOOK_SECRETS")
-    )
-    has_project_secret = any(
-        key.startswith("WEBHOOK_SECRET_") and bool(value)
-        for key, value in os.environ.items()
-    )
-    cognito_enabled = os.getenv("WEBHOOK_ENABLE_COGNITO_JWT", "false").lower() in (
-        "true",
-        "1",
-        "yes",
-    )
-    if not (has_global_secret or has_project_secret or cognito_enabled):
-        raise RuntimeError(
-            "Webhook authentication is not configured. Set WEBHOOK_SECRET, "
-            "WEBHOOK_SECRETS, WEBHOOK_SECRET_<PROJECT_ID>, or enable Cognito JWT."
-        )
+    if not webhook_auth_configured():
+        raise RuntimeError(WEBHOOK_AUTH_NOT_CONFIGURED_MESSAGE)
 
     await QueueBackendManager.initialize()
     stop_event = asyncio.Event()

--- a/packages/qdrant-loader/tests/unit/cli/test_serve_cmd.py
+++ b/packages/qdrant-loader/tests/unit/cli/test_serve_cmd.py
@@ -1,0 +1,50 @@
+"""Regression tests for `qdrant-loader serve` webhook-secret fail-closed behavior.
+
+AIKH-2368: with no WEBHOOK_SECRET / WEBHOOK_SECRETS / WEBHOOK_SECRET_<PROJECT_ID>
+and Cognito disabled, `serve` must refuse to start with a clear config error
+*before* any DB engine/uvicorn/asyncio resources are created - not crash later
+with an unhandled asyncio/SQLAlchemy error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+from click import ClickException
+from qdrant_loader.cli.commands.serve_cmd import _serve_main
+
+
+@pytest.fixture(autouse=True)
+def clear_webhook_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("WEBHOOK_SECRET") or key == "WEBHOOK_ENABLE_COGNITO_JWT":
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_serve_fails_closed_before_state_manager_init(monkeypatch):
+    """No webhook secret configured: serve must raise ClickException before
+    ever reaching StateManager.initialize() (i.e. before any DB engine, queue,
+    or uvicorn/asyncio resource is created)."""
+    monkeypatch.setattr(
+        "qdrant_loader.cli.config_loader.load_config_with_workspace",
+        lambda *a, **k: None,
+    )
+
+    initialize_calls = []
+
+    async def fake_initialize(self):
+        initialize_calls.append(self)
+
+    monkeypatch.setattr(
+        "qdrant_loader.core.state.state_manager.StateManager.initialize",
+        fake_initialize,
+    )
+
+    with pytest.raises(
+        ClickException, match="Webhook authentication is not configured"
+    ):
+        asyncio.run(_serve_main(None, None, None, "INFO"))
+
+    assert initialize_calls == []

--- a/packages/qdrant-loader/tests/unit/webhooks/test_auth.py
+++ b/packages/qdrant-loader/tests/unit/webhooks/test_auth.py
@@ -46,6 +46,21 @@ def test_webhook_auth_configured_true_with_secrets_json(monkeypatch):
     assert webhook_auth_configured() is True
 
 
+def test_webhook_auth_configured_false_when_secrets_json_is_empty_dict(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRETS", "{}")
+    assert webhook_auth_configured() is False
+
+
+def test_webhook_auth_configured_false_when_secrets_json_is_malformed(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRETS", "{not valid json")
+    assert webhook_auth_configured() is False
+
+
+def test_webhook_auth_configured_false_when_secrets_json_values_empty(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRETS", '{"project1": ""}')
+    assert webhook_auth_configured() is False
+
+
 def test_webhook_auth_configured_true_with_project_scoped_secret(monkeypatch):
     monkeypatch.setenv("WEBHOOK_SECRET_MYPROJECT", "secret")
     assert webhook_auth_configured() is True
@@ -90,3 +105,28 @@ def test_verify_webhook_token_rejects_invalid(monkeypatch):
             )
         )
     assert exc_info.value.status_code == 401
+
+
+def test_verify_webhook_token_honors_cognito_flag_set_after_import(monkeypatch):
+    # AIKH-2368: the Cognito flag must be read fresh at request time, not
+    # frozen at module import (serve_cmd imports this module before .env
+    # is loaded), otherwise a valid JWT would be rejected as a plain secret.
+    monkeypatch.setenv("WEBHOOK_ENABLE_COGNITO_JWT", "true")
+    monkeypatch.setenv("WEBHOOK_SECRET", "secret")
+
+    async def fake_validate_token(cls, token):
+        return {"sub": "user"}
+
+    monkeypatch.setattr(
+        "qdrant_loader.webhooks.auth.CognitoJWTValidator.validate_token",
+        classmethod(fake_validate_token),
+    )
+
+    fake_jwt = "header.payload.signature"
+    asyncio.run(
+        verify_webhook_token(
+            project_id=None,
+            webhook_token=None,
+            authorization=f"Bearer {fake_jwt}",
+        )
+    )

--- a/packages/qdrant-loader/tests/unit/webhooks/test_auth.py
+++ b/packages/qdrant-loader/tests/unit/webhooks/test_auth.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 
 import pytest
 from fastapi import HTTPException
@@ -6,6 +7,7 @@ from qdrant_loader.webhooks.auth import (
     _get_webhook_secret_from_env,
     get_webhook_secret,
     verify_webhook_token,
+    webhook_auth_configured,
 )
 
 
@@ -14,6 +16,44 @@ def clear_secret_cache():
     _get_webhook_secret_from_env.cache_clear()
     yield
     _get_webhook_secret_from_env.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_webhook_env(monkeypatch):
+    """Ensure no leftover WEBHOOK_* env vars leak between tests."""
+    for key in list(os.environ):
+        if key.startswith("WEBHOOK_SECRET") or key == "WEBHOOK_ENABLE_COGNITO_JWT":
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_webhook_auth_configured_false_when_nothing_set():
+    assert webhook_auth_configured() is False
+
+
+def test_webhook_auth_configured_false_when_secret_is_empty_string(monkeypatch):
+    # AIKH-2368: WEBHOOK_SECRET="" (present but empty) must be treated as unset.
+    monkeypatch.setenv("WEBHOOK_SECRET", "")
+    assert webhook_auth_configured() is False
+
+
+def test_webhook_auth_configured_true_with_global_secret(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRET", "secret")
+    assert webhook_auth_configured() is True
+
+
+def test_webhook_auth_configured_true_with_secrets_json(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRETS", '{"project1": "secret"}')
+    assert webhook_auth_configured() is True
+
+
+def test_webhook_auth_configured_true_with_project_scoped_secret(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRET_MYPROJECT", "secret")
+    assert webhook_auth_configured() is True
+
+
+def test_webhook_auth_configured_true_with_cognito_enabled(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_ENABLE_COGNITO_JWT", "true")
+    assert webhook_auth_configured() is True
 
 
 def test_get_webhook_secret_global(monkeypatch):

--- a/packages/qdrant-loader/tests/unit/webhooks/test_server.py
+++ b/packages/qdrant-loader/tests/unit/webhooks/test_server.py
@@ -66,7 +66,7 @@ def test_webhook_project_route_enqueues_single_event(mock_queue_backend, monkeyp
 
     with TestClient(app) as client:
         response = client.post(
-            "/webhooks/projects/project1/jira/my-jira-source?token=secret",
+            "/webhooks/projects/project1/jira/my-jira-source?secret=secret",
             json={
                 "webhookEvent": "jira:issue_updated",
                 "issue": {"key": "TEST-1", "id": "10001"},
@@ -87,7 +87,7 @@ def test_webhook_source_route_enqueues_event(mock_queue_backend, monkeypatch):
 
     with TestClient(app) as client:
         response = client.post(
-            "/webhooks/jira/my-jira-source?token=secret",
+            "/webhooks/jira/my-jira-source?secret=secret",
             json={
                 "webhookEvent": "jira:issue_deleted",
                 "issue": {"key": "TEST-2", "id": "10002"},
@@ -105,7 +105,7 @@ def test_webhook_requires_auth(monkeypatch):
 
     with TestClient(app) as client:
         response = client.post(
-            "/webhooks/jira/my-jira-source?token=wrong-secret",
+            "/webhooks/jira/my-jira-source?secret=wrong-secret",
             json={},
         )
 
@@ -118,7 +118,7 @@ def test_webhook_rejects_non_jira_source(mock_queue_backend, monkeypatch):
 
     with TestClient(app) as client:
         response = client.post(
-            "/webhooks/confluence/my-source?token=secret",
+            "/webhooks/confluence/my-source?secret=secret",
             json={},
         )
 
@@ -131,7 +131,7 @@ def test_ingest_route_enqueues_full_scan(mock_queue_backend, monkeypatch):
 
     with TestClient(app) as client:
         response = client.post(
-            "/ingest?project_id=project1&source_type=jira&source=my-source&force=true&token=secret",
+            "/ingest?project_id=project1&source_type=jira&source=my-source&force=true&secret=secret",
         )
 
     assert response.status_code == 202
@@ -166,7 +166,7 @@ def test_ingest_route_rejects_missing_source_type(mock_queue_backend, monkeypatc
 
     with TestClient(app) as client:
         response = client.post(
-            "/ingest?project_id=test-project&source=my-source&token=secret",
+            "/ingest?project_id=test-project&source=my-source&secret=secret",
         )
 
     assert response.status_code == 422

--- a/uv.lock
+++ b/uv.lock
@@ -4816,7 +4816,6 @@ name = "qdrant-loader-core"
 version = "1.0.3"
 source = { editable = "packages/qdrant-loader-core" }
 dependencies = [
-    { name = "falkordb", marker = "python_full_version < '3.13'" },
     { name = "pydantic", marker = "python_full_version < '3.13'" },
     { name = "structlog", marker = "python_full_version < '3.13'" },
 ]


### PR DESCRIPTION
# Pull Request

## Summary

Describe the change in 1–2 sentences.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Docs update
- [ ] Chore

## Docs Impact (required for any code or docs changes)

- [ ] Does this change require docs updates? If yes, list pages:
- [ ] Have you updated or added pages under `docs/`?
- [ ] Did you build the site and run the link checker? (`python website/build.py` + `python website/check_links.py`)
- [ ] Did you avoid banned placeholders? (no "TBD/coming soon")

## Testing

Describe how you tested this change. Include commands and results.

## Checklist

- [ ] Tests pass (`pytest -v`)
- [ ] Linting passes (make lint / make format)
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Affected areas:** `qdrant-loader serve` startup flow (webhook-auth fail-closed gating before state/DB/uvicorn lifecycle init), webhook auth + token verification, and request logging via `uvicorn.access` (credential-query redaction).
- **Configuration (breaking/additive):** Webhook caller query param renamed **`token` → `secret`** for secret lookup. Webhook auth is considered **unset when `WEBHOOK_SECRET` is empty**. Startup requires webhook auth config via **non-empty `WEBHOOK_SECRETS` JSON** (or project-scoped `WEBHOOK_SECRET_<PROJECT_ID>`). Cognito-JWT enablement is checked **at runtime**.
- **Tests:** Added redaction regression tests (including percent-encoded keys) and verified filter installation happens only once; added `serve` fail-closed test (ensures no `StateManager.initialize`); expanded `webhook_auth_configured()` env parsing and Cognito flag behavior tests; updated webhook/server route tests to use `secret=...`.
- **Security/resource safety:** Prevents plaintext credential/token/secrets in logs; avoids partial startup on misconfigured webhook auth; logging filter is exception-safe and never blocks access logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->